### PR TITLE
feat(machine): add NoOpTracer for embedding

### DIFF
--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -395,6 +395,7 @@ func (t *NoOpTracer) TransitionEnd(transition *Transition)  {}
 func (t *NoOpTracer) HandlerStart(
 	transition *Transition, emitter string, handler string) {
 }
+
 func (t *NoOpTracer) HandlerEnd(
 	transition *Transition, emitter string, handler string) {
 }

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -387,6 +387,24 @@ type Tracer interface {
 	QueueEnd(machine *Machine)
 }
 
+// NoOpTracer is a no-op implementation of Tracer, used for embedding.
+type NoOpTracer struct{}
+
+func (t *NoOpTracer) TransitionInit(transition *Transition) {}
+func (t *NoOpTracer) TransitionEnd(transition *Transition)  {}
+func (t *NoOpTracer) HandlerStart(
+	transition *Transition, emitter string, handler string) {
+}
+func (t *NoOpTracer) HandlerEnd(
+	transition *Transition, emitter string, handler string) {
+}
+func (t *NoOpTracer) End()                                {}
+func (t *NoOpTracer) MachineInit(mach *Machine)           {}
+func (t *NoOpTracer) MachineDispose(machID string)        {}
+func (t *NoOpTracer) NewSubmachine(parent, mach *Machine) {}
+func (t *NoOpTracer) QueueEnd(machine *Machine)           {}
+func (t *NoOpTracer) Inheritable() bool                   { return false }
+
 // ///////////////
 // ///// events, when, emitters
 // ///////////////


### PR DESCRIPTION
Avoids breaking tracers when new methods are added.

```
type MyTracer struct {
  *am.NoOpTracer
}
```