### PR TITLE
feat(machine): add export / import

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"os"
+	"path"
 	"regexp"
 	"testing"
 	"time"
@@ -2011,4 +2012,32 @@ func TestOnEventCtxDispose(t *testing.T) {
 // TODO TestAnyAnyHandler
 func TestAnyAnyHandler(t *testing.T) {
 	t.Skip()
+}
+
+func TestExportImport(t *testing.T) {
+	// init
+	m1 := NewNoRels(t, S{"A"})
+	defer m1.Dispose()
+
+	// change clocks
+	m1.Remove1("B", nil)
+	m1.Add1("A", nil)
+	m1.Add1("B", nil)
+	m1.Add1("C", nil)
+	m1Str := m1.String()
+
+	// export
+	jsonPath := path.Join(os.TempDir(), "am-TestExportImport.json")
+	err := m1.Export(jsonPath)
+	assert.NoError(t, err)
+	assert.Equal(t, fileExists(jsonPath), true, "JSON export should exist")
+
+	// import
+	m2 := NewNoRels(t, nil)
+	assert.NoError(t, err)
+	err = m2.Import(jsonPath)
+	assert.NoError(t, err)
+	assert.Equal(t, m1.ID, m2.ID, "imported machine ID should be the same")
+	assert.Equal(t, m1Str, m2.String(),
+		"imported machine clock should be the same")
 }

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -638,6 +638,12 @@ func SMerge(states ...S) S {
 	return slicesUniq(s)
 }
 
+type Export struct {
+	ID         string `json:"id"`
+	Clocks     Clocks `json:"clocks"`
+	StateNames S      `json:"state_names"`
+}
+
 // ///// ///// /////
 // ///// UTILS
 // ///// ///// /////

--- a/pkg/machine/misc_test.go
+++ b/pkg/machine/misc_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -127,4 +128,12 @@ func TestIsActiveTick(t *testing.T) {
 	assert.False(t, IsActiveTick(0))
 	assert.False(t, IsActiveTick(6548734))
 	assert.True(t, IsActiveTick(6548735))
+}
+
+func fileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return err == nil
 }

--- a/pkg/machine/utils_test.go
+++ b/pkg/machine/utils_test.go
@@ -17,6 +17,7 @@ type History struct {
 	CounterMx sync.Mutex
 }
 
+// TODO not thread safe
 func trackTransitions(m *Machine, events S) *History {
 	history := &History{
 		Order:   []string{},


### PR DESCRIPTION
Machine can be restarted on another host and continue previous work, eg in a lambda or [bacalhau](https://github.com/bacalhau-project) worker.

Code creating both machines has to be identical on both hosts.