### PR TITLE
fix: synchronous GetStateCtx, When, WhenNot

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -843,9 +843,7 @@ func (m *Machine) processStateCtxBindings() {
 	m.activeStatesLock.Lock()
 	var toCancel []context.CancelFunc
 	for _, s := range deactivated {
-		for _, cancel := range m.indexStateCtx[s] {
-			toCancel = append(toCancel, cancel)
-		}
+		toCancel = append(toCancel, m.indexStateCtx[s]...)
 		delete(m.indexStateCtx, s)
 	}
 	m.activeStatesLock.Unlock()

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -265,6 +265,20 @@ func (m *Machine) When(states []string, ctx context.Context) chan struct{} {
 			m.indexWhen[s] = append(m.indexWhen[s], binding)
 		}
 	}
+	go func() {
+		// dispose the binding on ctx.Done() and m.Ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-m.Ctx.Done():
+			m.activeStatesLock.Lock()
+			for _, s := range states {
+				if _, ok := m.indexWhen[s]; ok {
+					m.indexWhen[s] = lo.Without(m.indexWhen[s], binding)
+				}
+			}
+			m.activeStatesLock.Unlock()
+		}
+	}()
 	m.activeStatesLock.Unlock()
 
 	return ch
@@ -310,6 +324,20 @@ func (m *Machine) WhenNot(states []string, ctx context.Context) chan struct{} {
 			m.indexWhen[s] = append(m.indexWhen[s], binding)
 		}
 	}
+	go func() {
+		// dispose the binding on ctx.Done() and m.Ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-m.Ctx.Done():
+			m.activeStatesLock.Lock()
+			for _, s := range states {
+				if _, ok := m.indexWhen[s]; ok {
+					m.indexWhen[s] = lo.Without(m.indexWhen[s], binding)
+				}
+			}
+			m.activeStatesLock.Unlock()
+		}
+	}()
 	m.activeStatesLock.Unlock()
 
 	return ch

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -851,8 +851,6 @@ func (h *TestStateCtxHandlers) AState(e *am.Event) {
 	h.callbackCh = make(chan bool)
 	go func() {
 		<-stepCh
-		// TODO prevent flaky, close/cancel while processing the queue
-		time.Sleep(10 * time.Millisecond)
 		assertStates(t, e.Machine, S{})
 		assert.Error(t, stateCtx.Err(), "state context should be canceled")
 		h.callbackCh <- true

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -192,6 +193,23 @@ const (
 	LogDecisions
 	LogEverything
 )
+
+type (
+	// map of (single) state names to a list of bindings
+	indexWhen map[string][]*whenBinding
+	// map of (single) state names to a list of bindings
+	indexStateCtx map[string][]context.CancelFunc
+)
+
+type whenBinding struct {
+	ch       chan struct{}
+	negation bool
+	states   stateIsActive
+	matched  int
+	total    int
+}
+
+type stateIsActive map[string]bool
 
 // emitter represents a single event consumer, synchronized by channels.
 type emitter struct {

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -308,24 +308,6 @@ func (eh *ExceptionHandler) ExceptionState(e *Event) {
 
 // utils
 
-func isMapTrue(m map[string]bool) bool {
-	for _, value := range m {
-		if !value {
-			return false
-		}
-	}
-	return true
-}
-
-func isMapFalse(setMap map[string]bool) bool {
-	for _, value := range setMap {
-		if value {
-			return false
-		}
-	}
-	return true
-}
-
 // j joins state names
 func j(states []string) string {
 	return strings.Join(states, " ")

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -279,12 +279,7 @@ func (t *Transition) emitEvents() Result {
 	txArgs := A{"transition": t}
 	hasStateChanged := false
 
-	if m.Transition != nil {
-		panic("Already during a transition")
-	}
-
 	// start emitting
-	m.Transition = t
 	m.emit("transition-start", txArgs, nil)
 
 	// NEGOTIATION CALLS PHASE (cancellable)
@@ -325,7 +320,6 @@ func (t *Transition) emitEvents() Result {
 	}
 
 	// stop emitting
-	m.Transition = nil
 	m.emit("transition-end", txArgs, nil)
 
 	if result == Canceled {


### PR DESCRIPTION
Fixes #3.

Changes:
- `GetStateCtx` without using `emitter`
- `When`, `WhenNot` without using `emitter`