### PR TITLE
feat(machine): retain log level for pre-logs

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -444,7 +444,7 @@ func TestRemoveRelationCrossBlocking(t *testing.T) {
 		{
 			"using Set should de-activate the old one",
 			func(t *testing.T, m *Machine) {
-				// m = (D)
+				// (D:1)[A:0 B:0 C:0]
 				m.Set(S{"C"}, nil)
 				assertStates(t, m, S{"C"})
 			},
@@ -452,7 +452,7 @@ func TestRemoveRelationCrossBlocking(t *testing.T) {
 		{
 			"using Set should work both ways",
 			func(t *testing.T, m *Machine) {
-				// m = (D)
+				// (D:1)[A:0 B:0 C:0]
 				m.Set(S{"C"}, nil)
 				assertStates(t, m, S{"C"})
 				m.Set(S{"D"}, nil)
@@ -462,7 +462,7 @@ func TestRemoveRelationCrossBlocking(t *testing.T) {
 		{
 			"using Add should de-activate the old one",
 			func(t *testing.T, m *Machine) {
-				// m = (D)
+				// (D:1)[A:0 B:0 C:0]
 				m.Add(S{"C"}, nil)
 				assertStates(t, m, S{"C"})
 			},
@@ -470,7 +470,7 @@ func TestRemoveRelationCrossBlocking(t *testing.T) {
 		{
 			"using Add should work both ways",
 			func(t *testing.T, m *Machine) {
-				// m = (D)
+				// (D:1)[A:0 B:0 C:0]
 				m.Add(S{"C"}, nil)
 				assertStates(t, m, S{"C"})
 				m.Add(S{"D"}, nil)

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"slices"
 	"strings"
+	"sync"
 )
 
 func newStep(from string, to string, stepType StepType,
@@ -56,7 +57,8 @@ type Transition struct {
 	// Parent machine
 	Machine *Machine
 	// Log entries produced during the transition
-	LogEntries []*LogEntry
+	LogEntriesLock sync.Mutex
+	LogEntries     []*LogEntry
 	// start time of the transition
 
 	// Latest / current step of the transition
@@ -412,10 +414,10 @@ func (t *Transition) emitEvents() Result {
 
 	// stop emitting, collect previous log entries
 	m.logEntriesLock.Lock()
-	// TODO struct type
+	// TODO typed txArgs struct
 	txArgs["pre_logs"] = m.logEntries
 	txArgs["queue_len"] = len(m.queue)
-	m.logEntries = []string{}
+	m.logEntries = nil
 	m.logEntriesLock.Unlock()
 	m.emit(EventTransitionEnd, txArgs, nil)
 

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -335,7 +335,6 @@ func (d *Debugger) jumpFwd(ev *tcell.EventKey) *tcell.EventKey {
 func (d *Debugger) parseMsg(c *Client, idx int) {
 	msgTxParsed := MsgTxParsed{}
 	msgTx := c.MsgTxs[idx]
-	var entries []*am.LogEntry
 
 	// added / removed
 	if len(c.MsgTxs) > 1 && idx > 0 {
@@ -371,7 +370,7 @@ func (d *Debugger) parseMsg(c *Client, idx int) {
 	// TODO take from msgs
 	c.lastActive = time.Now()
 
-	d.parseMsgLog(c, msgTx, entries)
+	d.parseMsgLog(c, msgTx)
 }
 
 // isTxSkipped checks if the tx at the given index is skipped by filters


### PR DESCRIPTION
Because pre-logs (logs created in-between transitions) were all `LogChanges` level, it was impossible to filter out higher log level entries in the debugger.

Now:
- `[extern]` is `LogChanges`
- internal entries have their level attached