### PR TITLE
feat(machine): add global AnyAny negotiation handler

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -2007,3 +2007,8 @@ func TestOnEventCtxDispose(t *testing.T) {
 	m.Dispose()
 	<-m.WhenDisposed()
 }
+
+// TODO TestAnyAnyHandler
+func TestAnyAnyHandler(t *testing.T) {
+	t.Skip()
+}

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -498,8 +498,12 @@ func (e *emitter) dispose() {
 // ///// exception support
 // ///////////////
 
-// Exception is the Exception state name
-const Exception = "Exception"
+const (
+	// Exception is a name the Exception state.
+	Exception = "Exception"
+	// Any is a name of a meta state used in catch-all handlers.
+	Any = "Any"
+)
 
 // ExceptionArgsPanic is an optional argument ["panic"] for the Exception state
 // which describes a panic within a Transition handler.

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -264,7 +264,7 @@ func (t *Transition) emitEnterEvents() Result {
 		// isCalled := slices.Contains(t.CalledStates(), toState)
 		args := t.Mutation.Args
 
-		ret := t.emitHandler("Any", toState, "Any"+toState, args)
+		ret := t.emitHandler(Any, toState, Any+toState, args)
 		if ret == Canceled {
 			return ret
 		}
@@ -291,7 +291,7 @@ func (t *Transition) emitExitEvents() Result {
 				return ret
 			}
 		}
-		ret = t.emitHandler(from, "Any", from+"Any", nil)
+		ret = t.emitHandler(from, Any, from+Any, nil)
 		if ret == Canceled {
 			return ret
 		}
@@ -354,6 +354,7 @@ func (t *Transition) emitEvents() Result {
 	m.emit(EventTransitionStart, txArgs, nil)
 
 	// NEGOTIATION CALLS PHASE (cancellable)
+
 	// FooFoo handlers
 	if result != Canceled && t.Type() != MutationRemove {
 		result = t.emitSelfEvents()
@@ -367,6 +368,12 @@ func (t *Transition) emitEvents() Result {
 	// FooEnter handlers
 	if result != Canceled {
 		result = t.emitEnterEvents()
+	}
+
+	// global AnyAny handler
+	ret := t.emitHandler(Any, Any, Any+Any, t.Mutation.Args)
+	if ret == Canceled {
+		return ret
 	}
 
 	// FINAL HANDLERS (non cancellable)


### PR DESCRIPTION
- `AnyAny` **always** executes
- as the last negotiation handler
- can cancel the transition

```
func (h *Handlers) AnyAny(e *am.Event) bool {
  return true
}
```