### PR TITLE
fix: fix dispose crash, misc am-dbg issues

### DIFF
--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -812,7 +812,7 @@ func diposeWithCtx[T comparable](
 		case <-ctx.Done():
 		}
 		// GC only if needed
-		if mach.Disposed {
+		if mach.Disposed.Load() {
 			return
 		}
 

--- a/tools/cmd/am-dbg/main.go
+++ b/tools/cmd/am-dbg/main.go
@@ -12,8 +12,8 @@ import (
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	"github.com/pancsta/asyncmachine-go/tools/debugger"
-	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
+	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 
 	"github.com/spf13/cobra"
 )

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -33,7 +33,7 @@ const (
 	// TODO customize
 	playInterval = 500 * time.Millisecond
 	// TODO add param --max-clients
-	maxClients            = 150
+	maxClients            = 500
 	timeFormat            = "15:04:05.000000000"
 	fastJumpAmount        = 50
 	arrowThrottleMs       = 200
@@ -243,14 +243,17 @@ func (d *Debugger) updateFiltersBar() {
 
 	// tx filters
 	for _, item := range filters {
+
+		// checked
 		if item.active {
 			text += f(" [::b]%s[::-]", cview.Escape("[X]"))
 		} else {
 			text += f(" [ ]")
 		}
 
+		// focused
 		if d.focusedFilter == item.id && focused {
-			text += f("[%s][::b]%s[::-]", colorActive, item.label)
+			text += f("[%s][::bu]%s[::-]", colorActive, item.label)
 		} else if !focused {
 			text += f("[%s]%s", colorHighlight2, item.label)
 		} else {
@@ -483,11 +486,6 @@ func (d *Debugger) updateTimelines() {
 		d.timelineSteps.SetFilledColor(tcell.ColorRed)
 	}
 
-	// inactive steps bar when no next tx
-	if nextTx == nil {
-		d.timelineSteps.SetTitleColor(tcell.ColorGrey)
-		d.timelineSteps.SetBorderColor(tcell.ColorGrey)
-	}
 	stepsCount := 0
 	onLastTx := c.CursorTx >= txCount
 	if !onLastTx {
@@ -544,7 +542,7 @@ func (d *Debugger) updateSidebar(immediate bool) {
 
 // TODO sometimes scrolls for no reason
 func (d *Debugger) doUpdateSidebar() {
-	if d.Mach.Disposed {
+	if d.Mach.Disposed.Load() {
 		return
 	}
 


### PR DESCRIPTION
Fix dispose crash with timer being nil.

Minor am-dbg fixes:
- filters without a client
- steps timeline blinking
- tail order
- max clients 500