### PR TITLE
feat: add telemetry via net/rpc

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -463,7 +463,7 @@ func TestNegotiationCancel(t *testing.T) {
 				// DEnter will cancel the transition
 				return m.Set(S{"D"}, nil)
 			},
-			regexp.MustCompile(`\[cancel:\w+?] \(D\) by DEnter`),
+			regexp.MustCompile(`\[cancel] \(D\) by DEnter`),
 		},
 		{
 			"using add",
@@ -472,7 +472,7 @@ func TestNegotiationCancel(t *testing.T) {
 				// DEnter will cancel the transition
 				return m.Add(S{"D"}, nil)
 			},
-			regexp.MustCompile(`\[cancel:\w+?] \(D A\) by DEnter`),
+			regexp.MustCompile(`\[cancel] \(D A\) by DEnter`),
 		},
 	}
 	for _, test := range tests {
@@ -541,7 +541,7 @@ func TestNegotiationRemove(t *testing.T) {
 	// assert
 	assert.Equal(t, am.Canceled, result, "transition should be canceled")
 	assertStates(t, m, S{"A"}, "state shouldnt be changed")
-	assert.Regexp(t, `\[cancel:\w+?] \(\) by AExit`, log,
+	assert.Regexp(t, `\[cancel] \(\) by AExit`, log,
 		"log should explain the reason of cancellation")
 }
 
@@ -803,7 +803,7 @@ func TestPartialNegotiationPanic(t *testing.T) {
 	assert.Equal(t, am.Canceled, m.Add(S{"B"}, nil))
 	// assert
 	assertStates(t, m, S{"A", "Exception"})
-	assert.Regexp(t, `\[cancel:\w+?] \(B A\) by recover`, log,
+	assert.Regexp(t, `\[cancel] \(B A\) by recover`, log,
 		"log contains the target states and handler")
 }
 
@@ -835,7 +835,7 @@ func TestPartialFinalPanic(t *testing.T) {
 		"log contains the target states and handler")
 	assert.Contains(t, log, "[error:trace] goroutine",
 		"log contains the stack trace")
-	assert.Regexp(t, `\[cancel:\w+?] \(A B C\) by recover`, log,
+	assert.Regexp(t, `\[cancel] \(A B C\) by recover`, log,
 		"log contains the target states and handler")
 }
 

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -18,6 +18,9 @@ type A map[string]any
 // T is an ordered list of state clocks.
 type T []uint64
 
+// Clocks is a map of state names to their clocks.
+type Clocks map[string]uint64
+
 // State defines a single state of a machine, its properties and relations.
 type State struct {
 	Auto    bool

--- a/pkg/machine/resolver.go
+++ b/pkg/machine/resolver.go
@@ -61,9 +61,9 @@ func (rr *DefaultRelationsResolver) GetTargetStates(
 		}
 		m.log(lvl, "[rel:remove] %s by %s", name, j(blockedBy))
 		if m.Is(S{name}) {
-			t.addSteps(newStep(name, "", TransitionStepTypeRemove, nil))
+			t.addSteps(newStep("", name, TransitionStepTypeRemove, nil))
 		} else {
-			t.addSteps(newStep(name, "", TransitionStepTypeNoSet, nil))
+			t.addSteps(newStep("", name, TransitionStepTypeNoSet, nil))
 		}
 		return false
 	})
@@ -179,7 +179,7 @@ func (rr *DefaultRelationsResolver) stateBlockedBy(
 		if !lo.Contains(state.Remove, blocked) {
 			continue
 		}
-		t.addSteps(newStep(blocked, blocking, TransitionStepTypeRelation,
+		t.addSteps(newStep(blocking, blocked, TransitionStepTypeRelation,
 			RelationRemove))
 		blockedBy = append(blockedBy, blocking)
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,161 @@
+package telemetry
+
+import (
+	"encoding/gob"
+	"log"
+	"net/rpc"
+
+	"github.com/samber/lo"
+
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+const RpcHost = "localhost:9823"
+
+type Msg interface {
+	// Clock returns the state's clock, using the passed index
+	Clock(statesIndex am.S, state string) uint64
+	// Is true if the state is active, using the passed index
+	Is(statesIndex am.S, states am.S) bool
+}
+
+// MsgStruct contains the state and relations data.
+type MsgStruct struct {
+	// Machine ID
+	ID string
+	// state names defining the indexes for diffs
+	StatesIndex am.S
+	// all the states with relations
+	States am.States
+	// log level of the machine
+	LogLevel am.LogLevel
+}
+
+func (d *MsgStruct) Clock(_ am.S, _ string) uint64 {
+	return 0
+}
+
+func (d *MsgStruct) Is(_ am.S, _ am.S) bool {
+	return false
+}
+
+// MsgTx contains transaction data.
+type MsgTx struct {
+	// Transition ID
+	ID string
+	// map of positions from the index to the active state
+	StatesActive []bool
+	// map of positions from the index to state clocks
+	Clocks []uint64
+	// result of the transition
+	Accepted bool
+	// all the transition steps
+	Steps []*am.TransitionStep
+	// log entries since the last diff
+	LogEntries []string
+	// log entries before the transition, which happened after the prev one
+	PreLogEntries []string
+	// tx was triggered by an auto state
+	IsAuto bool
+}
+
+func (d *MsgTx) Clock(statesIndex am.S, state string) uint64 {
+	idx := lo.IndexOf(statesIndex, state)
+	return d.Clocks[idx]
+}
+
+func (d *MsgTx) Is(statesIndex am.S, states am.S) bool {
+	for _, state := range states {
+		idx := lo.IndexOf(statesIndex, state) //nolint:typecheck
+		if !d.StatesActive[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+type rpcClient struct {
+	client *rpc.Client
+}
+
+func newClient(url string) (*rpcClient, error) {
+	log.Printf("Connecting to %s", url)
+	client, err := rpc.Dial("tcp", url)
+	if err != nil {
+		return nil, err
+	}
+	return &rpcClient{client: client}, nil
+}
+
+func (c *rpcClient) sendMsgTx(msg *MsgTx) error {
+	var reply string
+	// TODO use Go() to not block
+	err := c.client.Call("RPCServer.MsgTx", msg, &reply)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *rpcClient) sendMsgStruct(msg *MsgStruct) error {
+	var reply string
+	// TODO use Go() to not block
+	err := c.client.Call("RPCServer.MsgStruct", msg, &reply)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func MonitorTransitions(m *am.Machine, url string) error {
+	var err error
+	gob.Register(am.Relation(0))
+	client, err := newClient(url)
+	if err != nil {
+		return err
+	}
+	msg := &MsgStruct{
+		ID:          m.ID,
+		StatesIndex: m.StateNames,
+		States:      m.States,
+		LogLevel:    m.LogLevel,
+	}
+	// TODO retries
+	err = client.sendMsgStruct(msg)
+	if err != nil {
+		log.Println(err)
+	}
+	go func() {
+		// bind to transitions
+		txEndCh := m.On([]string{"transition-end"}, nil)
+		// send incoming transitions
+		for event := range txEndCh {
+			tx := event.Args["transition"].(*am.Transition)
+			preLogs := event.Args["pre_logs"].([]string)
+			msg := &MsgTx{
+				ID:           tx.ID,
+				StatesActive: make([]bool, len(m.StateNames)),
+				Clocks:       make([]uint64, len(m.StateNames)),
+				Accepted:     tx.Accepted,
+				Steps: lo.Map(tx.Steps,
+					func(step *am.TransitionStep, _ int) *am.TransitionStep {
+						return step
+					}),
+				LogEntries:    tx.LogEntries,
+				PreLogEntries: preLogs,
+				IsAuto:        tx.IsAuto(),
+			}
+			for i, state := range m.StateNames {
+				msg.StatesActive[i] = m.Is(am.S{state})
+				msg.Clocks[i] = m.Clock(state)
+			}
+			// TODO retries
+			err := client.sendMsgTx(msg)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+		}
+	}()
+	return nil
+}


### PR DESCRIPTION
Initial telemetry implementation, needed for the upcoming debugger.

Changes:
- telemetry via `net/rpc`
- 2 types of msg
   - initial (full)
   - updates (refs and logs)
- add transaction IDs
- remove step IDs

Usage:
```go
import (
	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
)

// ...

err := telemetry.MonitorTransitions(mach, url)
```