### PR TITLE
docs: update manual to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ type Handlers struct {
 // negotiation handler
 func (h *Handlers) ProcessingFileEnter(e *am.Event) bool {
     // read-only ops
-    //   (decide if moving fwd is ok)
+    // decide if moving fwd is ok
     // no blocking
     // lock-free critical zone
     return true
@@ -120,11 +120,11 @@ func (h *Handlers) ProcessingFileState(e *am.Event) {
 // wait for Foo to have a tick >= 6 and Bar tick >= 10
 <-mach.WhenTime(am.S{"Foo", "Bar"}, am.T{6, 10}, nil)
 
-// wait for DownloadingFile to have a tick >= 6
-<-mach.WhenTickEq("DownloadingFile", 6, nil)
-
 // wait for DownloadingFile to have a tick increased by 2 since now
 <-mach.WhenTick("DownloadingFile", 2, nil)
+
+// wait for an error
+<-mach.WhenErr()
 ```
 
 See [docs/cookbook.md](docs/cookbook.md) for more snippets.
@@ -300,14 +300,25 @@ var States = am.Struct{
 
 - [godoc](https://godoc.org/github.com/pancsta/asyncmachine-go/pkg/machine)
 - [cookbook](/docs/cookbook.md)
-- [manual](/docs/manual.md) (outdated)
-  - [States](/docs/manual.md#states)
-    - [State Clocks](/docs/manual.md#state-clocks)
-    - [Auto States](/docs/manual.md#auto-states)
-  - [Transitions](/docs/manual.md#transitions)
-    - [Negotiation](/docs/manual.md#negotiation-handlers)
-  - [Relations](/docs/manual.md#relations)
-  - [Queue](/docs/manual.md#queue)
+- [manual](/docs/manual.md)
+  - [Machine and States](/docs/manual.md#machine-and-states)
+      - [State Clocks and Context](/docs/manual.md#state-clocks-and-context)
+      - [Auto States](/docs/manual.md#auto-states)
+      - [Categories of States](/docs/manual.md#categories-of-states)
+      - ...
+  - [Changing State](/docs/manual.md#changing-state)
+      - [State Mutations](/docs/manual.md#state-mutations)
+      - [Transition Lifecycle](/docs/manual.md#transition-lifecycle)
+      - [Calculating Target States](/docs/manual.md#calculating-target-states)
+      - [Negotiation Handlers](/docs/manual.md#negotiation-handlers)
+      - [Final Handlers](/docs/manual.md#final-handlers)
+      - ...
+  - [Advanced Topics](/docs/manual.md#advanced-topics)
+      - [State's Relations](/docs/manual.md#states-relations)
+      - [Queue and History](/docs/manual.md#queue-and-history)
+      - [Typesafe States](/docs/manual.md#typesafe-states)
+      - ...
+  - [Cheatsheet](/docs/manual.md#cheatsheet)
 
 ## Tools
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -173,11 +173,11 @@ args := am.A{"id": 123}
 when := mach.WhenArgs("EventConnected", args, nil)
 // wait with err and timeout
 select {
-    case <-time.After(5 * time.Second):
-return am.ErrTimeout
-    case <-mach.WhenErr(nil):
-return mach.Err
-    case <-when:
+case <-time.After(5 * time.Second):
+    return am.ErrTimeout
+case <-mach.WhenErr(nil):
+    return mach.Err
+case <-when:
     // EventConnected activated with (id=1232)
 }
 ```

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,66 +1,89 @@
-# asyncmachine-go manual
+# asyncmachine-go
 
-This manual hasn't been updated to `v0.4.0`. Please refer to [Cookbook](/docs/cookbook.md) and [/examples](/examples)
-for now.
+## Table of Contents
 
-- [asyncmachine-go manual](#asyncmachine-go-manual)
-   - [States](#states)
-      - [Everything is a state](#everything-is-a-state)
-      - [Defining States](#defining-states)
-      - [What to consider a "state"](#what-to-consider-a-state)
-      - [Asynchronous states](#asynchronous-states)
-   - [Mutations](#mutations)
-      - [`Add` mutation](#add-mutation)
-      - [`Remove` mutation](#remove-mutation)
-      - [`Set` mutation](#set-mutation)
-      - [Machine init](#machine-init)
-      - [State Clocks](#state-clocks)
-      - [Checking Active States](#checking-active-states)
-      - [Debugging](#debugging)
-      - [Auto states](#auto-states)
-      - [Multi states](#multi-states)
-      - ["Action" states](#action-states)
-   - [Transitions](#transitions)
-      - [Transition handlers](#transition-handlers)
-      - [Self handlers](#self-handlers)
-      - [Defining Handlers](#defining-handlers)
-      - [Event object](#event-object)
-      - [Transition lifecycle](#transition-lifecycle)
-      - [Calculating Target States](#calculating-target-states)
-      - [Negotiation Handlers](#negotiation-handlers)
-      - [Final Handlers](#final-handlers)
-      - [Dynamic Handlers](#dynamic-handlers)
-      - [State Context](#state-context)
-   - [Wait Methods](#wait-methods)
-   - [Error Handling](#error-handling)
-      - [Panics In Handlers](#panics-in-handlers)
-   - [Relations](#relations)
-      - [`Add` Relation](#add-relation)
-      - [`Remove` Relation](#remove-relation)
-      - [`Require` Relation](#require-relation)
-      - [`After` Relation](#after-relation)
-   - [Queue](#queue)
-   - [Logging](#logging)
-   - [Cheatsheet](#cheatsheet)
+<!-- TOC -->
 
-## States
+- [asyncmachine-go](#asyncmachine-go)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Comparison](#comparison)
+    - [Legend](#legend)
+  - [Machine and States](#machine-and-states)
+    - [Defining States](#defining-states)
+    - [Asynchronous States](#asynchronous-states)
+    - [Machine Init](#machine-init)
+    - [State Clocks and Context](#state-clocks-and-context)
+    - [Checking Active States](#checking-active-states)
+    - [Inspecting States](#inspecting-states)
+    - [Auto States](#auto-states)
+    - [Multi States](#multi-states)
+    - [Categories of States](#categories-of-states)
+  - [Changing State](#changing-state)
+    - [State Mutations](#state-mutations)
+    - [Mutation Arguments](#mutation-arguments)
+    - [Transition Lifecycle](#transition-lifecycle)
+    - [Transition Handlers](#transition-handlers)
+    - [Self handlers](#self-handlers)
+    - [Defining Handlers](#defining-handlers)
+    - [Event Object](#event-object)
+    - [Calculating Target States](#calculating-target-states)
+    - [Negotiation Handlers](#negotiation-handlers)
+    - [Final Handlers](#final-handlers)
+    - [Dynamic Handlers](#dynamic-handlers)
+  - [Advanced Topics](#advanced-topics)
+    - [State's Relations](#states-relations)
+    - [Waiting](#waiting)
+    - [Error Handling](#error-handling)
+    - [Panics In Handlers](#panics-in-handlers)
+    - [Queue and History](#queue-and-history)
+    - [Logging](#logging)
+    - [Debugging](#debugging)
+    - [Typesafe States](#typesafe-states)
+    - [Tracing and Metrics](#tracing-and-metrics)
+    - [Optimizing Data Input](#optimizing-data-input)
+  - [Cheatsheet](#cheatsheet)
+  - [Other sources](#other-sources)
 
-### Everything is a state
+<!-- TOC -->
 
-The fundamental idea is that **everything is a state**. A state represents certain abstraction in time. A simple
-example of a problem which can be easily solved using the concept of states is an elevator - it can be on one of the
-floors, it may be going down or up, it may have buttons pressed, or it may stand still, etc. Some of those states can
-happen simultaneously (going up with having buttons pressed), others can be mutually exclusive (going up and down).
+## Overview
 
-In AsyncMachine, multiple states can be active at the same time, unlike in a classic [FSM](https://en.wikipedia.org/wiki/Finite-state_machine).
+> **asyncmachine-go** is a general purpose state machine for managing complex asynchronous workflows in a safe and
+> structured way
+
+asyncmachine-go abstracts everything and all (but only if necessary) as a state. Many states can be active at the same
+time, some of them can mutually exclude each other, some can be divided into several smaller states, some states can be
+nested sub-machines, and finally, some states can aggregate groups of nested sub-machines.
+
+The purpose of asyncmachine-go is never to block (ie always be synchronous), which is achieved by splitting long-running
+actions into steps and orchestrating blocking calls according to a predefined convention. Another goal is to give
+structure to non-determinism, by embracing it.
+
+### Comparison
+
+Common differences from other state machines:
+
+- many states can be active at the same time
+- [transitions](#transition-lifecycle) between all the states are allowed
+- states are connected by [relations](#states-relations)
+- every transition can be [rejected](#transition-lifecycle)
+- [error is a state](#error-handling)
+
+### Legend
+
+Examples here use a string representations of machines in the format of [`(ActiveState:\d)[InactiveState:\d]`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.StringAll).
+
+## Machine and States
 
 ### Defining States
 
-States definition `am.States` is a map of `am.S` structs, which consist of a name, properties and
-[relations](#relations):
+Using [`am.Struct`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Struct) you can define
+a string-keyed map of [`am.State`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#State) structs.
+Those consist of properties and [relations](#states-relations):
 
 ```go
-am.States{
+am.Struct{
     "StateName": {
         // properties
         Auto:    true,
@@ -76,219 +99,219 @@ am.States{
 
 State names have a predefined **naming convention** which is `CamelCase`.
 
-Examples here use a string representation of a machine in the format of `(ActiveState:\d)[InactiveState:\d]`
-(see [debugging](#debugging)).
-
-### What to consider a "state"
-
-States should represent a higher-level view on what's happening in your workflow.
-
-In case of the elevator example mentioned above, you probably don't want to make every passenger a state described by
-its name, although it could be useful to have states like `Empty`, `Boarded` and `OverCapacity`.
-
-### Asynchronous states
-
-Considering that everything is a state, representing async actions can be achieved by creating two separate states -
-*in progress** and **completed**.
-
-For example, when downloading a file, it would be `DownloadingFile` and `FileDownloaded`. Having every meaningful action
-and event encapsulated as a *state* allows us to precisely react on input events. In case of the "file download" example
-, we could've had another states called `ButtonPressed`, which triggers the download, but makes a different decision in
-case the state `DownloadingFile` is currently active. Same goes for `FileDownloaded` which can behave differently if
-there's been another `DownloadingFile` state since the first download process had begun.
-
-## Mutations
-
-**Mutation methods** change the currently **Active States** for a machine. Each method receives a set of state names
-(0-n), these are **Called States** and are different from **Target States**, which are
-[calculated during a Transition](#calculating-target-states).
-
-*Every state mutation is non-blocking**, so the machine can constantly make decisions and update the currently active
-states, or put them into the [queue](#queue). All the mutation methods accepts multiple states.
-
-*Mutations aren't nested** - one can happen only after the previous one has finished. That's why mutation methods
-return a `Result`, which can be:
-
-- `Executed`
-- `Canceled`
-- `Queued`
-
-You can check prior to mutating if the machine is busy executing a transition by calling `DuringTransition()` method
-(see [Locks](#queue)).
-
-### `Add` mutation
-
-*Add** is the most common method, as it preserves the currently active states.
+**Example** - synchronous state
 
 ```go
-func (m *Machine) Add(states S, args A) Result
+Ready: {},
 ```
 
-Example:
+### Asynchronous States
+
+If a state represents a change from `A` to `B`, then it's considered as an **asynchronous state**. Async states can be
+represented **by 2 to 4 states**, depending on how granular information we need from them. More than 4
+states representing a single abstraction in time is called a Flow.
+
+**Example** - Asynchronous state (double)
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.Add(am.S{"Foo"})
-machine.StringAll() // (Foo:1)[Bar:0 Baz:0 Exception:0]
+DownloadingFile: {
+    Remove: groupFileDownloaded,
+},
+FileDownloaded: {
+    Remove: groupFileDownloaded,
+},
 ```
 
-### `Remove` mutation
-
-*Remove** deactivates only specified states.
+**Example** - asynchronous boolean state (triple)
 
 ```go
-func (m *Machine) Remove(states S, args A) Result
+Connected: {
+    Remove:  groupConnected,
+},
+Connecting: {
+    Remove:  groupConnected,
+},
+Disconnecting: {
+    Remove: groupConnected,
+},
 ```
 
-Example:
+**Example** - full asynchronous boolean state (quadruple)
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.Add(am.S{"Foo", "Bar"})
-machine.StringAll() // (Foo:1 Bar:1)[Baz:0 Exception:0]
-machine.Remove(am.S{"Foo"})
-machine.StringAll() // (Foo:1)[Bar:1 Baz:0 Exception:0]
+Connected: {
+    Remove:  groupConnected,
+},
+Connecting: {
+    Remove:  groupConnected,
+},
+Disconnecting: {
+    Remove: groupConnected,
+},
+Disconnected: {
+    Auto: true,
+    Remove: groupConnected,
+},
 ```
 
-### `Set` mutation
+### Machine Init
 
-*Set** removes all the currently active states, but the ones passed.
-
-```go
-func (m *Machine) Set(states S, args A) Result
-```
-
-Example:
-
-```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.Add(am.S{"Foo"})
-machine.StringAll() // (Foo:1)[Bar:0 Baz:0 Exception:0]
-machine.Set(am.S{"Bar"})
-machine.StringAll() // (Bar:1)[Foo:1 Baz:0 Exception:0]
-```
-
-### Machine init
-
-To initialize a machine, besides [state definitions](#defining-states), we also need a `context` and optional
-`Opts` struct (in case one want's to alter the defaults).
+There are two ways to initialize a machine - using
+[`am.New`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#New) or [`am.NewCommon`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#NewCommon)
+. The former one always returns an instance of
+[`Machine`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine), but it's limited to only
+initializing the states structure, with basic customizations via
+[`Opts`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Opts). The latter one is more feature-rich
+and provides [states verification](#typesafe-states), [handler binding](#transition-handlers), and
+[debugging](#debugging). It may also return an error.
 
 ```go
-// From examples/temporal-fileprocessing/fileprocessing.go
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+// ...
 ctx := context.Background()
-machine := am.New(ctx, am.States{
-    "DownloadingFile": {
-        Remove: am.S{"FileDownloaded"},
-    },
-    "FileDownloaded": {
-        Remove: am.S{"DownloadingFile"},
-    },
-    "ProcessingFile": {
-        Auto:    true,
-        Require: am.S{"FileDownloaded"},
-        Remove:  am.S{"FileProcessed"},
-    },
-    "FileProcessed": {
-        Remove: am.S{"ProcessingFile"},
-    },
-    "UploadingFile": {
-        Auto:    true,
-        Require: am.S{"FileProcessed"},
-        Remove:  am.S{"FileUploaded"},
-    },
-    "FileUploaded": {
-        Remove: am.S{"UploadingFile"},
-    },
-}, nil)
+states := am.Struct{"Foo":{}, "Bar":{}}
+mach := am.New(ctx, states, &am.Opts{
+    ID: "foo1",
+    LogLevel: am.LogChanges,
+})
 ```
 
-Each machine is given a random `ID`, its own `context` and the [Exception](#error-handling) state.
+Each machine has an ID (via `Opts.ID` or a random one) and the build-in [Exception](#error-handling) state.
 
-### State Clocks
+### State Clocks and Context
 
-*Every state has a clock**. State clocks are [logical clocks](https://en.wikipedia.org/wiki/Logical_clock) which
-increment ("tick") every time the state becomes active. Combination of all the state clocks makes the machine clock.
+**Every state has a clock**. State clocks are [logical clocks](https://en.wikipedia.org/wiki/Logical_clock) which
+increment ("tick") every time the state gets activated or de-activated. **Odd ticks mean active, while even ticks mean
+inactive.** The sum of all the state clocks is the **machine clock**.
 
-The purpose of a state clock is to distinguish different instances of the same state. Like in the "file download"
-example about a button and download process, the `FileDownloaded` state can check if it has been originated by the
-current `FileDownloading` state, simply by checking its clock. This helps to prevent race conditions.
+The purpose of a state clocks is to distinguish different instances of the same state. It's the most commonly used by
+being abstracted as `context.Context` via [`Machine.NewStateCtx(state string)`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#NewStateCtx).
 
-Each machine provides `Clock(state string) uint64`, `Time(states S) T`, `TimeSum(states S) T` methods. There's also a
-helper function `IsTimeAfter(t1 T, t2 T)`.
+Other related methods and functions:
 
-Example:
+- [`Machine.Clock(state string) uint64`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Clock)
+- [`Machine.Time(states S) T`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#Time)
+- [`Machine.TimeSum(states S) T`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#TimeSum)
+- [`Machine.HasStateChangedSince(clocks Clocks) book`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/machine.go#HasStateChangedSince)
+- [`IsTimeAfter(t1 T, t2 T)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#IsTimeAfter)
+- [`IsActiveTick(tick uint64)`](https://github.com/pancsta/asyncmachine-go/blob/v0.5.0/pkg/machine/misc.go#IsActiveTick)
+
+**Example** - clocks
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.Clock("Foo") // 0
+mach.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
+mach.Clock("Foo") // 0
 
-machine.Add(am.S{"Foo"})
-machine.Add(am.S{"Foo"})
-machine.StringAll() // (Foo:1)[Bar:0 Baz:0 Exception:0]
-machine.Clock("Foo") // 1
+mach.Add(am.S{"Foo"})
+mach.Add(am.S{"Foo"})
+mach.StringAll() // (Foo:1)[Bar:0 Baz:0 Exception:0]
+mach.Clock("Foo") // 1
 
-machine.Remove(am.S{"Foo"})
-machine.Add(am.S{"Foo"})
-machine.StringAll() // (Foo:2)[Bar:0 Baz:0 Exception:0]
-machine.Clock("Foo") // 2
+mach.Remove(am.S{"Foo"})
+mach.Add(am.S{"Foo"})
+mach.StringAll() // (Foo:3)[Bar:0 Baz:0 Exception:0]
+mach.Clock("Foo") // 3
 ````
+
+**Example** - state context
+
+```go
+func (h *Handlers) DownloadingFileState(e *am.Event) {
+    // open until the state remains active
+    ctx := e.Machine.NewStateCtx("DownloadingFile")
+    // fork to unblock
+    go func() {
+        // check if still valid
+        if ctx.Err() != nil {
+            return // expired
+        }
+    }()
+}
+```
 
 ### Checking Active States
 
-The currently active states can be checked using `Is(states S) bool`, `Not(states S) bool`, and `Any(states ...S) bool`.
-There are also debugging `String()`, `StringAll()` and `Inspect(states S)`.
+Each state can be **active** or **inactive**, determined by its [state clock](#state-clocks-and-context). You can check
+the current state at any time, [without a long delay](#transition-handlers), which makes it a dependable source of
+decisions.
+
+Methods to check the active states:
+
+- [`Machine.Is(states)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Is)
+- [`Machine.Is1(state)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Is1)
+- [`Not(states)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Not)
+- [`Not1(state)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Not1)
+- [`Any(states1, states2...)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Any)
+- [`Any1(state1, state2...)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Any1)
+
+Methods to inspect / dump the currently active states:
+
+- [`Machine.String()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.String)
+- [`Machine.StringAll()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.StringAll)
+- [`Machine.Inspect(states)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Inspect)
 
 `Is` checks if all the passed states are active.
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.Add(am.S{"Foo"})
-machine.Is(am.S{"Foo"}) // true
-machine.Is(am.S{"Foo", "Bar"}) // false
+// ()[Foo:0 Bar:0 Baz:0 Exception:0]
+
+mach.Add1("Foo", nil)
+// (Foo:1)[Bar:0 Baz:0 Exception:0]
+
+mach.Is1("Foo") // true
+mach.Is(am.S{"Foo", "Bar"}) // false
 ```
 
-`Not` checks if none of the passed states are active.
+`Not` checks if none of the passed states is active.
 
 ```go
-machine.StringAll() // ()[A:0 B:0 C:0 D:0 Exception:0]
-machine.Add(am.S{"A", "B"})
+// ()[A:0 B:0 C:0 D:0 Exception:0]
+
+mach.Add(am.S{"A", "B"}, nil)
+// (A:1 B:1)[C:0 D:0 Exception:0]
+
 // not(A) and not(C)
-machine.Not(am.S{"A", "C"}) // false
+mach.Not(am.S{"A", "C"}) // false
 // not(C) and not(D)
-machine.Not(am.S{"C", "D"}) // true
+mach.Not(am.S{"C", "D"}) // true
 ```
 
 `Any` is group call to `Is`, returns true if any of the params return true from `Is`.
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0 Exception:0]
-machine.Add(am.S{"Foo"})
+// ()[Foo:0 Bar:0 Baz:0 Exception:0]
+
+mach.Add1("Foo", nil)
+// (Foo:1)[Bar:0 Baz:0 Exception:0]
+
 // is(Foo, Bar) or is(Bar)
-machine.Any(am.S{"Foo", "Bar"}, am.S{"Bar"}) // false
+mach.Any(am.S{"Foo", "Bar"}, am.S{"Bar"}) // false
 // is(Foo) or is(Bar)
-machine.Any(am.S{"Foo"}, am.S{"Bar"}) // true
+mach.Any(am.S{"Foo"}, am.S{"Bar"}) // true
 ```
 
-### Debugging
+### Inspecting States
 
 Being able to inspect your machine at any given step is VERY important. These are the basic method which don't require
-any additional tools.
+any additional [debugging tools](#debugging).
 
-Inspecting active states and their [clocks](#state-clocks):
+**Example** - inspecting active states and their [clocks](#state-clocks-and-context)
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-machine.String() // ()
-machine.Add(am.S{"Foo"})
-machine.StringAll() // (Foo:1)[Bar:0 Baz:0 Exception:0]
-machine.String() // (Foo:1)
+mach.StringAll() // ->()[Foo:0 Bar:0 Baz:0 Exception:0]
+mach.String() // ->()
+
+mach.Add1("Foo")
+
+mach.StringAll() // ->(Foo:1)[Bar:0 Baz:0 Exception:0]
+mach.String() // ->(Foo:1)
 ```
 
-Inspecting relations:
+**Example** - inspecting relations
 
 ```go
 // From examples/temporal-fileprocessing/fileprocessing.go
-machine.Inspect()
+mach.Inspect()
 // Exception:
 //   State:   false 0
 //
@@ -321,14 +344,17 @@ machine.Inspect()
 //   Remove:  UploadingFile
 ```
 
-### Auto states
+### Auto States
 
-Automatic states (`Auto` property) are one of the most powerful concepts of AsyncMachine. **After every mutation, auto
-states will try to activate themselves**, assuming their dependencies are met. After every transition with a state
-change (`tick`), there will be a try to activate all not-active auto states. Auto states can be set partially. This
-mutation is **prepended** to the queue (instead of _appended_ like in case of _manual_ mutations).
+Automatic states (`Auto` property) are one of the most important concepts of **asyncmachine-go**. After every
+[transition](#transition-lifecycle) with a [clock change](#state-clocks-and-context) (tick), `Auto` states will try to
+active themselves via an auto mutation.
 
-Example log output:
+- `Auto` states can be set partially (within the same [mutation](#state-mutations))
+- Auto mutation is **prepended** to the [queue](#queue-and-history)
+- The `Remove` relation of `Auto` states isn't enforced within the auto mutation
+
+**Example** - log for FileProcessed causes an `Auto` state UploadingFile to activate
 
 ```text
 // [state] +FileProcessed -ProcessingFile
@@ -336,48 +362,146 @@ Example log output:
 // [state:auto] +UploadingFile
 ```
 
-### Multi states
+### Multi States
 
 Multi-state (`Multi` property) describes a state which can be activated many times, without being de-activated in the
-meantime. It always triggers `Enter` and `State` [transition handlers](#transition-handlers), plus
-the [clock](#state-clocks) is always incremented. It's useful for describing many instances of the same event (eg
-network input) without having to define more than one transition handler. `Exception` is a good example of a
-`Multi` state.
+meantime. It always triggers `Enter` and `State` [transition handlers](#transition-handlers), plus the
+[clock](#state-clocks-and-context) is always incremented. It's useful for describing many instances of the same event
+(e.g. network input) without having to define more than one transition handler. [`Exception`](#error-handling) is a good
+example of a `Multi` state (many errors can happen, and we want to know all of them). The downside is that `Multi`
+states don't have [state contexts](#state-clocks-and-context).
 
-### "Action" states
+### Categories of States
 
-A "state" usually describes something more "persistent" then an action, eg `Click` is an action while `Downloadeded`
-is a persistent state. "Action" states differ from [multi states](#multi-states) as they usually don't happen in bulk.
-Therefor there's no need to use `Multi` and a self-removal inside a [final transition handler](#final-handlers) is
-enough.
+States usually belong to one of these categories:
 
-Example:
+1. Input states (e.g. RPC msgs)
+2. Read-only states (e.g. external state / UI state / summaries)
+3. Action states (e.g. Start, ShowModal, public API methods)
+
+Action states often de-activate themselves after they are done, as a part of their [final handler](#final-handlers).
+
+**Example** - self removal
 
 ```go
-machine.StringAll() // ()[Foo:0 Bar:0 Baz:0 Exception:0]
-func (h *MachineHandlers) ClickState(e *am.Event) {
-    // this will get queued and eventually executed
-    h.Machine.Remove(am.S{"Click"})
+func (h *Handlers) ClickState(e *am.Event) {
+    // add removal to the queue
+    e.Machine.Remove1("Click")
 }
 ```
 
-This way the state `Click` stays integral (on / off) and you can reference the input action using
-[state relations](#relations) to perform further workflow steps.
+## Changing State
 
-## Transitions
+### State Mutations
 
-Transition performs a mutation of machine's active states to a different subset of possible states (>= 0). Eg a machine
-with states `Foo Bar Baz` can have active states mutated from `Foo` to `Foo Baz` or from nil to `Bar Baz`.
-Each transition has several steps and (optionally) calls several [handlers](#transition-handlers) (for each binding).
+**Mutation** is a request to change the currently [active states](#checking-active-states) of a machine. Each mutation
+has a list of states knows as **called states**, which are different from **target states**
+([calculated during a transition](#calculating-target-states)). Additionally, a mutation has an optional map of
+arguments of type [`am.Args`](#mutation-arguments).
 
-### Transition handlers
+Mutations are [queued](#queue-and-history), thus they are never nested - one can happen only after the previous one has
+been processed. Mutation methods return a
+[`Result`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Result), which can be:
 
-State handler is a function on struct, with a predefined name, which receives an [Event object](#event-object). There
-are [negotiation handlers](#negotiation-handlers) (return `bool`) and [final handlers](#final-handlers) (no return).
-Order of the handlers depends on currently active states and relations.
+- `Executed`
+- `Canceled`
+- `Queued`
+
+You can check if the machine is busy executing a transition by calling [`Machine.DuringTransition()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Result)
+(see [queue](#queue-and-history)) or wait until it's done with [`<-Machine.WhenQueueEnds()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.DuringTransition).
+
+There are 3 types of mutations:
+
+- add
+- remove
+- set
+
+[`Machine.Add(states, args)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Add) is the most
+common method, as it preserves the currently [active states](#checking-active-states). Each activation increases the
+[states' clock](#state-clocks-and-context) to an odd number.
+
+**Example** - Add mutation
 
 ```go
-func (h *MachineHandlers) DownloadingFileState(e *am.Event) {
+// ()[Foo:0 Bar:0 Baz:0 Exception:0]
+
+mach.Add1("Foo", nil)
+// (Foo:1)[Bar:0 Baz:0 Exception:0]
+
+mach.Add1("Bar", nil)
+// (Foo:1 Bar:1)[Baz:0 Exception:0]
+```
+
+[`Machine.Remove(states, args)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Remove)
+deactivates only the specified states. Each de-activation increases the [states' clock](#state-clocks-and-context) to an
+even number.
+
+**Example** - Remove mutation
+
+```go
+// ()[Foo:0 Bar:0 Baz:0 Exception:0]
+
+mach.Add(am.S{"Foo", "Bar"}, nil)
+// (Foo:1 Bar:1)[Baz:0 Exception:0]
+
+mach.Remove(am.S{"Foo"}, nil)
+// (Bar:1)[Foo:2 Baz:0 Exception:0]
+
+mach.Remove1("Bar", nil)
+// [Foo:2 Bar:2 Baz:0 Exception:0]
+```
+
+[`Machine.Set(states, args)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Set)
+de-activates all but the passed states and activates the remaining ones.
+
+**Example** - Set mutation
+
+```go
+// ()[Foo:0 Bar:0 Baz:0 Exception:0]
+
+mach.Add(am.S{"Foo"}, nil)
+// (Foo:1)[Bar:0 Baz:0 Exception:0]
+
+mach.Set(am.S{"Bar"}, nil)
+// (Bar:1)[Foo:2 Baz:0 Exception:0]
+```
+
+### Mutation Arguments
+
+TODO
+
+### Transition Lifecycle
+
+**Transition** is created from a [mutation](#state-mutations) and tries to execute it, which can result in the changing
+of machine's [active states](#checking-active-states). Each transition has several steps and (optionally) calls several
+[handlers](#transition-handlers) (for each of the [bindings](#defining-handlers)).
+
+Once a transition begins to execute, it goes through the following steps:
+
+1. [Calculating Target States](#calculating-target-states) - collecting target states based on
+   [relations](#states-relations), currently [active states](#checking-active-states) and
+   [called states](#state-mutations). Transition can already be `Canceled` at this point.
+2. [Negotiation handlers](#negotiation-handlers) - methods called for each state about-to-be activated or deactivated.
+   Each of these handlers can return `false` which will make the transition `Canceled`.
+3. Apply the **target states** to the machine - from this point `Is` (
+   [and other checking methods](#checking-active-states)) will reflect the target states.
+4. [Final handlers](#final-handlers) - methods called for each state about-to-be activated or deactivated, as well as
+   self handlers of currently active ones. Transition cannot be canceled at this point.
+
+### Transition Handlers
+
+State handler is a struct method with a predefined suffix or prefix, which receives an [Event object](#event-object).
+There are [negotiation handlers](#negotiation-handlers) (returning a `bool`) and [final handlers](#final-handlers) (with
+no return). Order of the handlers depends on currently [active states](#checking-active-states) and relations of
+[active](#checking-active-states) and [target states](#calculating-target-states).
+
+**Example** - handlers for the state Foo
+
+```go
+func (h *MachineHandlers) FooEnter(e *am.Event) bool {}
+func (h *MachineHandlers) FooState(e *am.Event) {}
+func (h *MachineHandlers) FooExit(e *am.Event) bool {}
+func (h *MachineHandlers) FooEnd(e *am.Event) {}
 ```
 
 List of handlers during a transition from `Foo` to `Bar`, in the order of execution:
@@ -390,42 +514,52 @@ List of handlers during a transition from `Foo` to `Bar`, in the order of execut
 - `FooEnd` - [final handler](#final-handlers)
 - `BarState` - [final handler](#final-handlers)
 
+All handlers execute in a series, one by one, thus they don't need to mutually exclude each other for accessing
+resources. This reduces the number of locks needed. No blocking is allowed in the body of a handler, unless it's in
+a goroutine. Additionally, each handler has a limited time to complete (**100ms** with the default handler timeout),
+which can be set via [`am.Opts`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Opts).
+
 ### Self handlers
 
-Self handler is a final handler for states which were active **before and after** a transition.
+Self handler is a final handler for states which were active **before and after** a transition (all no-change active
+states). The name is a doubled name of the state (eg `FooFoo`).
 
 List of handlers during a transition from `Foo` to `Foo Bar`, in the order of execution:
 
 - `AnyBar` - [negotiation handler](#negotiation-handlers)
 - `BarEnter` - [negotiation handler](#negotiation-handlers)
-- `FooSelf` - [final handler](#final-handlers) and **self handler**
+- `FooFoo` - [final handler](#final-handlers) and **self handler**
 - `BarState` - [final handler](#final-handlers)
+
+Self handlers provide a simple alternative to [`Multi` states](#multi-states), while fully maintaining [state clocks](#state-clocks-and-context).
 
 ### Defining Handlers
 
-Handlers are defined as struct methods. Each machine can have many handler structs bound to itself using `BindHandlers`,
-although at least one of the structs should embed provided `am.ExceptionHandler` (or equivalent).
+Handlers are defined as struct methods. Each machine can have many handler structs bound to itself using
+[`Machine.BindHandlers`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.BindHandlers),
+although at least one of the structs should embed the provided `am.ExceptionHandler` (or provide its own). Any existing
+struct can be used for handlers, as long as there's no name conflict.
 
-Example of binding handlers:
-
-- [go playground](https://play.golang.com/p/C4r1xnu-EpG)
+**Example** - define `FooState` and `FooEnter`
 
 ```go
-type MachineHandlers struct {
+type Handlers struct {
     // default handler for the build in Exception state
-    am.ExceptionHandler
+    *am.ExceptionHandler
 }
-func (h *MachineHandlers) FooState(e *am.Event) {
-    // final entry handler for Foo
+
+func (h *Handlers) FooState(e *am.Event) {
+    // final activation handler for Foo
 }
-func (h *MachineHandlers) FooEnter(e *am.Event) bool {
-    // negotiation entry handler for Foo
+
+func (h *Handlers) FooEnter(e *am.Event) bool {
+    // negotiation activation handler for Foo
     return true // accept this transition by Foo
 }
 
 func main() {
     // ...
-    err := machine.BindHandlers(&MachineHandlers{})
+    err := mach.BindHandlers(&MachineHandlers{})
 }
 ```
 
@@ -438,11 +572,9 @@ Log output:
 [handler] FooState
 ```
 
-### Event object
+### Event Object
 
-Every handler receives a pointer to an `Event` object, with a `Name` and `Machine`. When calling any
-[mutation method](#mutations), one can also pass an arguments struct `A` of type `map[string]any`. It will
-be attached to the `Event` object and delivered to all (executed) transition handlers.
+Every handler receives a pointer to an `Event` object, with `Name`, `Machine` and `Args`.
 
 ```go
 // definition
@@ -452,7 +584,7 @@ type Event struct {
     Args    A
 }
 // send args
-machine.Add(am.S{"Foo"}, A{"test": 123})
+mach.Add(am.S{"Foo"}, A{"test": 123})
 // ...
 // receive args
 func (h *MachineHandlers) FooState(e *am.Event) {
@@ -460,57 +592,53 @@ func (h *MachineHandlers) FooState(e *am.Event) {
 }
 ```
 
-### Transition lifecycle
-
-Once a transition begins to execute, it goes through the following steps:
-
-1. [Calculating Target States](#calculating-target-states) - collecting target states based on [relations](#relations),
-  currently active states and called states. Transition can already be `Canceled` at this point.
-2. [Negotiation handlers](#negotiation-handlers) - methods called for each state about-to-be activated or deactivated. Each
-  of these handlers can return `false` which will make the transition `Canceled`.
-3. Apply the target states to the machine - from this point `Is` will reflect the target states.
-4. [Final handlers](#final-handlers) - methods called for each state about-to-be activated or deactivated and self
-  handlers of currently active ones. Transition cannot be canceled at this point.
-
 ### Calculating Target States
 
-[Called States](#mutations) combined with currently [Active States](#mutations) and a [relations resolver](#relations)
-result in **target states** of a transition. This phase is **cancelable** - if any of the [Called States](#mutations)
-gets rejected, the *transition is canceled**. This isn't true for [Auto States](#auto-states), which can be accepted
-partially.
+[Called states](#state-mutations) combined with currently [active states](#checking-active-states) and
+a [relations resolver](#states-relations) result in **target states** of a transition. This phase is **cancelable** - if
+**any** of the [called states](#state-mutations) gets rejected, the **transition is canceled**. This isn't true for
+[Auto states](#auto-states), which can be partially rejected.
 
-Target states can be accessed with `machine.To()` or `machine.From()`.
+Transition exposes called, target and previous states using:
 
-- [go playground](https://play.golang.com/p/JxcQ-in4cCk)
+- [`e.Transition.StatesBefore`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Transition.StatesBefore)
+- [`e.Transition.TargetStates`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Transition.TargetStates)
+- [`e.Transition.ClocksBefore`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Transition.ClocksBefore)
+- [`e.Transition.ClocksAfter`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Transition.ClocksAfter)
+- [`e.Transition.Mutation.CalledStates`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Transition.CalledStates)
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
     "Foo": {
         Add: am.S{"Bar"},
     },
     "Bar": {}
 }, nil)
+
 // ...
+
 // handlers
 func (h *MachineHandlers) FooEnter(e *am.Event) bool {
-    e.Machine.From() // ()
-    e.Machine.To() // (Foo Bar)
+    e.Transition.StatesBefore // ()
+    e.Transition.TargetStates // (Foo Bar)
     e.Machine.Transition.CalledStates() // (Foo)
 
     e.Machine.Is(am.S{"Foo", "Bar"}) // false
     return true
 }
 func (h *MachineHandlers) FooState(e *am.Event) {
-    e.Machine.From() // ()
-    e.Machine.To() // (Foo Bar)
+    e.Transition.StatesBefore // ()
+    e.Transition.TargetStates // (Foo Bar)
     e.Machine.Transition.CalledStates() // (Foo)
 
     e.Machine.Is(am.S{"Foo", "Bar"}) // true
 }
+
 // ...
+
 // usage
-m.Add(am.S{"Foo"}, nil)
+m.Add1("Foo", nil)
 ```
 
 ```text
@@ -536,36 +664,44 @@ end
 ### Negotiation Handlers
 
 ```go
-// with a return
-func (h *MachineHandlers) FooEnter(e *am.Event) bool {}
-// without a return (always true)
-func (h *MachineHandlers) FooEnter(e *am.Event) {}
+// negotiation handler
+func (h *Handlers) ProcessingFileEnter(e *am.Event) bool {
+    // read-only ops
+    // decide if moving fwd is ok
+    // no blocking
+    // lock-free critical zone
+    return true
+}
 ```
 
-Negotiation handlers `Enter` and `Exit` are called for every state which is going to be activated or de-activated.
-They are allowed to cancel a transition by optionally returning `false`. Negotiation handlers shouldn't perform any
-action which cannot be undone. Their purpose is to make sure that [final transition handlers](#final-handlers) are good
-to go.
+Negotiation handlers `Enter` and `Exit` are called for every state which is going to be activated or de-activated. They
+are allowed to cancel a transition by optionally returning `false`. Negotiation handlers should only perform read-only
+operations, or at least be side effects free. Their purpose is to make sure that
+[final transition handlers](#final-handlers) are good to go.
 
-- [go playground](https://play.golang.com/p/ISxDpWiwtBc)
+**Example** - rejected negotiation
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
     "Foo": {
         Add: am.S{"Bar"},
     },
     "Bar": {},
 }, nil)
+
 // ...
+
 // handlers
 func (h *MachineHandlers) FooEnter(e *am.Event) bool {
     return false
 }
+
 // ...
+
 // usage
-m.Add(am.S{"Foo"}, nil) // am.Canceled
-m.StringAll() // ()[Bar:0 Foo:0 Exception:0]
+m.Add1("Foo", nil) // ->am.Canceled
+// ()[Bar:0 Foo:0 Exception:0]
 ```
 
 ```text
@@ -580,55 +716,64 @@ m.StringAll() // ()[Bar:0 Foo:0 Exception:0]
 
 Final handlers `State` and `End` are where the main handler logic resides. After the transition gets accepted by
 relations and negotiation handlers, final handlers will allocate and dispose resources, call APIs, and perform other
-actions with side effects. Just like [negotiation handlers](#negotiation-handlers), they are called for every state
-which is going to be activated or de-activated. Additionally, the `Self` handlers are called for states which remained
-active.
+blocking actions with side effects. Just like [negotiation handlers](#negotiation-handlers), they are called for every
+state which is going to be activated or de-activated. Additionally, the [Self handlers](#self-handlers) are called for
+states which remained active.
 
 Like any handler, final handlers cannot block the mutation. That's why they need to start a goroutine and continue their
-execution within it, while asserting the [State Context](#state-context) is still valid.
-
-- [go playground](https://play.golang.com/p/BvZThLj5fje)
+execution within it, while asserting the [state context](#state-clocks-and-context) is still valid.
 
 ```go
-func (h *MachineHandlers) FooState(e *am.Event) {
-    // critical zone
-    name := e.Args["name"].(string)
-    // fork
+func (h *Handlers) ProcessingFileState(e *am.Event) {
+    // read & write ops
+    // no blocking
+    // lock-free critical zone
+    mach := e.Machine
+    // tick-based context
+    stateCtx := mach.NewStateCtx("ProcessingFile")
     go func() {
-        // API calls, etc...
+        // block in the background, locks needed
+        if stateCtx.Err() != nil {
+            return // expired
+        }
+        // blocking call
+        err := processFile(h.Filename, stateCtx)
+        if err != nil {
+            mach.AddErr(err)
+            return
+        }
+        // re-check the tick ctx after a blocking call
+        if stateCtx.Err() != nil {
+            return // expired
+        }
+        // move to the next state in the flow
+        mach.Add1("FileProcessed", nil)
     }()
 }
 ```
 
-```text
-[add] Foo
-[state] +Foo
-[handler] FooState
-blocking API call start fake name
-blocking API call end fake name
-(Foo:1)[Exception:0]
-```
-
 ### Dynamic Handlers
 
-`On` returns a channel that will be notified with `*Event`, when any of the
-passed events happen. It's quick substitute for a predefined transition
-handler, although it does not guarantee a deterministic order of execution. It also accepts an optional context.
+[`OnEvent`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.OnEvent) returns a channel that
+will be notified with `*Event`, when any of the passed events happen. It's quick substitute for a predefined transition
+handler, although it does not guarantee a deterministic order of execution (dynamic handlers are triggered in bulk at
+the end of a transition). It also accepts an optional context for an earlier disposal. Usage of dynamic handlers is
+discouraged and may cause problems. To subscribe to events other than handlers, there's
+[Tracer API](#tracing-and-metrics).
 
-The main difference of **dynamic handlers** is that they don't return and the machine continues the execution right
-after notifying the channel.
-
-- [go playground](https://play.golang.com/p/Qbp7SCVLyde)
+**Example** - bind to `FooEnter`
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
     "Foo": {},
     "Bar": {},
 })
+
 // ...
+
 // usage
-fooEnter := m.On([]string{"FooEnter"}, nil)
+fooEnter := m.OnEvent([]string{"FooEnter"}, nil)
 go func() {
     <-fooEnter
     println("On(FooEnter)")
@@ -641,81 +786,280 @@ go func() {
 On(FooEnter)
 ```
 
-### State Context
+## Advanced Topics
 
-State Context is a `context.Context()` with a lifetime of a **single state's instance**
- ([clock tick](#state-clocks)).
+### State's Relations
 
-Consider following transitions (represented by [StringAll()](#debugging)):
+Each [state](#defining-states) can have 4 types of **relations**. Each relation accepts a list of state names. Relations
+are handled by [RelationsResolver](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#RelationsResolver),
+which should be extendable and potentially even replaceable.
 
-1. `(Foo:1)[Bar:0 Baz:0 Exception:0]`
-2. `()[Foo:1 Bar:0 Baz:0 Exception:0]`
-3. `(Foo:2)[Bar:0 Baz:0 Exception:0]`
+#### `Add` relation
 
-Steps 1 and 3 will have a different state context for `Foo`, because `Foo`'s clock has changed.
+The `Add` relation tries to activate listed states, whenever the owner state gets activated.
 
-Example usage of state clocks:
-
-- [go playground](https://play.golang.com/p/ZpkfivDk4ON)
-
-```go
-func (h *MachineHandlers) ProcessingFileState(e *am.Event) {
-    stateCtx := e.Machine.GetStateCtx("ProcessingFile")
-    go func () {
-        // check the state context
-        if stateCtx.Err() != nil {
-            println("state context canceled")
-            // no longer ProcessingFile, at least not in the same instance (the state could have been activated again)
-            return
-        }
-        // continue ops
-    }()
-}
-```
-
-```text
-[add] ProcessingFile
-[state] +ProcessingFile
-[handler] ProcessingFileState
-[remove] ProcessingFile
-[state] -ProcessingFile
-[add] ProcessingFile
-[state] +ProcessingFile
-[handler] ProcessingFileState
-state context canceled
-(ProcessingFile:2)[Exception:0]
-```
-
-## Wait Methods
-
-Wait Methods help to react on certain states are active (or not). Those are `When(states S, ctx)` and
-`WhenNot(states S, ctx)` which return a channel which closes, once the machine sets on the requested combination.
-They optionally accept a context to be disposed earlier then the machine itself.
-
-Example of waiting for states `Foo` and `Bar` being active at the same time:
-
-- [go playground](https://play.golang.com/p/vMuTHCWsSeL)
+Their activation is optional, meaning if any of those won't get accepted, the transition will still be `Executed`.
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
+    "Foo": {
+        Add: am.S{"Bar"},
+    },
+    "Bar": {},
+}, nil)
+
+// usage
+m.Add1("Foo", nil) // ->Executed
+// (Foo:1 Bar:1)[Exception:0]
+```
+
+```text
+[add] Foo
+[implied] Bar
+[state] +Foo +Bar
+(Foo:1 Bar:1)[Exception:0]
+```
+
+#### `Remove` relation
+
+The `Remove` relation prevents from activating, or deactivates listed states.
+
+If some of the [called states](#state-mutations) `Remove` other [called states](#state-mutations), or some of the
+[active states](#checking-active-states) `Remove` some of the [called states](#state-mutations), the
+[transition](#transition-lifecycle) will be [`Canceled`](#transition-lifecycle).
+
+Example of an [accepted transition](#transition-lifecycle) involving a `Remove` relation:
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {
+        Remove: am.S{"Bar"},
+    },
+    "Bar": {},
+}, nil)
+
+// usage
+m.Add1("Foo", nil) // ->Executed
+m.Add1("Bar", nil) // ->Executed
+println(m.StringAll()) // (Foo:1)[Bar:0 Exception:0]
+```
+
+```text
+[add] Foo
+[state] +Foo
+[add] Bar
+[cancel:reject] Bar
+(Foo:1)[Bar:0 Exception:0]
+```
+
+Example of a [canceled transition](#transition-lifecycle) involving a `Remove` relation - some of the
+[called states](#state-mutations) `Remove` other Called States.
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {},
+    "Bar": {
+        Remove: am.S{"Foo"},
+    },
+}, nil)
+
+// usage
+m.Add(am.S{"Foo", "Bar"}, nil) // ->Canceled
+m.Not1("Bar") // true
+// ()[Foo:0 Bar:0 Exception:0]
+```
+
+```text
+[add] Foo Bar
+[cancel:reject] Foo
+()[Exception:0 Foo:0 Bar:0]
+```
+
+Example of a [canceled transition](#transition-lifecycle) involving a `Remove` relation - some of the [active states](#checking-active-states)
+`Remove` some of the [called states](#state-mutations).
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {},
+    "Bar": {
+        Remove: am.S{"Foo"},
+    },
+}, nil)
+
+// usage
+m.Add1("Bar", nil) // ->Executed
+m.Add1("Foo", nil) // ->Canceled
+m.StringAll() // (Foo:1)[Bar:0 Exception:0]
+```
+
+```text
+[add] Bar
+[state] +Bar
+[add] Foo
+[cancel:reject] Foo
+(Bar:1)[Foo:0 Exception:0]
+```
+
+#### `Require` relation
+
+The `Require` relation describes the states required for this one to be activated.
+
+Example of an [accepted transition](#transition-lifecycle) involving a `Require` relation:
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {},
+    "Bar": {
+        Require: am.S{"Foo"},
+    }
+}, nil)
+
+// usage
+m.Add1("Foo", nil) // ->Executed
+m.Add1("Bar", nil) // ->Executed
+// (Foo:1 Bar:0)[Exception:0]
+```
+
+```text
+[add] Foo
+[state] +Foo
+[add] Bar
+[state] +Bar
+(Foo:1 Bar:1)[Exception:0]
+```
+
+Example of a [canceled transition](#transition-lifecycle) involving a `Require` relation:
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {},
+    "Bar": {
+        Require: am.S{"Foo"},
+    },
+}, nil)
+
+// usage
+m.Add(am.S{"Bar"}, nil) // ->Canceled
+// ()[Foo:0 Bar:0 Exception:0]
+```
+
+```text
+[add] Bar
+[reject] Bar(-Foo)
+[cancel:reject] Bar
+()[Foo:0 Bar:0 Exception:0]
+```
+
+#### `After` relation
+
+The `After` relation decides about the order of execution of [transition handlers](#transition-handlers). Handlers from
+the defined state will be executed **after** handlers from listed states.
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
+    "Foo": {
+        After: am.S{"Bar"},
+    },
+    "Bar": {
+        Require: am.S{"Foo"},
+    },
+}, nil)
+
+// ...
+
+// handlers
+func (h *MachineHandlers) FooState(e *am.Event) {
+    println("Foo")
+}
+func (h *MachineHandlers) BarState(e *am.Event) {
+    println("Bar")
+}
+
+// ...
+
+// usage
+m.Add(am.S{"Foo", "Bar"}, nil) // ->Executed
+```
+
+```text
+[add] Foo Bar
+[state] +Bar +Foo
+[handler] BarState
+Bar
+[handler] FooState
+Foo
+```
+
+### Waiting
+
+```go
+// wait until FileDownloaded becomes active
+<-mach.When1("FileDownloaded", nil)
+
+// wait until FileDownloaded becomes inactive
+<-mach.WhenNot1("DownloadingFile", args, nil)
+
+// wait for EventConnected to be activated with an arg ID=123
+<-mach.WhenArgs("EventConnected", am.A{"ID": 123}, nil)
+
+// wait for Foo to have a tick >= 6 and Bar tick >= 10
+<-mach.WhenTime(am.S{"Foo", "Bar"}, am.T{6, 10}, nil)
+
+// wait for DownloadingFile to have a tick increased by 2 since now
+<-mach.WhenTick("DownloadingFile", 2, nil)
+```
+
+Almost all "when" methods return a share channel which closes when an event happens (or the optionally passed context is
+canceled). They are used to wait until a certain moment, when we know the execution can proceed. Using "when" methods
+creates new channels and should be used with caution, possibly making use of the early disposal context. In the future,
+these channels will be reused and should scale way better.
+
+"When" methods are:
+
+- [`Machine.When(states, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.When)
+- [`Machine.WhenNot(states, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenNot)
+- [`Machine.When1(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.When1)
+- [`Machine.WhenNot1(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenNot1)
+- [`Machine.WhenArgs(state, args, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenArgs)
+- [`Machine.WhenTime(states, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenTime)
+- [`Machine.WhenTick(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenTick)
+- [`Machine.WhenTickEq(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenTickEq)
+- [`Machine.WhenQueueEnds(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenQueueEnds)
+- [`Machine.WhenErr(state, ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenErr)
+
+**Example** - waiting for states `Foo` and `Bar` to being active at the same time:
+
+```go
+// machine
+m := am.New(ctx, am.Struct{
     "Foo": {
         Add: am.S{"Bar"},
     },
     "Bar": {},
 })
+
 // ...
+
 // usage
 select {
-    case <-machine.When(am.S{"Foo", "Bar"}, nil):
+    case <-mach.When(am.S{"Foo", "Bar"}, nil):
         println("Foo Bar")
     }
 }
+
 // ...
+
 // state change
-m.Add(am.S{"Foo"}, nil)
-m.Add(am.S{"Bar"}, nil)
-println(m.StringAll()) // (Foo:1 Bar:1)[Exception:0]
+m.Add1("Foo", nil)
+m.Add1("Bar", nil)
+// (Foo:1 Bar:1)[Exception:0]
 ```
 
 ```text
@@ -726,26 +1070,29 @@ Foo Bar
 (Bar:1 Foo:1)[Exception:0]
 ```
 
-## Error Handling
+### Error Handling
 
-Considering that everything (meaningful) is a state, so should be errors. Every machine has a predefined `Exception`
-state and an optional `ExceptionHandler` struct, which can be embedded into own handlers.
+Considering that everything meaningful can be a state, so can errors. Every machine has a predefined
+[`Exception`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/machine#Exception)
+[`Multi` state](#multi-states) and an optional [`ExceptionHandler`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/machine#ExceptionHandler),
+which can be embedded into [handler structs](#defining-handlers). Creating more detailed error states which have an
+[`Add` relation](#states-relations) to the `Exception` state is one way of handing errors.
 
-There are helper methods to make dealing with the `Exception` state, those are `AddErr(error)`, `AddErrStr(string)`,
-`WhenErr(ctx)` and the `Err error` property.
+- [`Machine.AddErr(error)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.AddErr)
+- [`Machine.AddErrStr(string)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.AddErrStr)
+- [`Machine.WhenErr(ctx)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenErr)
+- [`Machine.Err`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Err)
 
-Example timeout flow with error handling:
-
-- [go playground](https://play.golang.com/p/lV1V8yc0yak)
+**Example** - timeout flow with error handling
 
 ```go
 select {
 case <-time.After(10 * time.Second):
     // timeout
-case <-machine.WhenErr(nil):
+case <-mach.WhenErr(nil):
     // error or machine disposed
-    fmt.Printf("err: %s\n", machine.Err)
-case <-machine.When(am.S{"Bar"}, nil):
+    fmt.Printf("err: %s\n", mach.Err)
+case <-mach.When1("Bar", nil):
     // state Bar active
 }
 ```
@@ -759,281 +1106,67 @@ err: fake err
 (Foo:1 Exception:1)[Bar:0]
 ```
 
-*Panics** are automatically caught and transformed into `Exception`. This can be disabled using
-`Machine.PanicToException` or `Opts.DontPanicToException`. Same goes for `Machine.PrintExceptions` and
-`DontPrintExceptions`.
-
 ### Panics In Handlers
 
-In case of a panic inside a transition handler, the recovery goes as follows:
+**Panics** are automatically caught and transformed into the [`Exception` state](#error-handling). This can be disabled
+using [`Machine.PanicToException`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.PanicToException)
+or [`Opts.DontPanicToException`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/machine#Opts.DontPanicToException).
+Same goes for [`Machine.PrintExceptions`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.PrintExceptions)
+and [`DontPrintExceptions`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/machine#Opts.DontPrintExceptions),
+which manipulate printing to the [log sink](#logging).
 
-*Panic in a [negotiation handler](#negotiation-handlers):**
+In case of a panic inside a transition handler, the recovery flow depends on the type of the erroneous handler.
+
+#### Panic in a [negotiation handler](#negotiation-handlers)
 
 1. Cancels the whole transition.
-2. Active states of the machine stay untouched.
-3. [Add mutation](#mutations) for the `Exception` state is prepended to the queue.
+2. [Active states](#checking-active-states) of the machine stay untouched.
+3. [Add mutation](#state-mutations) for the `Exception` state is prepended to the queue.
 
-*Panic in a [final handler](#final-handlers):**
+#### Panic in a [final handler](#final-handlers)
 
-1. Transition is accepted, Target States has been set as Active State.
+1. Transition has been accepted and [target states](#calculating-target-states) has been set as [active states](#state-mutations).
 2. Not all the [final handlers](#final-handlers) have been executed, so the states from non-executed handlers are
-  removed from active states.
-3. [Add mutation](#mutations) for the `Exception` state is prepended to the queue and the integrity should
-  be restored manually.
+  removed from [active states](#state-mutations).
+3. [Add mutation](#state-mutations) for the `Exception` state is prepended to the queue and the integrity should
+  be restored manually (e.g. [relations](#states-relations), resources involved).
 
-// TODO example
+TODO example
 
-## Relations
-
-Each state can have 4 types of **relations** and 2 **properties**. Each relation accepts a list of state names. Below
-the `am.State` struct (see [defining states](#defining-states) for more):
-
-```go
-type S []string
-type State struct {
-
-    // properties
-    Auto    bool
-    Multi   bool
-
-    // relations
-    Require S
-    Add     S
-    Remove  S
-    After   S
-}
-```
-
-### `Add` Relation
-
-The `Add` relation tries to activate listed states, along with the owner state.
-
-Their activation is optional, meaning if any of those won't get accepted, the transition will still be `Executed`.
-
-- [go playground](https://play.golang.com/p/rCrDqWZRN9d)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {
-        Add: am.S{"Bar"},
-    },
-    "Bar": {},
-}, nil)
-// usage
-m.Add(am.S{"Foo"}, nil)
-println(m.StringAll()) // (Foo:1 Bar:1)[Exception:0]
-```
-
-```text
-[add] Foo
-[implied] Bar
-[state] +Foo +Bar
-(Foo:1 Bar:1)[Exception:0]
-```
-
-### `Remove` Relation
-
-The `Remove` relation prevents from activating, or deactivates listed states.
-
-If some of the Called States `Remove` other Called States, or some of the Active States `Remove` some of the Called
-States, the [Transition](#transitions) will be `Canceled`.
-
-Example of an [accepted transition](#transition-lifecycle) involving a `Remove` relation:
-
-- [go playground](https://play.golang.com/p/3878ksPe2cN)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {
-        Remove: am.S{"Bar"},
-    },
-    "Bar": {},
-}, nil)
-// usage
-m.Add(am.S{"Foo"}, nil) // Executed
-m.Add(am.S{"Bar"}, nil) // Executed
-println(m.StringAll()) // (Foo:1)[Bar:0 Exception:0]
-```
-
-```text
-[add] Foo
-[state] +Foo
-[add] Bar
-[cancel:reject] Bar
-(Foo:1)[Bar:0 Exception:0]
-```
-
-Example of a [canceled transition](#transition-lifecycle) involving a `Remove` relation - some of the Called States
-`Remove` other Called States.
-
-- [go playground](https://play.golang.com/p/gkZnrLNKnTy)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {},
-    "Bar": {
-        Remove: am.S{"Foo"},
-    },
-}, nil)
-// usage
-m.Add(am.S{"Foo", "Bar"}, nil) // Canceled
-m.Not(am.S{"Bar"}) // true
-m.StringAll() // ()[Foo:0 Bar:0 Exception:0]
-```
-
-```text
-[add] Foo Bar
-[cancel:reject] Foo
-()[Exception:0 Foo:0 Bar:0]
-```
-
-Example of a [Canceled Transition](#transition-lifecycle) involving a `Remove` relation - some of the Active States
-`Remove` some of the Called States.
-
-- [go playground](https://play.golang.com/p/32W_04nwbNL)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {},
-    "Bar": {
-        Remove: am.S{"Foo"},
-    },
-}, nil)
-// usage
-m.Add(am.S{"Bar"}, nil) // Executed
-m.Add(am.S{"Foo"}, nil) // Canceled
-m.StringAll() // (Foo:1)[Bar:0 Exception:0]
-```
-
-```text
-[add] Bar
-[state] +Bar
-[add] Foo
-[cancel:reject] Foo
-(Bar:1)[Foo:0 Exception:0]
-```
-
-### `Require` Relation
-
-The `Require` relation describes the states required for this one to be activated.
-
-Example of an [Accepted Transition](#transition-lifecycle) involving a `Require` relation:
-
-- [go playground](https://play.golang.com/p/zjX4ShKoTPt)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {},
-    "Bar": {
-        Require: am.S{"Foo"},
-    }
-}, nil)
-// usage
-m.Add(am.S{"Foo"}, nil) // Executed
-m.Add(am.S{"Bar"}, nil) // Executed
-println(m.StringAll()) // (Foo:1 Bar:0)[Exception:0]
-```
-
-```text
-[add] Foo
-[state] +Foo
-[add] Bar
-[state] +Bar
-(Foo:1 Bar:1)[Exception:0]
-```
-
-Example of a [Canceled Transition](#transition-lifecycle) involving a `Require` relation:
-
-- [go playground](https://play.golang.com/p/FPXbIX49fAU)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {},
-    "Bar": {
-        Require: am.S{"Foo"},
-    },
-}, nil)
-// usage
-m.Add(am.S{"Bar"}, nil) // Canceled
-println(m.StringAll()) // ()[Foo:0 Bar:0 Exception:0]
-```
-
-```text
-[add] Bar
-[reject] Bar(-Foo)
-[cancel:reject] Bar
-()[Foo:0 Bar:0 Exception:0]
-```
-
-### `After` Relation
-
-The `After` relation decides about the order of the [Transition Handlers](#transition-handlers). Handlers from
-the defined state will be executed **after** handlers from listed states.
-
-- [go playground](https://play.golang.com/p/qnzaHlgGF31)
-
-```go
-// machine
-m := am.New(ctx, am.States{
-    "Foo": {
-        After: am.S{"Bar"},
-    },
-    "Bar": {
-        Require: am.S{"Foo"},
-    },
-}, nil)
-// ...
-// handlers
-func (h *MachineHandlers) FooState(e *am.Event) {
-    println("Foo")
-}
-func (h *MachineHandlers) BarState(e *am.Event) {
-    println("Bar")
-}
-// ...
-// usage
-m.Add(am.S{"Foo", "Bar"}, nil) // prints "Bar" and then "Foo"
-```
-
-```text
-[add] Foo Bar
-[state] +Bar +Foo
-[handler] BarState
-Bar
-[handler] FooState
-Foo
-```
-
-## Queue
+### Queue and History
 
 The purpose of AsyncMachine is to synchronize actions, which results in only one handler being executed at the same
-time. Every mutation happening inside the handler, will be queued and the mutation call will return `Queued`.
+time. Every mutation happening inside the handler, will be queued and the [mutation call](#state-mutations) will return [`Queued`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/machine#Queued).
 
-Queue itself can be accessed via `Machine.Queue` whereas there's also a helper function `IsQueued`, which checks if a
-particular mutation has been queued. It's especially helpful in making decisions based on scheduled actions.
+Queue itself can be accessed via [`Machine.Queue()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Queue)
+and checked using [`Machine.IsQueued()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.IsQueued).
+After the execution, queue creates history, which can be captured using a dedicated package [`pkg/history`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go@v0.5.0/pkg/history).
+Both sources can help to make informed decisions based on scheduled and past actions.
 
-- [go playground](https://play.golang.com/p/rD53ejBfRrv)
+- [`Machine.Queue()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.Queue)
+- [`Machine.IsQueued(mutationType, states, withoutArgsOnly, statesStrictEqual, startIndex)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.IsQueued)
+- [`Machine.DuringTransition()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.DuringTransition)
+- [`History.ActivatedRecently(state, duration)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/history#History.ActivatedRecently)
+- [`Machine.WhenQueueEnds()`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/machine#Machine.WhenQueueEnds)
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
     "Foo": {},
     "Bar": {}
 }, nil)
+
 // ...
+
 // handlers
 func (h *MachineHandlers) FooState(e *am.Event) {
-    e.Machine.Add(am.S{"Bar"}, nil) // Queued
+    e.Machine.Add1("Bar", nil) // ->Queued
 }
+
 // ...
+
 // usage
-m.Add(am.S{"Foo"}, nil) // Executed
+m.Add1("Foo", nil) // ->Executed
 ```
 
 ```text
@@ -1046,9 +1179,9 @@ m.Add(am.S{"Foo"}, nil) // Executed
 [state] +Bar
 ```
 
-## Logging
+### Logging
 
-Besides debugging methods, AsyncMachine offer a very verbose logging system with 4 levels of details:
+Besides [inspecting methods](#inspecting-states), AsyncMachine offers a very verbose logging system with 4 levels of details:
 
 - `LogNothing` (default)
 - `LogChanges` state changes and important messages
@@ -1056,13 +1189,11 @@ Besides debugging methods, AsyncMachine offer a very verbose logging system with
 - `LogDecisions` more verbose variant of Ops, explaining the reasoning behind
 - `LogEverything` useful only for deep debugging
 
-Example of all log level for the same code snippet:
-
-- [go playground](https://play.golang.com/p/dFdd_5MgGCV)
+Example of all log levels for the same code snippet:
 
 ```go
 // machine
-m := am.New(ctx, am.States{
+m := am.New(ctx, am.Struct{
     "Foo": {},
     "Bar": {
         Auto: true,
@@ -1070,7 +1201,9 @@ m := am.New(ctx, am.States{
     // disable ID logging
 }, &am.Opts{DontLogID: true})
 m.SetLogLevel(am.LogOps)
+
 // ...
+
 // handlers
 func (h *MachineHandlers) FooState(e *am.Event) {
     // empty
@@ -1078,9 +1211,11 @@ func (h *MachineHandlers) FooState(e *am.Event) {
 func (h *MachineHandlers) BarEnter(e *am.Event) bool {
     return false
 }
+
 // ...
+
 // usage
-m.Add(am.S{"Foo"}, nil) // Executed
+m.Add1("Foo", nil) // Executed
 ```
 
 - log level `LogChanges`
@@ -1130,19 +1265,146 @@ m.Add(am.S{"Foo"}, nil) // Executed
 [cancel:82e34] (Bar Foo) by BarEnter
 ```
 
+#### Arguments logging
+
+TODO
+
+#### Custom logging
+
+```go
+// max out the log level
+mach.SetLogLevel(am.LogEverything)
+// level based dispatcher
+mach.SetLogger(func(level LogLevel, msg string, args ...any) {
+    if level > am.LogChanges {
+        customLogDetails(msg, args...)
+        return
+    }
+    customLog(msg, args...)
+
+})
+
+// include some args in the log and traces
+mach.SetLogArgs(am.NewArgsMapper([]string{"id", "name"}, 20))
+```
+
+### Debugging
+
+TODO
+
+```bash
+$ am-dbg
+```
+
+```go
+import "github.com/pancsta/asyncmachine-go/pkg/telemetry"
+// ...
+err := telemetry.TransitionsToDBG(mach, "")
+```
+
+```bash
+# use AM_DEBUG to increase timeouts of NewCommon machines
+AM_DEBUG=1
+```
+
+### Typesafe States
+
+TODO
+
+**Example** - using am-gen
+
+```go
+// generate using either
+// $ am-gen states-file Foo,Bar
+// $ task gen-states-file Foo,Bar
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// States map defines relations and properties of states.
+var States = am.Struct{
+    Start:     {},
+    Heartbeat: {Require: S{Start}},
+}
+
+//#region boilerplate defs
+
+// Names of all the states (pkg enum).
+
+const (
+    Start             = "Start"
+    Heartbeat         = "Heartbeat"
+)
+
+// Names is an ordered list of all the state names.
+var Names = S{Start, Heartbeat}
+
+//#endregion
+```
+
+### Tracing and Metrics
+
+TODO
+
+### Optimizing Data Input
+
+TODO
+
+**Example** - batch data into a single transition
+
+```go
+var queue []*Msg
+var queueMx sync.Mutex
+var scheduled bool
+
+func Msg(msgTx *Msg) {
+    queueMx.Lock()
+    defer queueMx.Unlock()
+
+    if !scheduled {
+        scheduled = true
+        go func() {
+            // wait some time
+            time.Sleep(time.Second)
+
+            queueMx.Lock()
+            defer queueMx.Unlock()
+
+            // add in bulk
+            mach.Add1("Msgs", am.A{"msgs": queue})
+            queue = nil
+            scheduled = false
+        }()
+    }
+    // enqueue
+    queue = append(queue, msgTx)
+}
+```
+
 ## Cheatsheet
 
-- **State**: main entity of the machine, higher-level abstraction of a meaningful workflow step
-- **Active states**: states currently activated in the machine, `0-n` where `n == len(states)`
-- **Called states**: states passed to a [Mutation Method](#mutations), explicitly requested
-- **Target states**: states after resolving relations, based on previously Active States, about to become new Active
-   States
-- **Mutation**: change to currently Active States, created by [Mutation Methods](#mutations)
-- **Transition**: container object for a Mutation, handles relations and events
-- **Accepted transition**: transition which mutation has passed negotiation and relations
-- **Canceled transition**: transition which mutation has NOT passed negotiation or relations
-- **Queued transition**: transition which couldn't execute, as another one was in progress, as was added to the queue
-   instead
-- **Negotiation handlers**: handlers executed as the first ones, used to make decisions if the transition should be
+- **State**: main entity of the [machine](#machine-init), higher-level abstraction of a meaningful workflow step
+- **Active states**: [states](#defining-states) currently activated in the machine, `0-n` where `n == len(states)`
+- **Called states**: [states](#defining-states) passed to a [mutation method](#state-mutations), explicitly requested
+- **Target states**: [states](#defining-states) after resolving [relations](#states-relations), based on previously
+  [active states](#checking-active-states), about to become new [active states](#transition-lifecycle)
+- **Mutation**: change to currently [active states](#checking-active-states), created by [mutation methods](#state-mutations)
+- **Transition**: container object for a [mutation](#state-mutations), handles [relations](#states-relations) and [events](#dynamic-handlers)
+- **Accepted transition**: [transition](#transition-lifecycle) which [mutation](#state-mutations) has passed
+  [negotiation](#negotiation-handlers) and [relations](#states-relations)
+- **Canceled transition**: transition which [mutation](#state-mutations) has NOT passed [negotiation](#negotiation-handlers)
+  or [relations](#states-relations)
+- **Queued transition**: [transition](#transition-lifecycle) which couldn't execute, as another one was in progress, as
+  was added to the [queue](#queue-and-history) instead
+- **Transition handlers**: methods [defined on a handler struct](#defining-handlers), which are triggered during a [transition](#transition-lifecycle)
+- **Negotiation handlers**: [handlers](#defining-handlers) executed as the first ones, used to make a decision if the
+  [transition](#transition-lifecycle) should be
    accepted
-- **Final handlers**: handlers executed as the last ones, used for operations with side effects
+- **Final handlers**: [handlers](#defining-handlers) executed as the last ones, used for operations with side effects
+
+## Other sources
+
+Please refer to [Cookbook](/docs/cookbook.md) and [/examples](/examples).


### PR DESCRIPTION
Much needed refresh of the initial old draft, towards a more spec-like format. Some smaller chapters are still missing and marked as TODO.