### PR TITLE
refac(machine): reorder Eval params

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -1111,7 +1111,7 @@ func (m *Machine) queueMutation(mutationType MutationType, states S, args A) {
 // ctx: nil context defaults to machine's context.
 //
 // Note: usage of Eval is discouraged.
-func (m *Machine) Eval(ctx context.Context, fn func(), source string) bool {
+func (m *Machine) Eval(source string, fn func(), ctx context.Context) bool {
 	if source == "" {
 		panic("Error: source of eval is required")
 	}


### PR DESCRIPTION
Reorder of `Eval` params for readability.

Before:

```go
s.Mach.Eval(func() {
    t, ok := s.topics[topic]
    if !ok {
        s.Mach.Log("Error: topic not found", topic)
        return
    }
}, nil, "topicPeerChange")
```

After:

```go
s.Mach.Eval("topicPeerChange", func() {
    t, ok := s.topics[topic]
    if !ok {
        s.Mach.Log("Error: topic not found", topic)
        return
    }
}, nil)
```