### PR TITLE
feat: synchronous emitter bindings

### DIFF
--- a/examples/temporal-expense/expense_test.go
+++ b/examples/temporal-expense/expense_test.go
@@ -231,11 +231,10 @@ func ExpenseFlow(
 	})
 
 	// bind handlers and wait for Ready
-	binding, err := machine.BindHandlers(&MachineHandlers{})
+	err := machine.BindHandlers(&MachineHandlers{})
 	if err != nil {
 		return machine, err
 	}
-	<-binding.Ready
 
 	// reusable error channel
 	errCh := machine.WhenErr(nil)

--- a/examples/temporal-fileprocessing/fileprocessing.go
+++ b/examples/temporal-fileprocessing/fileprocessing.go
@@ -225,11 +225,10 @@ func FileProcessingFlow(ctx context.Context, log Logger, filename string) (*am.M
 	})
 
 	// bind handlers and wait for Ready
-	binding, err := machine.BindHandlers(&MachineHandlers{})
+	err := machine.BindHandlers(&MachineHandlers{})
 	if err != nil {
 		return machine, err
 	}
-	<-binding.Ready
 
 	// start it up!
 	machine.Add(am.S{"DownloadingFile"}, am.A{"filename": filename})

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -273,7 +273,7 @@ type ExceptionArgsPanic struct {
 	StackTrace   []byte
 }
 
-// ExceptionState is a (final) handler for the Exception state.
+// ExceptionState is a final entry handler for the Exception state.
 // Args:
 // - err error: The error that caused the Exception state.
 // - panic *ExceptionArgsPanic: Optional details about the panic.

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -36,7 +36,7 @@ type Event struct {
 	Machine *Machine
 	Args    A
 	// internal events lack a step
-	step    *TransitionStep
+	step *TransitionStep
 }
 
 type Opts struct {
@@ -200,7 +200,7 @@ type (
 	indexWhen map[string][]*whenBinding
 	// map of (single) state names to a list of bindings
 	indexStateCtx map[string][]context.CancelFunc
-	indexEventCh map[string][]chan *Event
+	indexEventCh  map[string][]chan *Event
 )
 
 type whenBinding struct {
@@ -225,8 +225,8 @@ type emitter struct {
 // delivery of all events.
 func (m *Machine) newEmitter(name string, methods *reflect.Value) *emitter {
 	e := &emitter{
-		id:       name,
-		methods:  methods,
+		id:      name,
+		methods: methods,
 	}
 	// TODO emitter mutex
 	m.emitters = append(m.emitters, e)

--- a/pkg/machine/popup_test.go
+++ b/pkg/machine/popup_test.go
@@ -102,9 +102,8 @@ func TestPopupMachine(t *testing.T) {
 		t.Logf(msg, args...)
 	})
 	// bind the Transition handlers
-	binding, err := machine.BindHandlers(&PopupMachineHandlers{})
+	err := machine.BindHandlers(&PopupMachineHandlers{})
 	assert.NoError(t, err)
-	<-binding.Ready
 
 	// test
 


### PR DESCRIPTION
Fixes #2 .

Changes:
- synchronous `BindHandlers` (breaking API change)
- synchronous `On`
- atomic queue lock (fixes a race)