### PR TITLE
fix(am-dbg): make LogUserScrolled pause the timeline

### DIFF
--- a/tools/debugger/log.go
+++ b/tools/debugger/log.go
@@ -139,11 +139,9 @@ func (d *Debugger) rebuildLog(ctx context.Context, endIndex int) error {
 		return err
 	}
 
-	// prevent scrolling when not in tail mode
-	if d.Mach.Not(am.S{ss.TailMode, ss.LogUserScrolled}) {
+	// scroll, but only if not manually scrolled
+	if d.Mach.Not1(ss.LogUserScrolled) {
 		d.log.ScrollToHighlight()
-	} else if d.Mach.Not1(ss.TailMode) {
-		d.log.ScrollToEnd()
 	}
 
 	return nil
@@ -160,11 +158,9 @@ func (d *Debugger) appendLogEntry(index int) error {
 		return err
 	}
 
-	// prevent scrolling when not in tail mode
-	if d.Mach.Not(am.S{ss.TailMode, ss.LogUserScrolled}) {
+	// scroll, but only if not manually scrolled
+	if d.Mach.Not1(ss.LogUserScrolled) {
 		d.log.ScrollToHighlight()
-	} else if d.Mach.Not1(ss.TailMode) {
-		d.log.ScrollToEnd()
 	}
 
 	return nil

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -53,7 +53,7 @@ var States = am.Struct{
 		Require: S{ClientSelected},
 		Remove:  GroupDialog,
 	},
-	LogUserScrolled:  {},
+	LogUserScrolled:  {Remove: S{Playing, TailMode}},
 	Ready:            {Require: S{Start}},
 	FilterAutoTx:     {},
 	FilterCanceledTx: {},
@@ -70,7 +70,7 @@ var States = am.Struct{
 	TreeMatrixView: {Remove: GroupViews},
 	TailMode: {
 		Require: S{ClientSelected},
-		Remove:  GroupPlaying,
+		Remove:  am.SMerge(GroupPlaying, S{LogUserScrolled}),
 	},
 	Playing: {
 		Require: S{ClientSelected},
@@ -108,7 +108,7 @@ var States = am.Struct{
 	},
 	ClientSelected: {
 		Require: S{Start},
-		Remove:  S{SelectingClient, LogUserScrolled},
+		Remove:  S{SelectingClient},
 	},
 	RemoveClient: {Require: S{ClientSelected}},
 }


### PR DESCRIPTION
`LogUserScrolled` was missing some sane relations with `Playing` and `TailMode`. Additionally, scrolling logic needed unification.

Now, manually scrolling the log will keep it there and cause `Paused`.