### PR TITLE
feat(machine): reuse state contexts

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -1123,6 +1123,10 @@ func (m *Machine) NewStateCtx(state string) context.Context {
 	m.activeStatesLock.Lock()
 	defer m.activeStatesLock.Unlock()
 
+	if _, ok := m.indexStateCtx[state]; ok {
+		return m.indexStateCtx[state].Ctx
+	}
+
 	// TODO handle cancelation while parsing the queue
 	// TODO include current clocks as context values
 	stateCtx, cancel := context.WithCancel(m.Ctx)
@@ -1133,11 +1137,9 @@ func (m *Machine) NewStateCtx(state string) context.Context {
 		return stateCtx
 	}
 
-	// add an index
-	if _, ok := m.indexStateCtx[state]; !ok {
-		m.indexStateCtx[state] = []context.CancelFunc{cancel}
-	} else {
-		m.indexStateCtx[state] = append(m.indexStateCtx[state], cancel)
+	binding := &CtxBinding{
+		Ctx:    stateCtx,
+		Cancel: cancel,
 	}
 
 	return stateCtx

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -488,8 +488,13 @@ type (
 	// bindings
 	IndexWhenArgs map[string][]*WhenArgsBinding
 	// IndexStateCtx is a map of (single) state names to a context cancel function
-	IndexStateCtx map[string][]context.CancelFunc
+	IndexStateCtx map[string]*CtxBinding
 )
+
+type CtxBinding struct {
+	Ctx    context.Context
+	Cancel context.CancelFunc
+}
 
 type WhenBinding struct {
 	Ch chan struct{}


### PR DESCRIPTION
Although optimizations are out of scope for current releases this one had made it in, as the new log reader was getting polluted with duplicated contexts.