### PR TITLE
feat(machine): add WhenQueueEnds

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1054,9 +1054,9 @@ Foo
 <-mach.WhenTick("DownloadingFile", 2, nil)
 ```
 
-Almost all "when" methods return a share channel which closes when an event happens (or the optionally passed context is
+All "when" methods return a channel, which closes when an event happens (or the optionally passed context gets
 canceled). They are used to wait until a certain moment, when we know the execution can proceed. Using "when" methods
-creates new channels and should be used with caution, possibly making use of the early disposal context. In the future,
+creates new channels and should be used with caution, ideally making use of the early disposal context. In the future,
 these channels will be reused and should scale way better.
 
 "When" methods are:

--- a/examples/nfa/nfa_test.go
+++ b/examples/nfa/nfa_test.go
@@ -1,28 +1,29 @@
 // Based on https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton
+// TODO add Input0, Input1, End
 //
-//=== RUN   TestRegexp
-//=== RUN   TestRegexp/test_101010_(OK)
-//[state] +Start +StepX
-//[state] +Input
-//[extern:InputState] input: 1
-//[state] +Input
-//[extern:InputState] input: 0
-//[state] +Input
-//[extern:InputState] input: 1
-//[state] +Step0 -StepX
-//[state] +Input
-//[extern:InputState] input: 0
-//[state] +Step1 -Step0
-//[state] +Input
-//[extern:InputState] input: 1
-//[state] +Step2 -Step1
-//[state] +Input
-//[extern:InputState] input: 0
-//[state] +Step3 -Step2
-//[state] -Start
-//--- PASS: TestRegexp (0.00s)
+// === RUN   TestRegexp
+// === RUN   TestRegexp/test_101010_(OK)
+// [state] +Start +StepX
+// [state] +Input
+// [extern:InputState] input: 1
+// [state] +Input
+// [extern:InputState] input: 0
+// [state] +Input
+// [extern:InputState] input: 1
+// [state] +Step0 -StepX
+// [state] +Input
+// [extern:InputState] input: 0
+// [state] +Step1 -Step0
+// [state] +Input
+// [extern:InputState] input: 1
+// [state] +Step2 -Step1
+// [state] +Input
+// [extern:InputState] input: 0
+// [state] +Step3 -Step2
+// [state] -Start
+// --- PASS: TestRegexp (0.00s)
 //    --- PASS: TestRegexp/test_101010_(OK) (0.00s)
-//PASS
+// PASS
 
 package nfa
 
@@ -81,11 +82,10 @@ func (t *Regexp) StartState(e *am.Event) {
 	mach.Add1(StepX, nil)
 
 	// jump out of the queue
+	queueEnd := mach.WhenQueueEnds(nil)
 	go func() {
-		// TODO use mach.WhenQueueEnds()
-		<-mach.When1(StepX, nil)
-		// needed for the queue lock to release
-		time.Sleep(1 * time.Millisecond)
+		// wait for drained
+		<-queueEnd
 
 		for _, c := range t.input {
 			switch c {

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -39,9 +39,9 @@ type State struct {
 // Struct is a map of state names to state definitions.
 type Struct = map[string]State
 
-///////////////
-///// options
-///////////////
+// /////////////
+// /// options
+// /////////////
 
 // Opts struct is used to configure a new Machine.
 type Opts struct {
@@ -107,9 +107,9 @@ func OptsWithParentTracers(opts *Opts, parent *Machine) *Opts {
 	return opts
 }
 
-///////////////
-///// enums
-///////////////
+// /////////////
+// /// enums
+// /////////////
 
 // Result enum is the result of a state Transition
 type Result int
@@ -300,9 +300,9 @@ func (r Relation) String() string {
 	return ""
 }
 
-///////////////
-///// logging
-///////////////
+// /////////////
+// /// logging
+// /////////////
 
 // Logger is a logging function for the machine.
 type Logger func(level LogLevel, msg string, args ...any)
@@ -384,9 +384,9 @@ type Tracer interface {
 	Inheritable() bool
 }
 
-///////////////
-///// events, when, emitters
-///////////////
+// /////////////
+// /// events, when, emitters
+// /////////////
 
 // Event struct represents a single event of a Mutation withing a Transition.
 // One event can have 0-n handlers.
@@ -453,6 +453,10 @@ type whenArgsBinding struct {
 	args A
 }
 
+type whenQueueBinding struct {
+	ch chan struct{}
+}
+
 type stateIsActive map[string]bool
 
 // emitter represents a single event consumer, synchronized by channels.
@@ -467,9 +471,9 @@ func (e *emitter) dispose() {
 	e.methods = nil
 }
 
-///////////////
-///// exception support
-///////////////
+// /////////////
+// /// exception support
+// /////////////
 
 // Exception is the Exception state name
 const Exception = "Exception"
@@ -511,9 +515,9 @@ func (eh *ExceptionHandler) ExceptionState(e *Event) {
 	}
 }
 
-///////////////
-///// pub utils
-///////////////
+// /////////////
+// /// pub utils
+// /////////////
 
 // DiffStates returns the states that are in states1 but not in states2.
 func DiffStates(states1 S, states2 S) S {
@@ -597,9 +601,9 @@ func SMerge(states ...S) S {
 	return slicesUniq(s)
 }
 
-///////////////
-///// utils
-///////////////
+// /////////////
+// /// utils
+// /////////////
 
 // j joins state names into a single string
 func j(states []string) string {

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -39,9 +39,9 @@ type State struct {
 // Struct is a map of state names to state definitions.
 type Struct = map[string]State
 
-// /////////////
-// /// options
-// /////////////
+// ///////////////
+// ///// options
+// ///////////////
 
 // Opts struct is used to configure a new Machine.
 type Opts struct {
@@ -107,9 +107,9 @@ func OptsWithParentTracers(opts *Opts, parent *Machine) *Opts {
 	return opts
 }
 
-// /////////////
-// /// enums
-// /////////////
+// ///////////////
+// ///// enums
+// ///////////////
 
 // Result enum is the result of a state Transition
 type Result int
@@ -300,9 +300,9 @@ func (r Relation) String() string {
 	return ""
 }
 
-// /////////////
-// /// logging
-// /////////////
+// ///////////////
+// ///// logging
+// ///////////////
 
 // Logger is a logging function for the machine.
 type Logger func(level LogLevel, msg string, args ...any)
@@ -384,9 +384,9 @@ type Tracer interface {
 	Inheritable() bool
 }
 
-// /////////////
-// /// events, when, emitters
-// /////////////
+// ///////////////
+// ///// events, when, emitters
+// ///////////////
 
 // Event struct represents a single event of a Mutation withing a Transition.
 // One event can have 0-n handlers.
@@ -471,9 +471,9 @@ func (e *emitter) dispose() {
 	e.methods = nil
 }
 
-// /////////////
-// /// exception support
-// /////////////
+// ///////////////
+// ///// exception support
+// ///////////////
 
 // Exception is the Exception state name
 const Exception = "Exception"
@@ -515,9 +515,9 @@ func (eh *ExceptionHandler) ExceptionState(e *Event) {
 	}
 }
 
-// /////////////
-// /// pub utils
-// /////////////
+// ///////////////
+// ///// pub utils
+// ///////////////
 
 // DiffStates returns the states that are in states1 but not in states2.
 func DiffStates(states1 S, states2 S) S {
@@ -601,9 +601,9 @@ func SMerge(states ...S) S {
 	return slicesUniq(s)
 }
 
-// /////////////
-// /// utils
-// /////////////
+// ///////////////
+// ///// utils
+// ///////////////
 
 // j joins state names into a single string
 func j(states []string) string {

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -41,6 +41,7 @@ type Transition struct {
 	// clocks of the states from after the transition
 	// TODO timeAfter, produce Clocks via ClockAfter(), add index diffs
 	ClocksAfter Clocks
+	TAfter      T
 	// State names with "enter" handlers to execute
 	Enters S
 	// State names with "exit" handlers to executed
@@ -388,6 +389,7 @@ func (t *Transition) emitEvents() Result {
 		clocks[state] = m.clock[state]
 	}
 	t.ClocksAfter = clocks
+	t.TAfter = m.time(nil)
 
 	// AUTO STATES
 	if result == Canceled {


### PR DESCRIPTION
`Machine.WhenQueueEnds` is useful to make sure a mutation method wont return `Queued`. Rarely used, usually inside handlers. Should be avoided.