### PR TITLE
fix(am-dbg): fix tail mode delay

### DIFF
--- a/tools/debugger/handlers.go
+++ b/tools/debugger/handlers.go
@@ -199,6 +199,7 @@ func (d *Debugger) PausedState(_ *am.Event) {
 }
 
 func (d *Debugger) TailModeState(_ *am.Event) {
+	d.C.CursorTx = len(d.C.MsgTxs)
 	// needed bc tail mode if carried over via SelectingClient
 	d.updateTxBars()
 	d.draw()


### PR DESCRIPTION
After `alt+v`, only a new network msg would move to the last tx.