### PR TITLE
feat(states): add pkg/states/pipes

### DIFF
--- a/pkg/states/pipes/pipes.go
+++ b/pkg/states/pipes/pipes.go
@@ -1,0 +1,141 @@
+// Package pipe provide helpers to pipe states from one machine to another.
+package pipes
+
+import (
+	"maps"
+
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+// Add adds a pipe for an Add mutation between source and target machines.
+//
+// targetState: default to sourceState
+func Add(
+	source, target *am.Machine, sourceState string, targetState string,
+	) am.HandlerFinal {
+	if sourceState == ""  {
+		panic(am.ErrStateMissing)
+	}
+	if targetState == "" {
+		targetState = sourceState
+	}
+	source.LogLvl(am.LogOps, "[pipe-out:add] %s to %s", sourceState, target.Id())
+	target.LogLvl(am.LogOps, "[pipe-in:add] %s from %s", targetState, source.Id())
+
+	return func(e *am.Event) {
+		id := e.Machine.Id()
+		target.LogLvl(am.LogOps, "[pipe:add] (%s) from %s", targetState, id)
+		args := maps.Clone(e.Args)
+		args["_pipe"] = id
+
+		target.Add1(targetState, e.Args)
+	}
+}
+
+func Remove(
+	source, target *am.Machine, sourceState string, targetState string,
+	) am.HandlerFinal {
+	if sourceState == ""  {
+		panic(am.ErrStateMissing)
+	}
+	if targetState == "" {
+		targetState = sourceState
+	}
+	source.LogLvl(am.LogOps, "[pipe-out:remove] %s to %s", sourceState,
+		target.Id())
+	target.LogLvl(am.LogOps, "[pipe-in:remove] %s from %s", targetState,
+		source.Id())
+
+	return func(e *am.Event) {
+		id := e.Machine.Id()
+		target.LogLvl(am.LogOps, "[pipe:remove] (%s) from %s", targetState, id)
+		args := maps.Clone(e.Args)
+		args["_pipe"] = id
+
+		target.Remove1(targetState, e.Args)
+	}
+}
+
+// BindConnected binds a [ss.ConnectedStruct] machine to 4 custom states. Each
+// one is optional and bound with Add/Remove.
+func BindConnected(
+	source, target *am.Machine, disconnected, connecting, connected,
+	disconnecting string,
+) error {
+
+	h := &struct {
+		DisconnectedState am.HandlerFinal
+		DisconnectedEnd   am.HandlerFinal
+
+		ConnectingState am.HandlerFinal
+		ConnectingEnd   am.HandlerFinal
+
+		ConnectedState am.HandlerFinal
+		ConnectedEnd   am.HandlerFinal
+
+		DisconnectingState am.HandlerFinal
+		DisconnectingEnd   am.HandlerFinal
+	}{}
+
+	s := ss.ConnectedStates
+	if disconnected != "" {
+		h.DisconnectedState = Add(source, target, s.Disconnected, disconnected)
+		h.DisconnectedEnd = Remove(source, target, s.Disconnected, disconnected)
+	}
+	if connecting != "" {
+		h.ConnectingState = Add(source, target, s.Connecting, connecting)
+		h.ConnectingEnd = Remove(source, target, s.Connecting, connecting)
+	}
+	if connected != "" {
+		h.ConnectedState = Add(source, target, s.Connected, connected)
+		h.ConnectedEnd = Remove(source, target, s.Connected, connected)
+	}
+	if disconnecting != "" {
+		h.DisconnectingState = Add(source, target, s.Disconnecting, disconnecting)
+		h.DisconnectingEnd = Remove(source, target, s.Disconnecting, disconnecting)
+	}
+
+	return source.BindHandlers(h)
+}
+
+// BindErr binds Exception to a custom state using Add. Empty state defaults to
+// [am.Exception].
+func BindErr(source, target *am.Machine, targetErr string) error {
+
+	if targetErr == "" {
+		targetErr = am.Exception
+	}
+
+	h := &struct {
+		ExceptionState am.HandlerFinal
+	}{
+		ExceptionState: Add(source, target, am.Exception, targetErr),
+	}
+
+	return source.BindHandlers(h)
+}
+
+// BindReady binds Ready to custom states using Add/Remove. Empty state
+// defaults to Ready.
+func BindReady(
+	source, target *am.Machine, activeState, inactiveState string,
+) error {
+
+	if activeState == "" {
+		activeState = ss.BasicStates.Ready
+	}
+	if inactiveState == "" {
+		inactiveState = ss.BasicStates.Ready
+	}
+
+	h := &struct {
+		ReadyState am.HandlerFinal
+		ReadyEnd   am.HandlerFinal
+	}{
+		ReadyState: Add(source, target, ss.BasicStates.Ready, activeState),
+		ReadyEnd:   Remove(source, target, ss.BasicStates.Ready, inactiveState),
+	}
+
+	return source.BindHandlers(h)
+}

--- a/pkg/states/ss_basic.go
+++ b/pkg/states/ss_basic.go
@@ -1,83 +1,49 @@
-// Package states is repository of common state definitions, used to make
-// state-based API easier to compose and exchange.
+// Package states provides reusable state definitions.
+//
+// - basic
+// - connected
 package states
 
 import am "github.com/pancsta/asyncmachine-go/pkg/machine"
 
-// S is a type alias for a list of state names.
-type S = am.S
+// BasicStatesDef contains all the states of the Basic state machine.
+type BasicStatesDef struct {
+	*am.StatesBase
 
-// State is a type alias for a single state definition.
-type State = am.State
+	// ErrNetwork indicates a generic network error.
+	ErrNetwork string
+	// ErrHandlerTimeout indicates one of state machine handlers has timed out.
+	ErrHandlerTimeout string
 
-// SAdd is a func alias for adding lists of states to a list of states.
-var SAdd = am.SAdd
+	// Start indicates the machine should be working. Removing start can force
+	// stop the machine.
+	Start string
+	// Ready indicates the machine meets criteria to perform work.
+	Ready string
+	// Healthcheck is a periodic request making sure that the machine is still
+	// alive.
+	Healthcheck string
+}
 
-// SExtend is a func alias for extending an existing state definition.
-var SExtend = am.StateAdd
-
-// StructMerge is a func alias for extending an existing state structure.
-var StructMerge = am.StructMerge
-
-// States map defines relations and properties of states.
-var States = am.Struct{
+var BasicStruct = am.Struct{
 	// Errors
 
-	ErrNetwork: {Require: S{am.Exception}},
+	ssB.Exception:         {Multi: true},
+	ssB.ErrNetwork:        {Require: S{am.Exception}},
+	ssB.ErrHandlerTimeout: {Require: S{am.Exception}},
 
-	Start: {},
-	Ready: {},
+	// Basics
 
-	// Disconnected -> Connected
-
-	Connecting: {
-		Require: S{Start},
-		Remove:  GroupConnected,
-	},
-	Connected: {
-		Require: S{Start},
-		Remove:  GroupConnected,
-	},
-	Disconnecting: {Remove: GroupConnected},
-	Disconnected: {
-		Auto:   true,
-		Remove: GroupConnected,
-	},
+	ssB.Start:       {},
+	ssB.Ready:       {Require: S{ssB.Start}},
+	ssB.Healthcheck: {},
 }
 
-// Groups of mutually exclusive states.
+// EXPORTS AND GROUPS
 
-var GroupConnected = S{Connecting, Connected, Disconnecting, Disconnected}
+var (
+	ssB = am.NewStates(BasicStatesDef{})
 
-// #region boilerplate defs
-
-// Names of all the states (pkg enum).
-
-const (
-	ErrNetwork = "ErrNetwork"
-
-	Start = "Start"
-	Ready = "Ready"
-
-	Connecting    = "Connecting"
-	Connected     = "Connected"
-	Disconnecting = "Disconnecting"
-	Disconnected  = "Disconnected"
+	// BasicStates contains all the states for the Basic machine.
+	BasicStates = ssB
 )
-
-// Names is an ordered list of all the state names.
-var Names = S{
-	am.Exception,
-
-	ErrNetwork,
-
-	Start,
-	Ready,
-
-	Connecting,
-	Connected,
-	Disconnecting,
-	Disconnected,
-}
-
-// #endregion

--- a/pkg/states/ss_connected.go
+++ b/pkg/states/ss_connected.go
@@ -1,0 +1,55 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+// ConnectedStatesDef contains all the states of the Connected state machine.
+type ConnectedStatesDef struct {
+	Connecting    string
+	Connected     string
+	Disconnecting string
+	Disconnected  string
+
+	*am.StatesBase
+}
+
+// ConnectedGroupsDef contains all the state groups of the Connected state set.
+type ConnectedGroupsDef struct {
+	Connected S
+}
+
+// ConnectedStruct represents all relations and properties of ConnectedStates.
+var ConnectedStruct = am.Struct{
+	cs.Connecting: {
+		Require: S{ssB.Start},
+		Remove:  cg.Connected,
+	},
+	cs.Connected: {
+		Require: S{ssB.Start},
+		Remove:  cg.Connected,
+	},
+	cs.Disconnecting: {Remove: cg.Connected},
+	cs.Disconnected: {
+		Auto:   true,
+		Remove: cg.Connected,
+	},
+}
+
+// EXPORTS AND GROUPS
+
+var (
+	cs = am.NewStates(ConnectedStatesDef{})
+	cg = am.NewStateGroups(ConnectedGroupsDef{
+		Connected: S{
+			cs.Connecting, cs.Connected, cs.Disconnecting,
+			cs.Disconnected,
+		},
+	})
+
+	// ConnectedStates contains all the states for the Connected state set.
+	ConnectedStates = cs
+
+	// ConnectedGroups contains all the state groups for the Connected state set.
+	ConnectedGroups = cg
+)

--- a/pkg/states/states_utils.go
+++ b/pkg/states/states_utils.go
@@ -1,0 +1,22 @@
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// State is a type alias for a state definition.
+type State = am.State
+
+// SAdd is a func alias for merging lists of states.
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition.
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition.
+var StateSet = am.StateSet
+
+// StructMerge is a func alias for extending an existing state structure.
+var StructMerge = am.StructMerge


### PR DESCRIPTION
State piping made it in earlier then expected. Pipe state from one machine to another, possibly as 2 different states. It's all transition handlers at the end, its easy to write you own and packages offer predefined one.

```go
import (
    am "github.com/pancsta/asyncmachine-go/pkg/machine"
    ampipe "github.com/pancsta/asyncmachine-go/pkg/rpc/states/pipes"
)

// ...

ampipe.BindReady(rpcClient.Mach, myMach, "RpcReady", "")

// ...

var source *am.Machine
var target *am.Machine

h := &struct {
    ReadyState am.HandlerFinal
    ReadyEnd   am.HandlerFinal
}{
    ReadyState: Add1(source, target, "Ready", "RpcReady"),
    ReadyEnd:   Remove1(source, target, "Ready", "RpcReady"),
}

source.BindHandlers(h)
```

More info in [`/pkg/states`](/pkg/states/README.md) and the [dedicated example](/examples/pipes/example_pipes.go).
