### PR TITLE
feat(machine): add info to state ctxs

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -1125,7 +1125,13 @@ func (m *Machine) NewStateCtx(state string) context.Context {
 
 	// TODO handle cancelation while parsing the queue
 	// TODO include current clocks as context values
-	stateCtx, cancel := context.WithCancel(m.Ctx)
+
+	v := CtxValue{
+		Id:    m.id,
+		State: state,
+		Tick:  m.clock[state],
+	}
+	stateCtx, cancel := context.WithCancel(context.WithValue(m.ctx, CtxKey, v))
 
 	// close early
 	if !m.is(S{state}) {

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -48,6 +48,19 @@ type State struct {
 // Struct is a map of state names to state definitions.
 type Struct = map[string]State
 
+// Context
+
+type (
+	CtxKeyName struct{}
+	CtxValue   struct {
+		Id    string
+		State string
+		Tick  uint64
+	}
+)
+
+var CtxKey = &CtxKeyName{}
+
 // ///// ///// /////
 
 // ///// OPTIONS


### PR DESCRIPTION
Contexts can be checked for why they've been created using `pkg/machine#CtxKey`:

```go
type CtxValue struct {
    Id    string
    State string
    Tick  uint64
}
```