### PR TITLE
feat(helpers): add 5 helper funcs, eg Add1Sync, EnvLogLevel

### DIFF
--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -129,6 +129,10 @@ const (
 	// - Machine.WhenArgs
 	// - Machine.WhenTime
 	Queued
+	// ResultNoOp means that the transition was a no-op, i.e. the state was
+	// already active. ResultNoOp is only used by helpers, and never returned by
+	// the machine itself.
+	ResultNoOp
 )
 
 var (


### PR DESCRIPTION
New helpers:

- RelationsMatrix
- TransitionMatrix
- EnvLogLevel
- Add1Sync
- Add1MultiSync

Most important is `Add1*Sync`, which is a syntax sugar to for old school imperative calls.