### PR TITLE
feat(node): add pkg/node

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1,0 +1,141 @@
+// Package node provides distributed worker pools with supervisors.
+package node
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	"github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+func init() {
+	gob.Register(&ARpc{})
+}
+
+const (
+	// EnvAmNodeLogSupervisor enables machine logging for node supervisor.
+	EnvAmNodeLogSupervisor = "AM_NODE_LOG_SUPERVISOR"
+	// EnvAmNodeLogClient enables machine logging for node client.
+	EnvAmNodeLogClient = "AM_NODE_LOG_CLIENT"
+)
+
+// ///// ///// /////
+
+// ///// ERRORS
+
+// ///// ///// /////
+
+// sentinel errors
+
+var (
+	ErrWorker        = errors.New("worker error")
+	ErrWorkerMissing = errors.New("worker missing")
+	ErrWorkerHealth  = errors.New("worker failed healthcheck")
+	ErrWorkerConn    = errors.New("error starting connection")
+	ErrWorkerKill    = errors.New("error killing worker")
+	ErrPool          = errors.New("pool error")
+	ErrRpc           = errors.New("rpc error")
+)
+
+// error mutations
+
+// AddErrWorker wraps an error in the ErrWorker sentinel and adds to a machine.
+func AddErrWorker(mach *am.Machine, err error, args am.A) {
+	mach.AddErrState(ssS.ErrWorker, fmt.Errorf("%w: %w", ErrWorker, err), args)
+}
+
+// AddErrWorkerStr wraps a msg in the ErrWorker sentinel and adds to a machine.
+func AddErrWorkerStr(mach *am.Machine, msg string, args am.A) {
+	mach.AddErrState(ssS.ErrWorker, fmt.Errorf("%w: %s", ErrWorker, msg), args)
+}
+
+// AddErrPool wraps an error in the ErrPool sentinel and adds to a machine.
+func AddErrPool(mach *am.Machine, err error, args am.A) {
+	mach.AddErrState(ssS.ErrPool, fmt.Errorf("%w: %w", ErrPool, err), args)
+}
+
+// AddErrPoolStr wraps a msg in the ErrPool sentinel and adds to a machine.
+func AddErrPoolStr(mach *am.Machine, msg string, args am.A) {
+	mach.AddErrState(ssS.ErrPool, fmt.Errorf("%w: %s", ErrPool, msg), args)
+}
+
+// AddErrRpc wraps an error in the ErrRpc sentinel and adds to a machine.
+func AddErrRpc(mach *am.Machine, err error, args am.A) {
+	err = fmt.Errorf("%w: %w", ErrRpc, err)
+	mach.AddErrState(states.BasicStates.ErrNetwork, err, args)
+}
+
+// ///// ///// /////
+
+// ///// ARGS
+
+// ///// ///// /////
+
+// A is a struct for node arguments. It's a typesafe alternative to am.A.
+type A struct {
+	// Id is a machine ID.
+	Id string `log:"id"`
+	// PublicAddr is the public address of a Supervisor or Worker.
+	PublicAddr string `log:"public_addr"`
+	// LocalAddr is the public address of a Supervisor or Worker.
+	LocalAddr string `log:"local_addr"`
+	// NodesList is a list of available nodes (supervisors' public RPC addresses).
+	NodesList  []string
+	ClientAddr string
+
+	// non-rpc fields
+
+	// Worker is the RPC client connected to a Worker.
+	Worker *rpc.Client
+	// Bootstrap is the RPC machine used to connect Worker to the Supervisor.
+	Bootstrap *bootstrap
+	// Dispose the worker
+	Dispose bool
+}
+
+// ARpc is a subset of A, that can be passed over RPC.
+type ARpc struct {
+	// Id is a machine ID.
+	Id string `log:"id"`
+	// PublicAddr is the public address of a Supervisor or Worker.
+	PublicAddr string `log:"public_addr"`
+	// LocalAddr is the public address of a Supervisor, Worker, or [bootstrap].
+	LocalAddr string `log:"local_addr"`
+	// NodesList is a list of available nodes (supervisors' public RPC addresses).
+	NodesList  []string
+	ClientAddr string
+}
+
+// ParseArgs extracts A from [am.Event.Args]["am_node"].
+func ParseArgs(args am.A) *A {
+	r, _ := args["am_node"].(*ARpc)
+	if r != nil {
+		return amhelp.ArgsToArgs(r, &A{})
+	}
+	a, _ := args["am_node"].(*A)
+	return a
+}
+
+// Pass prepares [am.A] from A to pass to further mutations.
+func Pass(args *A) am.A {
+	return am.A{"am_node": args}
+}
+
+// PassRpc prepares [am.A] from A to pass over RPC.
+func PassRpc(args *A) am.A {
+	return am.A{"am_node": amhelp.ArgsToArgs(args, &ARpc{})}
+}
+
+// LogArgs is an args logger for A.
+func LogArgs(args am.A) map[string]string {
+	a := ParseArgs(args)
+	if a == nil {
+		return nil
+	}
+
+	return amhelp.ArgsToLogMap(a)
+}

--- a/pkg/node/node_client.go
+++ b/pkg/node/node_client.go
@@ -1,0 +1,379 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+)
+
+var ssC = states.ClientStates
+
+// Client is a node client, connecting to a supervisor and then a worker.
+type Client struct {
+	*am.ExceptionHandler
+	Mach *am.Machine
+
+	Name       string
+	SuperAddr  string
+	LogEnabled bool
+	// LeaveSuper is a flag to leave the supervisor after connecting to the
+	// worker. TODO
+	LeaveSuper bool
+	// ConnTimeout is the time to wait for an outbound connection to be
+	// established. Default is 5 seconds.
+	ConnTimeout time.Duration
+
+	// network
+
+	SuperRpc  *rpc.Client
+	WorkerRpc *rpc.Client
+
+	// internal
+
+	// current nodes list (set by Start)
+	nodesList []string
+	stateDeps *ClientStateDeps
+}
+
+// implement ConsumerHandlers
+var _ ssrpc.ConsumerHandlers = &Client{}
+
+func NewClient(ctx context.Context, id string, workerKind string,
+	stateDeps *ClientStateDeps, opts *ClientOpts,
+) (*Client, error) {
+	// validate
+	if id == "" {
+		return nil, errors.New("client: workerStruct required")
+	}
+	if stateDeps == nil {
+		return nil, errors.New("client: stateNames required")
+	}
+	if stateDeps.WorkerSStruct == nil {
+		return nil, errors.New("client: workerStruct required")
+	}
+	if stateDeps.WorkerSNames == nil {
+		return nil, errors.New("client: stateNames required")
+	}
+	if stateDeps.ClientSStruct == nil {
+		return nil, errors.New("client: workerStruct required")
+	}
+	if stateDeps.ClientSNames == nil {
+		return nil, errors.New("client: stateNames required")
+	}
+	if workerKind == "" {
+		return nil, errors.New("client: workerKind required")
+	}
+	if opts == nil {
+		opts = &ClientOpts{}
+	}
+
+	err := amhelp.Implements(stateDeps.WorkerSNames, states.WorkerStates.Names())
+	if err != nil {
+		err := fmt.Errorf(
+			"worker has to implement am/node/states/WorkerStates: %w", err)
+		return nil, err
+	}
+
+	name := fmt.Sprintf("%s-%s-%s", workerKind, id,
+		time.Now().Format("150405"))
+
+	c := &Client{
+		Name:        name,
+		ConnTimeout: 5 * time.Second,
+		LogEnabled:  os.Getenv(EnvAmNodeLogClient) != "",
+		stateDeps:   stateDeps,
+	}
+	mach, err := am.NewCommon(ctx, "nc-"+name, stateDeps.ClientSStruct,
+		stateDeps.ClientSNames, c, opts.Parent, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mach.SetLogArgs(LogArgs)
+	c.Mach = mach
+	amhelp.MachDebugEnv(mach)
+
+	// check base states
+	err = amhelp.Implements(mach.StateNames(), ssC.Names())
+	if err != nil {
+		err := fmt.Errorf(
+			"client has to implement am/node/states/ClientStates: %w", err)
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// ///// ///// /////
+
+// ///// HANDLERS
+
+// ///// ///// /////
+
+func (c *Client) StartEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && len(a.NodesList) > 0
+}
+
+func (c *Client) StartState(e *am.Event) {
+	var err error
+	ctx := c.Mach.NewStateCtx(ssC.Start)
+	args := ParseArgs(e.Args)
+	addr := args.NodesList[0]
+	c.nodesList = args.NodesList
+
+	// init super rpc (but dont connect just yet)
+	c.SuperRpc, err = rpc.NewClient(ctx, addr, "nc-super-"+c.Name,
+		states.SupervisorStruct, ssS.Names(), &rpc.ClientOpts{
+			Parent:   c.Mach,
+			Consumer: c.Mach,
+		})
+	if err != nil {
+		err := fmt.Errorf("failed to connect to the Supervisor: %w", err)
+		AddErrRpc(c.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(c.SuperRpc.Mach)
+
+	// bind to super rpc
+	err = errors.Join(
+		ampipe.BindConnected(c.SuperRpc.Mach, c.Mach, ssC.SuperDisconnected,
+			ssC.SuperConnecting, ssC.SuperConnected, ssC.SuperDisconnecting),
+		ampipe.BindErr(c.SuperRpc.Mach, c.Mach, ssC.ErrSupervisor),
+		ampipe.BindReady(c.SuperRpc.Mach, c.Mach, ssC.SuperReady, ""),
+	)
+	if err != nil {
+		c.Mach.AddErr(err, nil)
+		return
+	}
+
+	// unblock
+	go func() {
+		// try all nodes TODO randomize
+		for i, addr := range args.NodesList {
+			if ctx.Err() != nil {
+				return // expired
+			}
+			c.Mach.Log("trying node %d: %s", i, addr)
+
+			// (re)start and wait
+			// TODO handle in ExceptionState when SuperConnecting active
+			c.Mach.Remove1(am.Exception, nil)
+			c.SuperRpc.Addr = addr
+			// fewer retries, bc of fallbacks
+			// TODO config via a composable RetryPolicy from rpc-c
+			c.SuperRpc.ConnRetries = 3
+			c.SuperRpc.Start()
+			err := amhelp.WaitForAny(ctx, c.ConnTimeout,
+				c.Mach.When1(ssC.SuperReady, nil),
+				c.SuperRpc.Mach.WhenNot1(ssrpc.ClientStates.Start, nil),
+			)
+			if ctx.Err() != nil {
+				return // expired
+			}
+
+			// stopped rpc client is an error
+			if c.SuperRpc.Mach.Not1(ssrpc.ClientStates.Start) {
+				// TODO blacklist the node for X time
+				// re-start
+				c.SuperRpc.Stop(ctx, false)
+				c.Mach.Remove1(ssC.Exception, nil)
+				continue
+			}
+
+			if err != nil {
+				err := errors.Join(err, c.SuperRpc.Mach.Err())
+				AddErrRpc(c.Mach, err, nil)
+
+				return
+			}
+		}
+	}()
+}
+
+func (c *Client) StartEnd(e *am.Event) {
+	if c.SuperRpc != nil {
+		c.SuperRpc.Stop(context.TODO(), true)
+	}
+	if c.WorkerRpc != nil {
+		c.WorkerRpc.Stop(context.TODO(), true)
+	}
+}
+
+func (c *Client) WorkerRequestedEnter(e *am.Event) bool {
+	return c.SuperRpc.Worker.Is1(ssS.WorkersAvailable)
+}
+
+func (c *Client) WorkerRequestedState(e *am.Event) {
+	c.SuperRpc.Worker.Add1(ssS.ProvideWorker, PassRpc(&A{
+		Id: GetRpcClientId(c.Name),
+	}))
+}
+
+func (c *Client) WorkerPayloadEnter(e *am.Event) bool {
+	a := rpc.ParseArgs(e.Args)
+	return a != nil && a.Name != "" && a.Payload != nil
+}
+
+// WorkerPayloadState handles both Supervisor and Worker passing payloads.
+func (c *Client) WorkerPayloadState(e *am.Event) {
+	c.Mach.Remove1(ssC.WorkerPayload, nil)
+	args := rpc.ParseArgs(e.Args)
+	c.log("worker %s delivered: %s", args.Payload.Source, args.Name)
+
+	if args.Name != ssS.ProvideWorker {
+		// worker impl will handle
+		return
+	}
+
+	if c.Mach.Not1(ssC.WorkerRequested) {
+		c.log("worker not requested")
+		return
+	}
+
+	ctx := c.Mach.NewStateCtx(ssC.WorkerRequested)
+	ctxStart := c.Mach.NewStateCtx(ssC.Start)
+	addr, ok := args.Payload.Data.(string)
+	if !ok || addr == "" {
+		err := errors.New("invalid worker address")
+		c.Mach.AddErrState(ssC.ErrSupervisor, err, nil)
+
+		return
+	}
+	c.log("connecting to worker: %s", addr)
+
+	// unblock
+	go func() {
+		// connect to the worker
+		var err error
+		c.WorkerRpc, err = rpc.NewClient(ctxStart, addr, GetClientId(c.Name),
+			c.stateDeps.WorkerSStruct, c.stateDeps.WorkerSNames, &rpc.ClientOpts{
+				Parent:   c.Mach,
+				Consumer: c.Mach,
+			})
+		if err != nil {
+			err := fmt.Errorf("failed to connect to the Worker: %w", err)
+			AddErrRpc(c.Mach, err, nil)
+			return
+		}
+		// delay for rpc/Mux
+		c.WorkerRpc.HelloDelay = 100 * time.Millisecond
+		amhelp.MachDebugEnv(c.WorkerRpc.Mach)
+
+		// bind to worker rpc
+		err = errors.Join(
+			ampipe.BindConnected(c.WorkerRpc.Mach, c.Mach, ssC.WorkerDisconnected,
+				ssC.WorkerConnecting, ssC.WorkerConnected, ssC.WorkerDisconnecting),
+			ampipe.BindErr(c.WorkerRpc.Mach, c.Mach, ssC.ErrWorker),
+			ampipe.BindReady(c.WorkerRpc.Mach, c.Mach, ssC.WorkerReady, ""),
+		)
+		if err != nil {
+			c.Mach.AddErr(err, nil)
+			return
+		}
+
+		// start and wait
+		c.WorkerRpc.Start()
+		err = amhelp.WaitForAny(ctx, c.ConnTimeout,
+			c.Mach.When1(ssC.WorkerReady, nil),
+			c.WorkerRpc.Mach.WhenErr(context.TODO()),
+		)
+		// TODO retry
+		if err != nil {
+			c.Mach.Remove1(ssC.WorkerRequested, nil)
+		}
+	}()
+}
+
+// ///// ///// /////
+
+// ///// METHODS
+
+// ///// ///// /////
+
+func (c *Client) Start(nodesList []string) {
+	c.Mach.Add1(ssC.Start, Pass(&A{
+		NodesList: nodesList,
+	}))
+}
+
+func (c *Client) Stop(ctx context.Context) {
+	if c.SuperRpc != nil {
+		c.SuperRpc.Stop(ctx, false)
+	}
+	if c.WorkerRpc != nil {
+		c.WorkerRpc.Stop(ctx, false)
+	}
+	c.Mach.Remove1(ssC.Start, nil)
+}
+
+func (c *Client) ReqWorker(ctx context.Context) error {
+	// failsafe worker request
+	_, err := amhelp.NewReqAdd1(c.Mach, ssC.WorkerRequested, nil).Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = amhelp.WaitForAll(ctx, c.ConnTimeout,
+		c.Mach.When1(ssC.WorkerReady, nil))
+	if err != nil {
+		return err
+	}
+
+	c.log("worker connected: %s", c.WorkerRpc.Worker.ID)
+	return nil
+}
+
+func (c *Client) Dispose(ctx context.Context) {
+	c.Stop(ctx)
+	c.SuperRpc = nil
+	c.WorkerRpc = nil
+	c.Mach.Dispose()
+}
+
+func (c *Client) log(msg string, args ...any) {
+	if !c.LogEnabled {
+		return
+	}
+	c.Mach.Log(msg, args...)
+}
+
+// ///// ///// /////
+
+// ///// MISC
+
+// ///// ///// /////
+
+// ClientStateDeps contains the state definitions and names of the client and
+// worker machines, needed to create a new client.
+type ClientStateDeps struct {
+	ClientSStruct am.Struct
+	ClientSNames  am.S
+	WorkerSStruct am.Struct
+	WorkerSNames  am.S
+}
+
+type ClientOpts struct {
+	// Parent is a parent state machine for a new client state machine. See
+	// [am.Opts].
+	Parent am.Api
+}
+
+// GetClientId returns a machine ID from a name.
+func GetClientId(name string) string {
+	return "nc-worker-" + name
+}
+
+// GetRpcClientId returns a machine ID from a name.
+func GetRpcClientId(name string) string {
+	return rpc.GetClientId("nc-worker-" + name)
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,510 @@
+package node
+
+import (
+	"context"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+
+	testutils "github.com/pancsta/asyncmachine-go/internal/testing/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	amhelpt "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+const defTimeout = 5 * time.Second
+
+func init() {
+	_ = godotenv.Load()
+
+	if os.Getenv(am.EnvAmTestDebug) != "" {
+		amhelp.EnableDebugging(true)
+	}
+}
+
+func TestFork1(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// supervisor
+	s, err := NewSupervisor(ctx, getKind(t), []string{"test"},
+		testutils.RelsNodeWorkerStruct, testutils.RelsNodeWorkerStates, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetPool(1, 1, 0, 1)
+
+	// fork func
+	s.testFork = newTestFork(ctx, t, "test")
+	s.testKill = newTestKill(ctx, t, "test")
+
+	whenForked := s.Mach.WhenTicks(states.SupervisorStates.WorkerForked, 1, nil)
+	s.Start(":0")
+	amhelpt.WaitForAll(t, ctx, defTimeout, whenForked)
+
+	// assert
+	assert.Equal(t, 1, s.workers.Count())
+	amhelpt.AssertNoErrNow(t, s.Mach)
+}
+
+func TestFork1Process(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wPath string
+	if strings.HasSuffix(wd, "pkg/node") {
+		wPath = "./test/worker/node_test_worker.go"
+	} else {
+		wPath = "./pkg/node/test/worker/node_test_worker.go"
+	}
+
+	// supervisor
+	cmd := []string{"go", "run", wPath}
+	s, err := NewSupervisor(ctx, "NTW", cmd,
+		testutils.RelsNodeWorkerStruct, testutils.RelsNodeWorkerStates, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Max = 1
+
+	whenForked := s.Mach.WhenTicks(states.SupervisorStates.WorkerForked, 1, nil)
+	s.Start(":0")
+	amhelpt.WaitForAll(t, ctx, defTimeout, whenForked)
+
+	// assert
+	assert.Equal(t, 1, s.workers.Count())
+	amhelpt.AssertNoErrNow(t, s.Mach)
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+// TestFork5With2 tests a pool of 5 with 2 warm workers and 2 min workers.
+func TestFork5Warm2Min2(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// supervisor
+	s, err := NewSupervisor(ctx, getKind(t), []string{"test"},
+		testutils.RelsNodeWorkerStruct, testutils.RelsNodeWorkerStates, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetPool(2, 5, 2, 0)
+
+	// fork func
+	s.testFork = newTestFork(ctx, t, "test")
+
+	s.Start(":0")
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		s.Mach.When1(ssS.PoolReady, nil))
+
+	// wait for the warm workers TODO depend on a state, not human time
+	amhelpt.Wait(t, ctx, defTimeout)
+
+	// assert
+	assert.Equal(t, 4, s.workers.Count())
+	assert.Len(t, s.AllWorkers(), 4)
+	assert.GreaterOrEqual(t, len(s.ReadyWorkers()), s.Min) // TODO flaky (3)
+	assert.GreaterOrEqual(t, len(s.IdleWorkers()), s.Min)  // TODO flaky (3)
+	assert.Len(t, s.BusyWorkers(), 0)
+	amhelpt.AssertNoErrNow(t, s.Mach)
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+// TestFork5Warm2Min2 tests a pool of 15 with 0 warm workers and 7 min workers.
+func TestFork15Warm0Min7(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// supervisor
+	s, err := NewSupervisor(ctx, getKind(t), []string{"test"},
+		testutils.RelsNodeWorkerStruct, testutils.RelsNodeWorkerStates, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetPool(7, 15, 0, 0)
+
+	// fork func
+	s.testFork = newTestFork(ctx, t, "test")
+
+	s.Start(":0")
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		s.Mach.When1(ssS.PoolReady, nil))
+
+	// assert
+	assert.Equal(t, 7, s.workers.Count())
+	assert.Len(t, s.AllWorkers(), 7)
+	assert.GreaterOrEqual(t, len(s.ReadyWorkers()), s.Min)
+	assert.GreaterOrEqual(t, len(s.IdleWorkers()), s.Min)
+	assert.Len(t, s.BusyWorkers(), 0)
+	amhelpt.AssertNoErrNow(t, s.Mach)
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+func TestClientSupervisor(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// supervisor
+	s := newSupervisor(t, ctx, getKind(t), 1)
+
+	cDeps := &ClientStateDeps{
+		WorkerSStruct: testutils.RelsNodeWorkerStruct,
+		WorkerSNames:  testutils.RelsNodeWorkerStates,
+		ClientSStruct: states.ClientStruct,
+		ClientSNames:  states.ClientStates.Names(),
+	}
+	c, err := NewClient(ctx, "cli", getKind(t), cDeps, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Start([]string{s.PublicMux.Addr})
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		c.Mach.When1(ssC.SuperReady, nil))
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+func TestClientSupervisorFallback(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// TODO flaky for `task test`
+	if os.Getenv("AM_TEST_RUNNER") != "" {
+		time.Sleep(time.Second)
+	}
+
+	// init
+	s := newSupervisor(t, ctx, getKind(t), 1)
+	c := newClient(t, ctx)
+
+	// provide a wrong address as the 1st one
+	c.Start([]string{"localhost:666", s.PublicMux.Addr})
+	// TODO inject a short-timeout retry policy to node client
+	amhelpt.WaitForAll(t, ctx, defTimeout*2,
+		c.Mach.When1(ssC.SuperReady, nil))
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+
+	if amhelp.IsDebug() {
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// TODO TestKillWorker
+
+func TestClientWorker(t *testing.T) {
+	// t.Parallel()
+	// amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, s := newConnectedClient(t, ctx)
+
+	// get worker
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		c.SuperRpc.Worker.When1(ssS.WorkersAvailable, nil))
+	err := c.ReqWorker(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		c.Mach.When1(ssC.WorkerReady, nil))
+	w := getWorker(t, c.WorkerRpc.Addr)
+
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		w.Mach.When1(ssW.ClientConnected, nil))
+
+	// assert
+	amhelpt.AssertIs1(t, w.Mach, ssW.ClientConnected)
+	amhelpt.AssertNoErrNow(t, s.Mach)
+	amhelpt.AssertNoErrNow(t, c.Mach)
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+// TODO TestClientWorkerReconn
+
+// TODO Test2ClientsWorker
+
+func TestClientWorkerPayload(t *testing.T) {
+	// // t.Parallel()
+	amhelp.EnableDebugging(false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// client
+
+	c, s := newConnectedClient(t, ctx)
+
+	// get worker
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		c.SuperRpc.Worker.When1(ssS.WorkersAvailable, nil))
+	err := c.ReqWorker(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		c.Mach.When1(ssC.WorkerReady, nil))
+	w := getWorker(t, c.WorkerRpc.Addr)
+
+	// bind payload handler
+	h := &clientHandlers{t: t}
+	err = c.Mach.BindHandlers(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	whenPayload := c.Mach.WhenTicks(ssC.WorkerPayload, 1, nil)
+	c.WorkerRpc.Worker.Add1(ssW.WorkRequested, am.A{"input": 2})
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		whenPayload, w.Mach.When1(ssW.ClientConnected, nil))
+
+	// assert
+
+	assert.Equal(t, 4, h.payload.Data.(int))
+
+	s.Stop()
+	<-s.Mach.WhenDisposed()
+}
+
+// ///// ///// /////
+
+// ///// UTILS
+
+// ///// ///// /////
+
+func newConnectedClient(t *testing.T, ctx context.Context) (
+	*Client, *Supervisor,
+) {
+	// init
+	sup := newSupervisor(t, ctx, getKind(t), 0)
+	c := newClient(t, ctx)
+
+	c.Start([]string{sup.PublicMux.Addr})
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+
+		c.Mach.When1(ssC.SuperReady, nil))
+
+	return c, sup
+}
+
+func newClient(t *testing.T, ctx context.Context) *Client {
+	cDeps := &ClientStateDeps{
+		WorkerSStruct: testutils.RelsNodeWorkerStruct,
+		WorkerSNames:  testutils.RelsNodeWorkerStates,
+		ClientSStruct: states.ClientStruct,
+		ClientSNames:  states.ClientStates.Names(),
+	}
+	c, err := NewClient(ctx, "cli", getKind(t), cDeps, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// newSupervisor creates a new Supervisor with a test fork function and returns
+// on PoolReady.
+func newSupervisor(
+	t *testing.T, ctx context.Context, workerKind string, workers int,
+) *Supervisor {
+	sup, err := NewSupervisor(ctx, workerKind, []string{"test"},
+		testutils.RelsNodeWorkerStruct, testutils.RelsNodeWorkerStates, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if workers != 0 {
+		sup.SetPool(workers, workers, 0, 0)
+	}
+
+	// fork func
+	sup.testFork = newTestFork(ctx, t, workerKind)
+	sup.testKill = newTestKill(ctx, t, workerKind)
+
+	sup.Start(":0")
+	amhelpt.WaitForAll(t, ctx, defTimeout,
+		sup.Mach.When1(ssS.PoolReady, nil))
+
+	return sup
+}
+
+var (
+	workers   = map[string]*Worker{}
+	workersMx = sync.Mutex{}
+)
+
+// newTestFork creates a new test fork function that creates a new Worker and
+// connects it to the Supervisor.
+func newTestFork(
+	ctx context.Context, t *testing.T, workerKind string,
+) func(addr string) error {
+	return func(addr string) error {
+		if amhelp.IsDebug() {
+			t.Logf("fork worker: %s", addr)
+		}
+
+		// worker
+		mach := testutils.NewRelsNodeWorker(t, nil)
+		worker, err := NewWorker(ctx, workerKind, mach.GetStruct(),
+			mach.StateNames(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = worker.Mach.BindHandlers(&workerHandlers{t: t})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// connect Worker to the bootstrap machine
+		worker.Start(addr)
+		err = amhelp.WaitForAll(ctx, defTimeout,
+			worker.Mach.When1(ssW.RpcReady, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		workersMx.Lock()
+		defer workersMx.Unlock()
+
+		workers[workerKind+"-"+worker.LocalAddr] = worker
+		workers[workerKind+"-"+worker.PublicAddr] = worker
+		workers[workerKind+"-"+worker.BootAddr] = worker
+
+		return nil
+	}
+}
+
+func newTestKill(
+	ctx context.Context, t *testing.T, workerKind string,
+) func(addr string) error {
+	return func(addr string) error {
+		t.Logf("kill worker: %s", addr)
+		workersMx.Lock()
+		defer workersMx.Unlock()
+
+		idx := workerKind + "-" + addr
+		worker, ok := workers[idx]
+		if !ok {
+			t.Fatalf("worker not found: %s", idx)
+		}
+
+		worker.Stop(true)
+		delete(workers, workerKind+"-"+worker.BootAddr)
+		delete(workers, workerKind+"-"+worker.LocalAddr)
+		delete(workers, workerKind+"-"+worker.PublicAddr)
+
+		return nil
+	}
+}
+
+func getWorker(t *testing.T, addr string) *Worker {
+	workersMx.Lock()
+	defer workersMx.Unlock()
+
+	idx := getKind(t) + "-" + addr
+	worker, ok := workers[idx]
+	if !ok {
+		t.Fatalf("worker not found: %s", idx)
+	}
+
+	return worker
+}
+
+type workerHandlers struct {
+	t *testing.T
+}
+
+func (w *workerHandlers) WorkRequestedState(e *am.Event) {
+	input := e.Args["input"].(int)
+
+	payload := &rpc.ArgsPayload{
+		Name:   w.t.Name(),
+		Data:   input * input,
+		Source: e.Machine.Id(),
+	}
+
+	e.Machine.Add1(ssW.ClientSendPayload, rpc.Pass(&rpc.A{
+		Name:    w.t.Name(),
+		Payload: payload,
+	}))
+}
+
+type clientHandlers struct {
+	t       *testing.T
+	payload *rpc.ArgsPayload
+}
+
+// implement ssrpc.ConsumerHandlers
+var _ ssrpc.ConsumerHandlers = &clientHandlers{}
+
+func (c *clientHandlers) WorkerPayloadState(e *am.Event) {
+	args := rpc.ParseArgs(e.Args)
+
+	if args.Name != ssS.ProvideWorker {
+		c.payload = args.Payload
+	}
+}
+
+var workerKind []string
+
+// getKind returns a worker kind from uppercase letters and numbers of the test
+// name.
+func getKind(t *testing.T) string {
+	var result []rune
+	for _, r := range t.Name() {
+		if unicode.IsUpper(r) || unicode.IsDigit(r) {
+			result = append(result, r)
+		}
+	}
+
+	kind := string(result)
+
+	// add a number for collisions
+	if slices.Contains(workerKind, kind) {
+		for i := 1; i < 10; i++ {
+			dig := strconv.Itoa(i)
+			if !strings.Contains(kind+dig, kind) {
+				break
+			}
+		}
+	}
+
+	return string(result)
+}

--- a/pkg/node/node_worker.go
+++ b/pkg/node/node_worker.go
@@ -1,0 +1,305 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+)
+
+var (
+	ssW = states.WorkerStates
+	sgW = states.WorkerGroups
+)
+
+type Worker struct {
+	*am.ExceptionHandler
+	Mach *am.Machine
+
+	Name string
+	Kind string
+	// AcceptClient is the ID of a client, passed by the supervisor. Worker should
+	// only accept connections from this client.
+	AcceptClient string
+
+	// ConnTimeout is the time to wait for an outbound connection to be
+	// established.
+	ConnTimeout     time.Duration
+	DeliveryTimeout time.Duration
+
+	// BootAddr is the address of the bootstrap machine.
+	BootAddr string
+	// BootRpc is the RPC client connection to bootstrap machine, which passes
+	// connection info to the Supervisor.
+	BootRpc *rpc.Client
+
+	// LocalAddr is the address of the local RPC server.
+	LocalAddr string
+	// LocalRpc is the local RPC server, used by the Supervisor to connect.
+	LocalRpc *rpc.Server
+
+	// PublicAddr is the address of the public RPC server.
+	PublicAddr string
+	// PublicRpc is the public RPC server, used by the Client to connect.
+	PublicRpc *rpc.Server
+}
+
+func NewWorker(ctx context.Context, kind string, workerStruct am.Struct,
+	stateNames am.S, opts *WorkerOpts,
+) (*Worker, error) {
+	// validate
+	if kind == "" {
+		return nil, errors.New("worker: workerSNames required")
+	}
+	if stateNames == nil {
+		return nil, errors.New("worker: workerSNames required")
+	}
+	if workerStruct == nil {
+		return nil, errors.New("worker: workerStruct required")
+	}
+	if opts == nil {
+		opts = &WorkerOpts{}
+	}
+
+	name := fmt.Sprintf("%s-%s-%s", kind, utils.Hostname(), utils.RandID(6))
+
+	w := &Worker{
+		ConnTimeout:     5 * time.Second,
+		DeliveryTimeout: 5 * time.Second,
+		Name:            name,
+		Kind:            kind,
+	}
+
+	if amhelp.IsDebug() {
+		// increase timeouts using context.WithTimeout directly
+		w.DeliveryTimeout = 10 * w.DeliveryTimeout
+	}
+
+	mach, err := am.NewCommon(ctx, "nw-"+w.Name, workerStruct, stateNames, w,
+		opts.Parent, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mach.SetLogArgs(LogArgs)
+	w.Mach = mach
+	amhelp.MachDebugEnv(mach)
+
+	// check base states
+	err = amhelp.Implements(mach.StateNames(), ssW.Names())
+	if err != nil {
+		err := fmt.Errorf(
+			"client has to implement am/node/states/WorkerStates: %w", err)
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// ///// ///// /////
+
+// ///// HANDLERS
+
+// ///// ///// /////
+
+func (w *Worker) ErrNetworkState(e *am.Event) {
+	// TODO handle RPC errors
+}
+
+func (w *Worker) StartEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a.LocalAddr != ""
+}
+
+func (w *Worker) StartState(e *am.Event) {
+	var err error
+	ctx := w.Mach.NewStateCtx(ssW.Start)
+	args := ParseArgs(e.Args)
+	w.BootAddr = args.LocalAddr
+
+	// local RPC
+	opts := &rpc.ServerOpts{
+		PayloadState: ssW.SuperSendPayload,
+		Parent:       w.Mach,
+	}
+	w.LocalRpc, err = rpc.NewServer(ctx, "localhost:0", "nw-loc-"+w.Name, w.Mach,
+		opts)
+	if err != nil {
+		AddErrRpc(w.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(w.LocalRpc.Mach)
+	w.LocalRpc.DeliveryTimeout = w.DeliveryTimeout
+	err = errors.Join(
+		rpc.BindServer(w.LocalRpc.Mach, w.Mach, ssW.LocalRpcReady,
+			ssW.SuperConnected),
+		ampipe.BindErr(w.LocalRpc.Mach, w.Mach, ssW.ErrSupervisor))
+	if err != nil {
+		w.Mach.AddErr(err, nil)
+		return
+	}
+
+	// public RPC
+	opts = &rpc.ServerOpts{
+		PayloadState: ssW.ClientSendPayload,
+		Parent:       w.Mach,
+	}
+	w.PublicRpc, err = rpc.NewServer(ctx, ":0", "nw-pub-"+w.Name, w.Mach, opts)
+	if err != nil {
+		AddErrRpc(w.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(w.PublicRpc.Mach)
+	w.PublicRpc.DeliveryTimeout = w.DeliveryTimeout
+	err = errors.Join(
+		rpc.BindServer(w.PublicRpc.Mach, w.Mach, ssW.PublicRpcReady,
+			ssW.ClientConnected),
+		ampipe.BindErr(w.PublicRpc.Mach, w.Mach, ssW.ErrClient))
+	if err != nil {
+		w.Mach.AddErr(err, nil)
+		return
+	}
+
+	// start
+	if w.LocalRpc.Start() != am.Executed {
+		AddErrRpc(w.Mach, nil, nil)
+		return
+	}
+	if w.PublicRpc.Start() != am.Executed {
+		AddErrRpc(w.Mach, nil, nil)
+		return
+	}
+}
+
+func (w *Worker) StartEnd(e *am.Event) {
+	args := ParseArgs(e.Args)
+
+	if w.PublicRpc != nil {
+		w.PublicRpc.Stop(true)
+	}
+	w.PublicRpc = nil
+
+	if w.LocalRpc != nil {
+		w.LocalRpc.Stop(true)
+	}
+	w.LocalRpc = nil
+
+	if w.BootRpc != nil {
+		w.BootRpc.Stop(context.TODO(), true)
+	}
+	w.BootRpc = nil
+
+	if args.Dispose {
+		w.Mach.Dispose()
+	}
+}
+
+func (w *Worker) LocalRpcReadyState(e *am.Event) {
+	// get the local addr
+	w.LocalAddr = w.LocalRpc.Addr
+}
+
+func (w *Worker) PublicRpcReadyState(e *am.Event) {
+	// get the local addr
+	w.PublicAddr = w.PublicRpc.Addr
+}
+
+func (w *Worker) RpcReadyState(e *am.Event) {
+	var err error
+	ctx := w.Mach.NewStateCtx(ssW.LocalRpcReady)
+	w.Mach.Add1(ssW.Ready, nil)
+
+	// connect to the bootstrap machine
+	opts := &rpc.ClientOpts{Parent: w.Mach}
+	w.BootRpc, err = rpc.NewClient(ctx, w.BootAddr, "nw-"+w.Name,
+		states.BootstrapStruct, states.BootstrapStates.Names(), opts)
+	if err != nil {
+		AddErrRpc(w.Mach, err, nil)
+		return
+	}
+	err = ampipe.BindErr(w.BootRpc.Mach, w.Mach, "")
+	if err != nil {
+		AddErrRpc(w.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(w.BootRpc.Mach)
+	w.BootRpc.Start()
+
+	// unblock
+	go func() {
+		// wait for the bootstrap client to be ready
+		err := amhelp.WaitForAll(ctx, w.ConnTimeout,
+			w.BootRpc.Mach.When1(ssrpc.ClientStates.Ready, nil))
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			AddErrRpc(w.Mach, err, nil)
+			return
+		}
+
+		// pass the local port to [bootstrap.WorkerAddState] via RPC
+		w.BootRpc.Worker.Add1(ssB.WorkerAddr, PassRpc(&A{
+			LocalAddr:  w.LocalAddr,
+			PublicAddr: w.PublicAddr,
+			Id:         w.Mach.Id(),
+		}))
+		// dispose
+		w.BootRpc.Stop(context.TODO(), true)
+		w.BootRpc = nil
+	}()
+}
+
+func (w *Worker) HealthcheckState(e *am.Event) {
+	w.Mach.Remove1(ssW.Healthcheck, nil)
+}
+
+func (w *Worker) ServeClientEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.Id != ""
+}
+
+func (w *Worker) ServeClientState(e *am.Event) {
+	args := ParseArgs(e.Args)
+	w.AcceptClient = args.Id
+	w.PublicRpc.AllowId = w.AcceptClient
+}
+
+func (w *Worker) SendPayloadEnter(e *am.Event) bool {
+	// use SuperSendPayload and ClientSendPayload instead
+	return false
+}
+
+// ///// ///// /////
+
+// ///// METHODS
+
+// ///// ///// /////
+
+func (w *Worker) Start(localAddr string) am.Result {
+	return w.Mach.Add1(ssW.Start, Pass(&A{LocalAddr: localAddr}))
+}
+
+func (w *Worker) Stop(dispose bool) {
+	w.Mach.Remove1(ssW.Start, Pass(&A{Dispose: dispose}))
+}
+
+// ///// ///// /////
+
+// ///// MISC
+
+// ///// ///// /////
+
+type WorkerOpts struct {
+	// Parent is a parent state machine for a new Worker state machine. See
+	// [am.Opts].
+	Parent am.Api
+}

--- a/pkg/node/states/ss_bootstrap.go
+++ b/pkg/node/states/ss_bootstrap.go
@@ -1,0 +1,35 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+// BootstrapStatesDef contains all the states of the Bootstrap state machine.
+// The target state is WorkerAddr, activated by an aRPC client.
+type BootstrapStatesDef struct {
+
+	// WorkerAddr - The awaited worker passed its connection details.
+	WorkerAddr string
+
+	// inherit from WorkerStatesDef
+	*ssrpc.WorkerStatesDef
+}
+
+// BootstrapStruct represents all relations and properties of
+// BootstrapStatesDef.
+var BootstrapStruct = StructMerge(
+	// inherit from WorkerStruct
+	ssrpc.WorkerStruct,
+	am.Struct{
+		cos.WorkerAddr: {},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	cos = am.NewStates(BootstrapStatesDef{})
+
+	// BootstrapStates contains all the states for the Bootstrap machine.
+	BootstrapStates = cos
+)

--- a/pkg/node/states/ss_node_client.go
+++ b/pkg/node/states/ss_node_client.go
@@ -1,0 +1,96 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	"github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+// ClientStatesDef contains all the states of the Client state machine.
+type ClientStatesDef struct {
+	*am.StatesBase
+
+	Exception string
+	ErrWorker     string
+	ErrSupervisor string
+
+	// worker
+
+	WorkerDisconnected  string
+	WorkerConnecting    string
+	WorkerConnected     string
+	WorkerDisconnecting string
+	WorkerReady         string
+	// Ready - Client is connected to a worker and ready to delegate work and
+	// receive payloads.
+	Ready string
+
+	// supervisor
+
+	SuperDisconnected  string
+	SuperConnecting    string
+	SuperConnected     string
+	SuperDisconnecting string
+	// SuperReady - Client is fully connected to the Supervisor.
+	SuperReady string
+	// WorkerRequested - Client has requested a Worker from the Supervisor.
+	WorkerRequested string
+
+	// inherit from BasicStatesDef
+	*states.BasicStatesDef
+	// inherit from ConsumerStatesDef
+	*ssrpc.ConsumerStatesDef
+}
+
+// ClientGroupsDef contains all the state groups of the Client state machine.
+type ClientGroupsDef struct {
+	*states.ConnectedGroupsDef
+	// TODO?
+}
+
+// ClientStruct represents all relations and properties of ClientStates.
+var ClientStruct = StructMerge(
+	// inherit from BasicStruct
+	states.BasicStruct,
+	// inherit from ConsumerStruct
+	ssrpc.ConsumerStruct,
+	am.Struct{
+
+		// errors
+
+		ssC.ErrWorker:     {Require: S{am.Exception}},
+		ssC.ErrSupervisor: {Require: S{am.Exception}},
+
+		// piped
+
+		ssC.SuperDisconnected:  {},
+		ssC.SuperConnecting:    {},
+		ssC.SuperConnected:     {},
+		ssC.SuperDisconnecting: {},
+		ssC.SuperReady:         {},
+
+		ssC.WorkerDisconnected:  {},
+		ssC.WorkerConnecting:    {},
+		ssC.WorkerConnected:     {},
+		ssC.WorkerDisconnecting: {},
+		ssC.WorkerReady:         {Remove: S{ssC.WorkerRequested}},
+
+		// client
+
+		ssC.WorkerRequested: {Require: S{ssC.SuperReady}},
+		ssC.Ready:           {Require: S{ssC.WorkerReady}},
+	})
+
+// TODO handlers iface
+
+// EXPORTS AND GROUPS
+
+var (
+	ssC = am.NewStates(ClientStatesDef{})
+	sgC = am.NewStateGroups(ClientGroupsDef{}, states.ConnectedGroups)
+
+	// ClientStates contains all the states for the Client machine.
+	ClientStates = ssC
+	// ClientGroups contains all the state groups for the Client machine.
+	ClientGroups = sgC
+)

--- a/pkg/node/states/ss_node_worker.go
+++ b/pkg/node/states/ss_node_worker.go
@@ -1,0 +1,140 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+// WorkerStatesDef contains all the states of the Worker state machine.
+type WorkerStatesDef struct {
+	*am.StatesBase
+
+	// errors
+
+	ErrWork        string
+	ErrWorkTimeout string
+	ErrClient      string
+	ErrSupervisor  string
+
+	// basics
+
+	// Ready - Worker is able to perform work.
+	Ready string
+
+	// rpc
+
+	// LocalRpcReady - Supervisor RPC server is ready for connections.
+	LocalRpcReady string
+	// PublicRpcReady - Client RPC server is ready for connections.
+	PublicRpcReady string
+	// RpcReady - both RPC servers are ready.
+	RpcReady string
+	// SuperConnected - Worker is connected to the Supervisor.
+	SuperConnected string
+	// ServeClient - Worker is requested to accept a connection from client
+	// am.A["id"].
+	ServeClient string
+	// ClientConnected - Worker is connected to a client.
+	ClientConnected   string
+	ClientSendPayload string
+	SuperSendPayload  string
+
+	// work
+
+	Idle          string
+	WorkRequested string
+	Working       string
+	WorkReady     string
+
+	// inherit from WorkerStatesDef
+	*ssrpc.WorkerStatesDef
+}
+
+// WorkerGroupsDef contains all the state groups of the Worker state machine.
+type WorkerGroupsDef struct {
+
+	// WorkStatus represents work-related states, 1 active at a time. This group
+	// has to be bound by the implementation, e.g. using Add relation from custom
+	// work states.
+	WorkStatus S
+}
+
+// WorkerStruct represents all relations and properties of WorkerStates.
+var WorkerStruct = StructMerge(
+	// inherit from BasicStruct
+	ssrpc.WorkerStruct,
+	am.Struct{
+
+		// errors
+
+		ssW.ErrWork:        {Require: S{am.Exception}},
+		ssW.ErrWorkTimeout: {Require: S{am.Exception}},
+		ssW.ErrClient:      {Require: S{am.Exception}},
+		ssW.ErrSupervisor:  {Require: S{am.Exception}},
+
+		// piped
+
+		ssW.LocalRpcReady:   {Require: S{ssW.Start}},
+		ssW.PublicRpcReady:  {Require: S{ssW.Start}},
+		ssW.SuperConnected:  {Require: S{ssW.Start}},
+		ssW.ClientConnected: {Require: S{ssW.Start}},
+
+		// basics
+
+		ssW.Ready: {Require: S{ssW.LocalRpcReady}},
+
+		// rpc
+
+		ssW.RpcReady: {
+			Auto:    true,
+			Require: S{ssW.LocalRpcReady, ssW.PublicRpcReady},
+		},
+		ssW.ServeClient: {Require: S{ssW.PublicRpcReady}},
+		ssW.ClientSendPayload: {
+			Require: S{ssW.PublicRpcReady},
+		},
+		ssW.SuperSendPayload: {
+			Require: S{ssW.LocalRpcReady},
+		},
+
+		// disable SendPayload
+		ssW.SendPayload: {Add: S{ssW.ErrSendPayload, ssW.Exception}},
+
+		// work
+
+		ssW.Idle: {
+			Auto:    true,
+			Require: S{ssW.Ready},
+			Remove:  sgW.WorkStatus,
+		},
+		ssW.WorkRequested: {
+			Require: S{ssW.Ready},
+			Remove:  sgW.WorkStatus,
+		},
+		ssW.Working: {
+			Require: S{ssW.Ready},
+			Remove:  sgW.WorkStatus,
+		},
+		ssW.WorkReady: {
+			Require: S{ssW.Ready},
+			Remove:  sgW.WorkStatus,
+		},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	// ssW is worker states from WorkerStatesDef.
+	ssW = am.NewStates(WorkerStatesDef{})
+
+	// sgW is worker groups from WorkerGroupsDef.
+	sgW = am.NewStateGroups(WorkerGroupsDef{
+		WorkStatus: S{ssW.WorkRequested, ssW.Working, ssW.WorkReady, ssW.Idle},
+	})
+
+	// WorkerStates contains all the states for the Worker machine.
+	WorkerStates = ssW
+
+	// WorkerGroups contains all the state groups for the Worker machine.
+	WorkerGroups = sgW
+)

--- a/pkg/node/states/ss_supervisor.go
+++ b/pkg/node/states/ss_supervisor.go
@@ -1,0 +1,230 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	"github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+// SupervisorStatesDef contains all the states of the Supervisor state machine.
+type SupervisorStatesDef struct {
+	*am.StatesBase
+
+	// errors
+
+	ErrWorker string
+	ErrPool   string
+
+	// network
+
+	LocalRpcReady  string
+	PublicRpcReady string
+	// Ready - Supervisor is ready to accept new clients.
+	Ready string
+	// Heartbeat checks the health of the worker pool and network connections.
+	Heartbeat string
+
+	// pool
+
+	// PoolStarting - Supervisor is starting workers to meet the pool definition.
+	PoolStarting string
+	// NormalizingPool - Supervisor is re-spawning some workers.
+	NormalizingPool string
+	// PoolNormalized - Supervisor has normalized the pool. Check PoolReady for
+	// the result.
+	PoolNormalized string
+	// PoolReady - Minimum amount of workers are ready.
+	PoolReady string
+	// TODO all warm warkers ready
+	// PoolWarm string
+	// WorkersAvailable - There are some idle workers in the pool.
+	WorkersAvailable string
+
+	// worker
+
+	// ForkWorker - Supervisor starts forking a new worker by creating a new aRPC
+	// server.
+	ForkWorker string
+	// ForkingWorker - Supervisor is forking a new worker.
+	ForkingWorker string
+	// AwaitingWorker - Supervisor is waiting for a worker to connect.
+	AwaitingWorker string
+	// WorkerForked - Supervisor has successfully forked a new worker.
+	WorkerForked  string
+	KillWorker    string
+	KillingWorker string
+	WorkerKilled  string
+	// WorkerReady - One of the workers become ready.
+	WorkerReady string
+	// WorkerGone - One of the workers has disconnected.
+	WorkerGone string
+
+	// client
+
+	// ClientConnected - At least 1 client is connected to the supervisor.
+	ClientConnected string
+	// ClientDisconnected - 1 Client has disconnected from the supervisor.
+	ClientDisconnected string
+	// ProvideWorker - Client requests a new worker.
+	ProvideWorker string
+	// WorkerIssues - Client complains about the worker.
+	WorkerIssues      string
+	ClientSendPayload string
+
+	// supervisor
+
+	SuperConnected    string
+	SuperDisconnected string
+	SuperSendPayload  string
+
+	// inherit from WorkerStatesDef
+	*ssrpc.WorkerStatesDef
+}
+
+// SupervisorGroupsDef contains all the state groups of the Supervisor state
+// machine.
+type SupervisorGroupsDef struct {
+	*states.ConnectedGroupsDef
+
+	// PoolStatus are pool's possible statuses, 1 active at a time.
+	PoolStatus S
+	// Errors list all possible errors of Supervisor.
+	Errors S
+	// PoolNormalized async
+	PoolNormalized S
+}
+
+// SupervisorStruct represents all relations and properties of SupervisorStates.
+var SupervisorStruct = StructMerge(
+	// inherit from WorkerStruct
+	ssrpc.WorkerStruct,
+	am.Struct{
+
+		// errors
+
+		ssS.ErrWorker: {
+			Require: S{ssS.Exception},
+			Add:     S{ssS.NormalizingPool, ssS.Heartbeat},
+		},
+		ssS.ErrPool: {
+			Require: S{ssS.Exception},
+			Remove:  S{ssS.PoolNormalized},
+			Add:     S{ssS.Heartbeat},
+		},
+
+		// piped
+
+		ssS.ClientConnected:    {Multi: true},
+		ssS.ClientDisconnected: {Multi: true},
+		ssS.SuperConnected:     {Multi: true},
+		ssS.SuperDisconnected:  {Multi: true},
+		ssS.LocalRpcReady:      {Require: S{ssS.Start}},
+		ssS.PublicRpcReady:     {Require: S{ssS.Start}},
+		ssS.WorkerReady: {
+			Multi:   true,
+			Require: S{ssS.Start},
+			Add:     S{ssS.PoolReady},
+		},
+		ssS.WorkerGone: {
+			Multi:   true,
+			Require: S{ssS.Start},
+			Remove:  S{ssS.PoolReady},
+		},
+
+		// basics
+
+		ssS.Start: {Add: S{ssS.PoolStarting}},
+		ssS.Ready: {Require: S{
+			ssS.LocalRpcReady, ssS.PublicRpcReady, ssS.PoolReady}},
+		ssS.Heartbeat: {Require: S{ssS.Start}},
+
+		// rpc
+
+		// disable SendPayload
+		ssW.SendPayload: {Add: S{ssW.ErrSendPayload, ssW.Exception}},
+
+		// worker pool
+
+		ssS.PoolStarting: {
+			Remove: sgS.PoolStatus,
+			Add:    S{ssS.NormalizingPool},
+		},
+		ssS.PoolReady: {
+			Require: S{ssS.Start},
+			Remove:  sgS.PoolStatus,
+			Add:     S{ssS.Heartbeat},
+		},
+		ssS.NormalizingPool: {
+			Require: S{ssS.Start},
+			Remove:  sgS.PoolNormalized,
+			// ErrWorker marks problematic workers
+			After: S{ssS.ErrWorker},
+		},
+		ssS.PoolNormalized: {
+			Require: S{ssS.Start},
+			Remove:  sgS.PoolNormalized,
+			Add:     S{ssS.Heartbeat},
+		},
+		ssS.WorkersAvailable: {Require: S{ssS.PoolReady}},
+
+		// worker
+
+		ssS.ForkWorker: {
+			Multi:   true,
+			Require: S{ssS.Start},
+		},
+		ssS.ForkingWorker: {
+			Multi:   true,
+			Require: S{ssS.Start},
+		},
+		ssS.AwaitingWorker: {
+			Multi:   true,
+			Require: S{ssS.Start},
+		},
+		ssS.WorkerForked: {
+			Multi:   true,
+			Require: S{ssS.Start},
+			Add:     S{ssS.Heartbeat},
+		},
+		ssS.KillWorker:    {Multi: true},
+		ssS.KillingWorker: {Multi: true},
+		ssS.WorkerKilled: {
+			Multi: true,
+			Add:   S{ssS.NormalizingPool, ssS.Heartbeat},
+		},
+
+		// client
+
+		ssS.ProvideWorker: {
+			Multi:   true,
+			Require: S{ssS.WorkersAvailable},
+		},
+		ssS.WorkerIssues: {
+			Multi: true,
+		},
+		ssS.ClientSendPayload: {Multi: true},
+
+		// supervisor
+
+		ssS.SuperSendPayload: {Multi: true},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	// ssS is supervisor states from SupervisorStatesDef.
+	ssS = am.NewStates(SupervisorStatesDef{})
+
+	// sgS is supervisor groups from SupervisorGroupsDef.
+	sgS = am.NewStateGroups(SupervisorGroupsDef{
+		PoolStatus:     S{ssS.PoolStarting, ssS.PoolReady},
+		Errors:         S{ssS.ErrWorker, ssS.ErrPool},
+		PoolNormalized: S{ssS.PoolNormalized, ssS.NormalizingPool},
+	})
+
+	// SupervisorStates contains all the states for the Supervisor machine.
+	SupervisorStates = ssS
+
+	// SupervisorGroups contains all the state groups for the Supervisor machine.
+	SupervisorGroups = sgS
+)

--- a/pkg/node/states/states.go
+++ b/pkg/node/states/states.go
@@ -1,0 +1,19 @@
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// SAdd is a func alias for merging lists of states.
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition.
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition.
+var StateSet = am.StateSet
+
+// StructMerge is a func alias for extending an existing state structure.
+var StructMerge = am.StructMerge

--- a/pkg/node/supervisor.go
+++ b/pkg/node/supervisor.go
@@ -1,0 +1,1004 @@
+package node
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"slices"
+	"sync"
+	"time"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
+
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+)
+
+var (
+	ssS = states.SupervisorStates
+	ssB = states.BootstrapStates
+)
+
+type Supervisor struct {
+	*am.ExceptionHandler
+	Mach *am.Machine
+
+	// WorkerKind is the kind of worker this supervisor is managing.
+	WorkerKind string
+	// WorkerBin is the path and args to the worker binary.
+	WorkerBin []string
+	// Name is the name of the supervisor.
+	Name       string
+	LogEnabled bool
+
+	// worker pool
+
+	// Max is the maximum number of workers. Default is 10.
+	Max int
+	// Min is the minimum number of workers. Default is 2.
+	Min int
+	// Warm is the number of warm (ready) workers. Default is 5.
+	Warm int
+	// MaxClientWorkers is the maximum number of workers per 1 client. Defaults to
+	// Max.
+	MaxClientWorkers int
+	// WorkerErrTtl is the time to keep worker errors in memory. Default is 10m.
+	WorkerErrTtl time.Duration
+	// WorkerErrRecent is the time to consider recent errors. Default is 1m.
+	WorkerErrRecent time.Duration
+	// WorkerErrKill is the number of errors to kill a worker. Default is 3.
+	WorkerErrKill int
+
+	// network
+
+	// ConnTimeout is the time to wait for an outbound connection to be
+	// established. Default is 5s.
+	ConnTimeout     time.Duration
+	DeliveryTimeout time.Duration
+	// PoolPause is the time to wait between normalizing the pool. Default is 5s.
+	PoolPause time.Duration
+	// HealthcheckPause is the time between trying to get a Healtcheck response
+	// from a worker.
+	HealthcheckPause time.Duration
+	Heartbeat        time.Duration
+
+	// PublicAddr is the address for the public RPC server to listen on. The
+	// effective address is at [PublicMux.Addr].
+	PublicAddr string
+	// PublicMux is the public listener to create RPC servers for each client.
+	PublicMux *rpc.Mux
+	// PublicRpc are the public RPC servers of connected clients, indexed by
+	// remote addresses.
+	PublicRpcs map[string]*rpc.Server
+
+	// LocalAddr is the address for the local RPC server to listen on. The
+	// effective address is at [LocalRpc.Addr].
+	LocalAddr string
+	// LocalRpc is the local RPC server, used by other supervisors to connect.
+	// TODO rpc/mux
+	LocalRpc *rpc.Server
+
+	// TODO healthcheck endpoint
+	// HttpAddr string
+
+	// workerPids is a map of local RPC addresses to workerInfo data.
+	workers cmap.ConcurrentMap[string, *workerInfo]
+
+	// workerSNames is a list of states for the worker.
+	workerSNames am.S
+	// workerStruct is the struct for the worker.
+	workerStruct am.Struct
+
+	// in-memory workers
+
+	testFork func(string) error
+	testKill func(string) error
+
+	normalizeStart time.Time
+
+	// self removing multi handlers
+
+	WorkerReadyState       am.HandlerFinal
+	WorkerGoneState        am.HandlerFinal
+	ClientSendPayloadState am.HandlerFinal
+	SuperSendPayloadState  am.HandlerFinal
+}
+
+func NewSupervisor(
+	ctx context.Context, workerKind string, workerBin []string,
+	workerStruct am.Struct, workerSNames am.S, opts *SupervisorOpts,
+) (*Supervisor, error) {
+	// validate
+	if len(workerBin) == 0 || workerBin[0] == "" {
+		return nil, errors.New("super: workerBin required")
+	}
+	if workerStruct == nil {
+		return nil, errors.New("super: workerStruct required")
+	}
+	if workerSNames == nil {
+		return nil, errors.New("super: workerSNames required")
+	}
+	if opts == nil {
+		opts = &SupervisorOpts{}
+	}
+
+	err := amhelp.Implements(workerSNames, states.WorkerStates.Names())
+	if err != nil {
+		err := fmt.Errorf(
+			"worker has to implement am/node/states/WorkerStates: %w", err)
+		return nil, err
+	}
+
+	name := fmt.Sprintf("%s-%s-%s-%d", workerKind, utils.Hostname(),
+		time.Now().Format("150405"), opts.InstanceNum)
+
+	s := &Supervisor{
+		WorkerKind: workerKind,
+		WorkerBin:  workerBin,
+		Name:       name,
+		LogEnabled: os.Getenv(EnvAmNodeLogSupervisor) != "",
+
+		// defaults
+
+		Max:              10,
+		Min:              2,
+		Warm:             5,
+		MaxClientWorkers: 10,
+		ConnTimeout:      5 * time.Second,
+		DeliveryTimeout:  5 * time.Second,
+		Heartbeat:        1 * time.Minute,
+		PoolPause:        5 * time.Second,
+		HealthcheckPause: 500 * time.Millisecond,
+		WorkerErrTtl:     10 * time.Minute,
+		WorkerErrRecent:  1 * time.Minute,
+		WorkerErrKill:    3,
+
+		// rpc
+
+		PublicRpcs: make(map[string]*rpc.Server),
+
+		// internals
+
+		workerSNames: workerSNames,
+		workerStruct: workerStruct,
+		workers:      cmap.New[*workerInfo](),
+	}
+
+	if amhelp.IsDebug() {
+		// increase timeouts using context.WithTimeout directly
+		s.DeliveryTimeout = 10 * s.DeliveryTimeout
+	}
+
+	mach, err := am.NewCommon(ctx, "ns-"+s.Name, states.SupervisorStruct,
+		ssS.Names(), s, opts.Parent, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mach.SetLogArgs(LogArgs)
+	s.Mach = mach
+	amhelp.MachDebugEnv(mach)
+
+	// self removing multi handlers
+	s.WorkerReadyState = amhelp.RemoveMulti(mach, ssS.WorkerReady)
+	s.WorkerGoneState = amhelp.RemoveMulti(mach, ssS.WorkerGone)
+	s.ClientSendPayloadState = amhelp.RemoveMulti(mach, ssS.ClientSendPayload)
+	s.SuperSendPayloadState = amhelp.RemoveMulti(mach, ssS.SuperSendPayload)
+
+	// check base states
+	err = amhelp.Implements(mach.StateNames(), ssS.Names())
+	if err != nil {
+		err := fmt.Errorf(
+			"client has to implement am/node/states/SupervisorStates: %w", err)
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// ///// ///// /////
+
+// ///// HANDLERS
+
+// ///// ///// /////
+
+func (s *Supervisor) ErrWorkerState(e *am.Event) {
+	// remove errors as handled
+	s.Mach.Remove(am.S{ssS.ErrWorker, ssS.Exception}, nil)
+	args := ParseArgs(e.Args)
+	w, _ := s.workers.Get(args.LocalAddr)
+	// TODO am.ParseArgs
+	err, _ := e.Args["err"].(error)
+
+	// kill?
+	if !errors.Is(err, ErrWorkerKill) && w != nil {
+		err1 := w.errs.Add(utils.RandID(0), err, 0)
+		err2 := w.errsRecent.Add(utils.RandID(0), err, 0)
+		if err := errors.Join(err1, err2); err != nil {
+			s.Mach.Log("failed to add error to worker %s: %v", args.LocalAddr, err)
+		}
+
+		// kill if too many errs
+		if w.errs.ItemCount() > s.WorkerErrKill {
+			s.Mach.Add1(ssS.KillingWorker, Pass(&A{
+				LocalAddr: args.LocalAddr,
+			}))
+		}
+	}
+
+	// dispose bootstrap
+	if args.Bootstrap != nil {
+		args.Bootstrap.Dispose()
+	}
+
+	// re-check the pool status
+	s.Mach.Remove1(ssS.PoolReady, nil)
+}
+
+// TODO ErrPool
+
+func (s *Supervisor) StartEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.PublicAddr != "" && a.LocalAddr != ""
+}
+
+func (s *Supervisor) ClientConnectedState(e *am.Event) {
+	s.Mach.Remove1(ssS.ClientConnected, nil)
+}
+
+func (s *Supervisor) ClientDisconnectedEnter(e *am.Event) bool {
+	a := rpc.ParseArgs(e.Args)
+	return a != nil && a.Addr != ""
+}
+
+func (s *Supervisor) ClientDisconnectedState(e *am.Event) {
+	s.Mach.Remove1(ssS.ClientDisconnected, nil)
+
+	addr := rpc.ParseArgs(e.Args).Addr
+	srv, ok := s.PublicRpcs[addr]
+	if !ok {
+		s.log("client %s disconnected, but not found", addr)
+	}
+	srv.Stop(true)
+	delete(s.PublicRpcs, addr)
+}
+
+func (s *Supervisor) StartState(e *am.Event) {
+	var err error
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+	args := ParseArgs(e.Args)
+	s.LocalAddr = args.LocalAddr
+	s.PublicAddr = args.PublicAddr
+
+	// public rpc (muxed)
+	s.PublicMux, err = rpc.NewMux(ctx, "ns-pub-"+s.Name, s.newClientConn,
+		&rpc.MuxOpts{Parent: s.Mach})
+	if err != nil {
+		AddErrRpc(s.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(s.PublicMux.Mach)
+
+	// local rpc
+	opts := &rpc.ServerOpts{
+		Parent:       s.Mach,
+		PayloadState: ssS.SuperSendPayload,
+	}
+	s.LocalRpc, err = rpc.NewServer(ctx, s.LocalAddr, "ns-loc-"+s.Name, s.Mach,
+		opts)
+	if err != nil {
+		AddErrRpc(s.Mach, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(s.LocalRpc.Mach)
+	s.LocalRpc.DeliveryTimeout = s.DeliveryTimeout
+	err = rpc.BindServerMulti(s.LocalRpc.Mach, s.Mach, ssS.LocalRpcReady,
+		ssS.SuperConnected, ssS.SuperDisconnected)
+	if err != nil {
+		AddErrRpc(s.Mach, err, nil)
+		return
+	}
+
+	// start
+	s.PublicMux.Start()
+	s.LocalRpc.Start()
+
+	// unblock
+	go func() {
+		// wait for the RPC servers to become ready
+		err := amhelp.WaitForAll(ctx, s.ConnTimeout,
+			s.PublicMux.Mach.When1(ssrpc.MuxStates.Ready, nil),
+			s.LocalRpc.Mach.When1(ssrpc.ServerStates.RpcReady, nil))
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			err := errors.Join(err, s.PublicMux.Mach.Err(), s.LocalRpc.Mach.Err())
+			AddErrRpc(s.Mach, err, nil)
+			return
+		}
+
+		// wait for the pool
+		select {
+		case <-ctx.Done():
+			return // expired
+		case <-s.Mach.When1(ssS.PoolReady, nil):
+		}
+
+		// start Heartbeat
+		t := time.NewTicker(s.Heartbeat)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return // expired
+			case <-t.C:
+				s.Mach.Add1(ssS.Heartbeat, nil)
+			}
+		}
+	}()
+}
+
+func (s *Supervisor) StartEnd(e *am.Event) {
+	// TODO stop all rpc servers
+	if s.PublicMux != nil {
+		s.PublicMux.Stop(true)
+	}
+	if s.LocalRpc != nil {
+		s.LocalRpc.Stop(true)
+	}
+}
+
+func (s *Supervisor) ForkWorkerEnter(e *am.Event) bool {
+	return s.workers.Count() < s.Max
+}
+
+func (s *Supervisor) ForkWorkerState(e *am.Event) {
+	s.Mach.Remove1(ssS.ForkWorker, nil)
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+
+	// init bootstrap machine
+	boot, err := newBootstrap(ctx, s.Mach, s.Name)
+	if err != nil {
+		AddErrWorker(s.Mach, err, nil)
+		return
+	}
+	argsOut := &A{Bootstrap: boot}
+
+	// start connection-bootstrap machine
+	res := boot.Mach.Add1(states.BootstrapStates.Start, nil)
+	if res != am.Executed || boot.Mach.IsErr() {
+		AddErrWorker(s.Mach, ErrWorkerConn, Pass(argsOut))
+		return
+	}
+
+	// unblock
+	go func() {
+		// wait for bootstrap RPC to become ready
+		err := amhelp.WaitForAll(ctx, s.ConnTimeout,
+			boot.server.Mach.When1(ssrpc.ServerStates.RpcReady, nil))
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			AddErrWorker(s.Mach, err, Pass(argsOut))
+			return
+		}
+
+		// next
+		s.Mach.Add1(ssS.ForkingWorker, Pass(argsOut))
+	}()
+}
+
+func (s *Supervisor) ForkingWorkerEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.Bootstrap != nil && a.Bootstrap.Addr() != "" &&
+		s.workers.Count() < s.Max
+}
+
+func (s *Supervisor) ForkingWorkerState(e *am.Event) {
+	s.Mach.Remove1(ssS.ForkingWorker, nil)
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+	args := ParseArgs(e.Args)
+	b := args.Bootstrap
+	argsOut := &A{Bootstrap: b}
+
+	// test forking, if provided
+	if s.testFork != nil {
+		// unblock
+		go func() {
+			if ctx.Err() != nil {
+				return // expired
+			}
+			if err := s.testFork(args.Bootstrap.Addr()); err != nil {
+				AddErrWorker(s.Mach, err, Pass(argsOut))
+				return
+			}
+			// fake entry
+			s.workers.Set(b.Addr(), newWorkerInfo(s, b, nil))
+
+			// next
+			s.Mach.Add1(ssS.AwaitingWorker, Pass(argsOut))
+		}()
+
+		// tests end here
+		return
+	}
+
+	// prep for forking
+	var cmdArgs []string
+	if len(s.WorkerBin) > 1 {
+		cmdArgs = s.WorkerBin[1:]
+	}
+	cmdArgs = slices.Concat(cmdArgs, []string{"-a", b.Addr()})
+	s.log("forking worker %s %s", s.WorkerBin[0], cmdArgs)
+	cmd := exec.CommandContext(ctx, s.WorkerBin[0], cmdArgs...)
+	cmd.Env = os.Environ()
+	s.workers.Set(b.Addr(), newWorkerInfo(s, b, cmd.Process))
+
+	// read errors
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		AddErrWorker(s.Mach, err, Pass(argsOut))
+		return
+	}
+	scanner := bufio.NewScanner(stderr)
+
+	// fork the worker
+	err = cmd.Start()
+	if err != nil {
+		AddErrWorker(s.Mach, err, Pass(argsOut))
+		return
+	}
+
+	// monitor the fork
+	go func() {
+		var out string
+		for scanner.Scan() {
+			out += scanner.Text() + "\n"
+		}
+
+		// skip ctx expire, [cmd] already inherited it
+		err := cmd.Wait()
+		if err != nil {
+			if out != "" {
+				s.log("fork error: %s", out)
+			}
+			AddErrWorker(s.Mach, err, Pass(argsOut))
+
+			return
+		}
+	}()
+
+	// next
+	s.Mach.Add1(ssS.AwaitingWorker, Pass(argsOut))
+}
+
+func (s *Supervisor) AwaitingWorkerEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.Bootstrap != nil && a.Bootstrap.Addr() != ""
+}
+
+func (s *Supervisor) AwaitingWorkerState(e *am.Event) {
+	s.Mach.Remove1(ssS.AwaitingWorker, nil)
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+	args := ParseArgs(e.Args)
+	b := args.Bootstrap
+	argsOut := &A{Bootstrap: b}
+
+	// unblock
+	go func() {
+		// worker ok, dispose bootstrap
+		defer b.Dispose()
+
+		// wait for the worker to connect to bootstrap
+		err := amhelp.WaitForAll(ctx, s.ConnTimeout,
+			b.Mach.When1(ssB.WorkerAddr, nil))
+		// bootstraps dispose themselves, which closes chans
+		if ctx.Err() != nil || b.Mach.Disposed.Load() {
+			return // expired
+		}
+		if err != nil {
+			AddErrWorker(s.Mach, err, Pass(argsOut))
+			return
+		}
+
+		// rpc to the worker
+		// TODO panic timing err?
+		workerAddr := b.WorkerArgs.Load().LocalAddr
+		wrpc, err := rpc.NewClient(ctx, workerAddr, s.Name, s.workerStruct,
+			s.workerSNames, &rpc.ClientOpts{Parent: s.Mach})
+		if err != nil {
+			AddErrWorker(s.Mach, err, Pass(argsOut))
+			return
+		}
+		amhelp.MachDebugEnv(wrpc.Mach)
+
+		// wait for client ready
+		wrpc.Start()
+		err = amhelp.WaitForErrAny(ctx, s.ConnTimeout, wrpc.Mach,
+			wrpc.Mach.When1(ssC.Ready, ctx))
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			AddErrWorker(s.Mach, wrpc.Mach.Err(), Pass(argsOut))
+			return
+		}
+		argsOut.Worker = wrpc
+
+		// next
+		s.Mach.Add1(ssS.WorkerForked, Pass(argsOut))
+	}()
+}
+
+func (s *Supervisor) WorkerForkedEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.Bootstrap != nil && a.Bootstrap.Addr() != "" &&
+		a.Worker != nil
+}
+
+func (s *Supervisor) WorkerForkedState(e *am.Event) {
+	s.Mach.Remove1(ssS.WorkerForked, nil)
+	args := ParseArgs(e.Args)
+	b := args.Bootstrap
+	addr := b.WorkerArgs.Load().LocalAddr
+	wrpc := args.Worker
+	argsOut := &A{
+		LocalAddr: addr,
+		Id:        wrpc.Mach.Id(),
+	}
+
+	// switch addresses and set
+	info, ok := s.workers.Get(b.Addr())
+	if !ok {
+		AddErrWorker(s.Mach, ErrWorkerMissing, Pass(argsOut))
+		return
+	}
+	info.mx.Lock()
+	defer info.mx.Unlock()
+	info.rpc = wrpc
+	info.publicAddr = b.WorkerArgs.Load().PublicAddr
+	info.localAddr = addr
+	s.workers.Set(addr, info)
+	s.workers.Remove(b.Addr())
+
+	// custom pipe worker states
+	err := errors.Join(
+		ampipe.BindReady(wrpc.Mach, s.Mach, ssS.WorkerReady, ""),
+		wrpc.Mach.BindHandlers(&struct {
+			ExceptionState am.HandlerFinal
+			ReadyEnd       am.HandlerFinal
+		}{
+			ExceptionState: func(e *am.Event) {
+				AddErrWorker(s.Mach, wrpc.Mach.Err(), Pass(argsOut))
+			},
+			ReadyEnd: func(event *am.Event) {
+				s.Mach.Add1(ssS.KillWorker, Pass(argsOut))
+			},
+		}),
+	)
+	if err != nil {
+		AddErrWorker(s.Mach, err, Pass(argsOut))
+		return
+	}
+
+	// ping and re-check the pool status
+	wrpc.Worker.Add1(ssW.Healthcheck, nil)
+	s.Mach.Add1(ssS.PoolReady, nil)
+}
+
+func (s *Supervisor) KillingWorkerEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.LocalAddr != ""
+}
+
+func (s *Supervisor) KillingWorkerState(e *am.Event) {
+	s.Mach.Remove1(ssS.KillingWorker, nil)
+	addr := ParseArgs(e.Args).LocalAddr
+	argsOut := &A{LocalAddr: addr}
+
+	// fake kill in tests
+	if s.testKill != nil {
+		if err := s.testKill(addr); err != nil {
+			s.Mach.AddErr(err, Pass(argsOut))
+			return
+		}
+
+		return
+	}
+
+	w, ok := s.workers.Get(addr)
+	if !ok {
+		s.log("worker %s not found", addr)
+	}
+	err := w.proc.Kill()
+	if err != nil {
+		s.Mach.AddErr(err, Pass(argsOut))
+	}
+
+	// TODO confirm port disconnect
+
+	s.Mach.Add1(ssS.WorkerKilled, Pass(argsOut))
+}
+
+func (s *Supervisor) WorkerKilledEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.LocalAddr != ""
+}
+
+func (s *Supervisor) WorkerKilledState(e *am.Event) {
+	s.Mach.Remove1(ssS.WorkerKilled, nil)
+
+	args := ParseArgs(e.Args)
+	s.workers.Remove(args.LocalAddr)
+
+	// re-check the pool status
+	s.Mach.Remove1(ssS.PoolReady, nil)
+}
+
+func (s *Supervisor) PoolReadyEnter(e *am.Event) bool {
+	return len(s.ReadyWorkers()) >= s.Min
+}
+
+func (s *Supervisor) PoolReadyExit(e *am.Event) bool {
+	return len(s.ReadyWorkers()) < s.Min
+}
+
+func (s *Supervisor) HeartbeatState(e *am.Event) {
+	// TODO detect stuck NormalizingPool
+	// TODO time limit heartbeat
+	ctx := s.Mach.NewStateCtx(ssS.Heartbeat)
+
+	// clear gone workers TODO check if binding is enough
+	// for _, info := range s.StartedWorkers() {
+	// 	w := info.rpc.Worker
+	//
+	// 	// was Ready, but not anymore
+	// 	if w.Not1(ssW.Ready) && w.Tick(ssW.Ready) > 2 {
+	// 		s.Mach.Add1(ssS.KillingWorker, Pass(&A{
+	// 			LocalAddr: info.localAddr,
+	// 		}))
+	// 	}
+	// }
+
+	// ping ready workers
+	ready := s.ReadyWorkers()
+
+	// unblock
+	go func() {
+		defer s.Mach.Remove1(ssS.Heartbeat, nil)
+		wg := sync.WaitGroup{}
+
+		for _, info := range ready {
+			w := info.rpc.Worker
+			wg.Add(1)
+
+			// parallel
+			go func() {
+				defer wg.Done()
+
+				// 3 tries
+				ok := false
+				tick := info.rpc.Mach.Tick(ssW.Healthcheck)
+				for i := 0; i < 3; i++ {
+
+					// blocking rpc call
+					info.rpc.Mach.Add1(ssW.Healthcheck, nil)
+					if ctx.Err() != nil {
+						return // expired
+					}
+					if tick < info.rpc.Mach.Tick(ssW.Healthcheck) {
+						ok = true
+						break
+					}
+
+					_ = amhelp.Wait(ctx, s.HealthcheckPause)
+				}
+
+				if !ok {
+					AddErrWorker(s.Mach, ErrWorkerHealth, Pass(&A{
+						LocalAddr: info.localAddr,
+						Id:        w.ID,
+					}))
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		// update states
+		s.Mach.Add1(ssS.PoolReady, nil)
+		s.Mach.Remove1(ssS.PoolReady, nil)
+		if len(s.IdleWorkers()) > 0 {
+			s.Mach.Add1(ssS.WorkersAvailable, nil)
+		} else {
+			s.Mach.Remove1(ssS.WorkersAvailable, nil)
+		}
+	}()
+}
+
+func (s *Supervisor) NormalizingPoolState(e *am.Event) {
+	ctx := s.Mach.NewStateCtx(ssS.NormalizingPool)
+	s.normalizeStart = time.Now()
+
+	// unblock
+	go func() {
+		defer s.Mach.Add1(ssS.PoolNormalized, nil)
+		ready := false
+
+		// 5 rounds
+		for i := 0; i < 5; i++ {
+
+			// include warm workers, [i] is 0-based
+			existing := s.workers.Count()
+			for ii := existing; ii < s.Min+s.Warm && ii < s.Max; ii++ {
+				s.Mach.Add1(ssS.ForkWorker, nil)
+			}
+
+			// wait and keep checking
+			check := func() bool {
+				// TODO dont flood the log
+				ready = len(s.ReadyWorkers()) >= s.Min
+				if ready {
+					s.Mach.Add1(ssS.PoolReady, nil)
+				}
+
+				return !ready
+			}
+			// blocking call
+			_ = amhelp.Interval(ctx, s.ConnTimeout, 50*time.Millisecond, check)
+			if ready {
+				break
+			}
+
+			// not ok, wait a bit
+			if !amhelp.Wait(ctx, s.PoolPause) {
+				return // expired
+			}
+
+			ready = s.Mach.Is1(ssS.PoolReady)
+			if ready {
+				break
+			}
+
+			s.log("failed to normalize pool, round %d", i)
+		}
+
+		if !ready {
+			AddErrPoolStr(s.Mach, "failed to normalize pool", nil)
+		}
+
+		s.normalizeStart = time.Time{}
+	}()
+}
+
+func (s *Supervisor) ProvideWorkerEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.Id != ""
+}
+
+func (s *Supervisor) ProvideWorkerState(e *am.Event) {
+	s.Mach.Remove1(ssS.ProvideWorker, nil)
+	args := ParseArgs(e.Args)
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+
+	// unblock
+	go func() {
+		// find and Idle worker
+		for _, info := range s.IdleWorkers() {
+
+			// confirm with the worker
+			res := amhelp.Add1Block(ctx, info.rpc.Worker, ssW.ServeClient, PassRpc(&A{
+				Id: args.Id,
+			}))
+			if ctx.Err() != nil {
+				return // expired
+			}
+			if res != am.Executed {
+				s.log("worker %s rejected %s", info.rpc.Worker.ID, args.Id)
+				continue
+			}
+
+			// send the addr to the client via RPC SendPayload
+			s.Mach.Add1(ssS.ClientSendPayload, rpc.Pass(&rpc.A{
+				Name: "worker_addr",
+				Payload: &rpc.ArgsPayload{
+					Name:   ssS.ProvideWorker,
+					Source: s.Mach.Id(),
+					Data:   info.publicAddr,
+				},
+			}))
+
+			s.log("worker %s provided to %s", info.rpc.Worker.ID, args.Id)
+			break
+		}
+	}()
+}
+
+// ///// ///// /////
+
+// ///// METHODS
+
+// ///// ///// /////
+
+func (s *Supervisor) Start(publicAddr string) {
+	s.Mach.Add1(ssS.Start, Pass(&A{
+		LocalAddr:  "localhost:0",
+		PublicAddr: publicAddr,
+	}))
+}
+
+func (s *Supervisor) Stop() {
+	s.Mach.Remove1(ssS.Start, nil)
+	s.Mach.Dispose()
+}
+
+// SetPool sets the pool parameters with defaults.
+func (s *Supervisor) SetPool(min, max, warm, maxPerClient int) {
+	if max < min {
+		min = max
+	}
+	s.Min = min
+	s.Max = max
+	s.Warm = warm
+	if maxPerClient == 0 {
+		maxPerClient = s.Max
+	}
+	s.MaxClientWorkers = maxPerClient
+
+	s.CheckPool()
+}
+
+// CheckPool tries to set pool as ready and normalizes it, if not.
+func (s *Supervisor) CheckPool() bool {
+	s.Mach.Add1(ssS.NormalizingPool, nil)
+	s.Mach.Add1(ssS.PoolReady, nil)
+
+	return s.Mach.Is1(ssS.PoolReady)
+}
+
+// AllWorkers returns workers (in any state).
+func (s *Supervisor) AllWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for item := range s.workers.IterBuffered() {
+		ret = append(ret, item.Val)
+	}
+
+	return ret
+}
+
+// InitingWorkers returns workers being currently initialized.
+func (s *Supervisor) InitingWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for _, info := range s.AllWorkers() {
+		info.mx.RLock()
+		if info.rpc == nil {
+			ret = append(ret, info)
+		}
+		info.mx.RUnlock()
+	}
+
+	return ret
+}
+
+// IdleWorkers returns Idle workers.
+func (s *Supervisor) IdleWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for _, info := range s.RpcWorkers() {
+		info.mx.RLock()
+		w := info.rpc.Worker
+		if !info.hasErrs() && w.Is1(ssW.Idle) {
+			ret = append(ret, info)
+		}
+		info.mx.RUnlock()
+	}
+
+	return ret
+}
+
+// RpcWorkers returns workers with an RPC connection.
+func (s *Supervisor) RpcWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for _, info := range s.AllWorkers() {
+		info.mx.RLock()
+		if info.rpc != nil && info.rpc.Worker != nil {
+			ret = append(ret, info)
+		}
+		info.mx.RUnlock()
+	}
+
+	return ret
+}
+
+// BusyWorkers returns Busy workers.
+func (s *Supervisor) BusyWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for _, info := range s.RpcWorkers() {
+		info.mx.RLock()
+		w := info.rpc.Worker
+		if !info.hasErrs() && info.rpc != nil &&
+			w.Any1(sgW.WorkStatus...) && !w.Is1(ssW.Idle) {
+			ret = append(ret, info)
+		}
+		info.mx.RUnlock()
+	}
+
+	return ret
+}
+
+// ReadyWorkers returns Ready workers.
+func (s *Supervisor) ReadyWorkers() []*workerInfo {
+	var ret []*workerInfo
+	for _, info := range s.RpcWorkers() {
+		info.mx.RLock()
+		w := info.rpc.Worker
+		if !info.hasErrs() && info.rpc != nil && w.Is1(ssW.Ready) {
+			ret = append(ret, info)
+		}
+		info.mx.RUnlock()
+	}
+
+	return ret
+}
+
+func (s *Supervisor) Dispose() {
+	s.Mach.Dispose()
+}
+
+func (s *Supervisor) log(msg string, args ...any) {
+	if !s.LogEnabled {
+		return
+	}
+	s.Mach.Log(msg, args...)
+}
+
+// newClientConn creates a new RPC server for a client.
+// TODO keep one forked and bind immediately
+func (s *Supervisor) newClientConn(
+	num int, conn net.Conn,
+) (*rpc.Server, error) {
+	s.log("new client connection %d", num)
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+	name := fmt.Sprintf("ns-pub-%d-%s", num, s.Name)
+
+	opts := &rpc.ServerOpts{
+		Parent:       s.Mach,
+		PayloadState: ssS.ClientSendPayload,
+	}
+	rpcS, err := rpc.NewServer(ctx, s.PublicAddr, name, s.Mach, opts)
+	if err != nil {
+		return nil, err
+	}
+	amhelp.MachDebugEnv(rpcS.Mach)
+
+	// set up
+	rpcS.DeliveryTimeout = s.DeliveryTimeout
+	err = rpc.BindServerMulti(rpcS.Mach, s.Mach, ssS.PublicRpcReady,
+		ssS.ClientConnected, ssS.ClientDisconnected)
+	if err != nil {
+		return nil, err
+	}
+
+	// store
+	ok := s.Mach.Eval("newClientConn", func() {
+		// TODO check ctx
+		s.PublicRpcs[conn.RemoteAddr().String()] = rpcS
+	}, ctx)
+	if !ok {
+		return nil, am.ErrHandlerTimeout
+	}
+
+	s.log("new client connection %d ready", num)
+	return rpcS, nil
+}

--- a/pkg/node/supervisor_misc.go
+++ b/pkg/node/supervisor_misc.go
@@ -1,0 +1,154 @@
+package node
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+)
+
+type SupervisorOpts struct {
+	// InstanceNum is the number of this instance in a failsafe config, used for
+	// the ID.
+	InstanceNum int
+	// Parent is a parent state machine for a new Supervisor state machine. See
+	// [am.Opts].
+	Parent am.Api
+}
+
+// bootstrap is a bootstrap machine for a worker to connect to the supervisor,
+// after forking.
+//
+// Flow: Start to WorkerLocalAddr.
+type bootstrap struct {
+	*am.ExceptionHandler
+	Mach *am.Machine
+
+	// Name is the name of this bootstrap.
+	Name       string
+	LogEnabled bool
+	// WorkerArgs contains connection info sent by the Worker.
+	WorkerArgs atomic.Pointer[A]
+
+	server *rpc.Server
+}
+
+func newBootstrap(
+	ctx context.Context, superMach *am.Machine, supName string,
+) (*bootstrap, error) {
+	c := &bootstrap{
+		Name:       supName + utils.RandID(6),
+		LogEnabled: os.Getenv(EnvAmNodeLogSupervisor) != "",
+	}
+	mach, err := am.NewCommon(ctx, "nb-"+c.Name, states.BootstrapStruct,
+		ssB.Names(), c, superMach, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// prefix the random ID
+	c.Mach = mach
+	amhelp.MachDebugEnv(mach)
+
+	return c, nil
+}
+
+func (b *bootstrap) StartState(e *am.Event) {
+	var err error
+	ctx := b.Mach.NewStateCtx(ssB.Start)
+
+	// init rpc
+	b.server, err = rpc.NewServer(ctx, "localhost:0", "nb-"+b.Name, b.Mach,
+		&rpc.ServerOpts{Parent: b.Mach})
+	if err != nil {
+		b.Mach.AddErrState(ssB.ErrNetwork, err, nil)
+		return
+	}
+	amhelp.MachDebugEnv(b.server.Mach)
+	err = ampipe.BindErr(b.server.Mach, b.Mach, ssB.ErrNetwork)
+	if err != nil {
+		b.Mach.AddErr(err, nil)
+		return
+	}
+
+	// start
+	b.server.Start()
+}
+
+func (b *bootstrap) StartEnd(e *am.Event) {
+	if b.server != nil {
+		b.server.Stop(true)
+	}
+	b.Mach.Dispose()
+}
+
+func (b *bootstrap) WorkerAddrEnter(e *am.Event) bool {
+	a := ParseArgs(e.Args)
+	return a != nil && a.LocalAddr != "" && a.PublicAddr != "" && a.Id != ""
+}
+
+func (b *bootstrap) WorkerAddrState(e *am.Event) {
+	args := ParseArgs(e.Args)
+	b.log("worker addr %s: %s / %s", args.Id, args.PublicAddr, args.LocalAddr)
+	cp := *args
+	b.WorkerArgs.Store(&cp)
+}
+
+func (b *bootstrap) Dispose() {
+	// TODO send bye to rpc-c
+	b.log("disposing bootstrap")
+	b.Mach.Remove1(ssB.Start, nil)
+}
+
+// Addr returns the address of the bootstrap server.
+func (b *bootstrap) Addr() string {
+	if b.server == nil {
+		return ""
+	}
+
+	return b.server.Addr
+}
+
+func (b *bootstrap) log(msg string, args ...any) {
+	if !b.LogEnabled {
+		return
+	}
+	b.Mach.Log(msg, args...)
+}
+
+// workerInfo is supervisor's data for a worker.
+type workerInfo struct {
+	b          *bootstrap
+	proc       *os.Process
+	rpc        *rpc.Client
+	publicAddr string
+	localAddr  string
+	errs       *cache.Cache
+	errsRecent *cache.Cache
+	mx         sync.RWMutex
+}
+
+func newWorkerInfo(
+	s *Supervisor, boot *bootstrap, proc *os.Process,
+) *workerInfo {
+	return &workerInfo{
+		errs:       cache.New(s.WorkerErrTtl, time.Minute),
+		errsRecent: cache.New(s.WorkerErrRecent, time.Minute),
+		b:          boot,
+		proc:       proc,
+	}
+}
+
+func (w *workerInfo) hasErrs() bool {
+	return w.errsRecent.ItemCount() > 0
+}

--- a/pkg/node/test/worker/node_test_worker.go
+++ b/pkg/node/test/worker/node_test_worker.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	testutils "github.com/pancsta/asyncmachine-go/internal/testing/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/node"
+	"github.com/pancsta/asyncmachine-go/pkg/node/states"
+	"github.com/pancsta/asyncmachine-go/pkg/rpc"
+)
+var ssW = states.WorkerStates
+
+func main() {
+	ctx := context.Background()
+	fA := flag.String("a", "", "addr")
+	flag.Parse()
+	if fA == nil || *fA == "" {
+		panic("addr is required")
+	}
+	addr := *fA
+
+	slog.Info("fork worker", "addr", addr)
+
+	// worker
+
+	// machine init
+	mach := am.New(context.Background(), testutils.RelsNodeWorkerStruct, &am.Opts{
+		ID: "t-worker-" + addr})
+	err := mach.VerifyStates(testutils.RelsNodeWorkerStates)
+	if err != nil {
+		panic(err)
+	}
+
+	if os.Getenv(am.EnvAmDebug) != "" {
+		mach.SetLogLevel(am.LogEverything)
+		mach.HandlerTimeout = 2 * time.Minute
+	}
+	worker, err := node.NewWorker(ctx, "NTW", mach.GetStruct(),
+		mach.StateNames(), nil)
+	if err != nil {
+		panic(err)
+	}
+	err = worker.Mach.BindHandlers(&workerHandlers{Mach: mach})
+	if err != nil {
+		panic(err)
+	}
+
+	// connect Worker to the bootstrap machine
+	res := worker.Start(addr)
+	if res != am.Executed {
+		panic(worker.Mach.Err())
+	}
+	err = amhelp.WaitForAll(ctx, 1*time.Second,
+		worker.Mach.When1(ssW.RpcReady, nil))
+	if err != nil {
+		panic(err)
+	}
+
+	// wait for connection
+	_ = amhelp.WaitForAll(ctx, 3*time.Second,
+		worker.Mach.When1(ssW.SuperConnected, nil))
+	// block until disconnected
+	<-worker.Mach.WhenNot1(ssW.SuperConnected, nil)
+}
+
+
+type workerHandlers struct {
+	Mach *am.Machine
+}
+
+func (w *workerHandlers) WorkRequestedState(e *am.Event) {
+	input := e.Args["input"].(int)
+
+	payload := &rpc.ArgsPayload{
+		Name:   w.Mach.Id(),
+		Data:   input * input,
+		Source: e.Machine.Id(),
+	}
+
+	e.Machine.Add1(ssW.ClientSendPayload, rpc.Pass(&rpc.A{
+		Name:    w.Mach.Id(),
+		Payload: payload,
+	}))
+}


### PR DESCRIPTION
This is the highlight of the v0.8.0 release - distributed worker pools with supervisors. Still in an early stage, but behaves very well.

```mermaid
flowchart LR
    c1-RemoteWorker -- aRPC --> w1-rpcPub
    c1-RemoteSupervisor -- aRPC --> s1-rpcPub

    subgraph Client 1
        c1-Client[Client]
        c1-RemoteWorker[RemoteWorker]
        c1-RemoteSupervisor[RemoteSupervisor]
        c1-Client --> c1-RemoteWorker
        c1-Client --> c1-RemoteSupervisor
    end

    subgraph Client 2
        c2-Client[Client]
        c2-RemoteWorker[RemoteWorker]
        c2-RemoteSupervisor[RemoteSupervisor]
        c2-Client --> c2-RemoteWorker
        c2-Client --> c2-RemoteSupervisor
    end

    subgraph Node Host

        subgraph Worker Pool
            w1-rpcPub --> Worker1
            w1-rpcPub([Public aRPC])
            w1-rpcPriv --> Worker1
            w1-rpcPriv([Private aRPC])
            w2-rpcPub --> Worker2
            w2-rpcPub([Public aRPC])
            w2-rpcPriv --> Worker2
            w2-rpcPriv([Private aRPC])
            w3-rpcPub --> Worker3
            w3-rpcPub([Public aRPC])
            w3-rpcPriv --> Worker3
            w3-rpcPriv([Private aRPC])
        end

        s1-rpcPub([Public aRPC])
        s1-rpcPub --> Supervisor1
        Supervisor1 --> RemoteWorker1
        Supervisor1[Supervisor]
        RemoteWorker1 -- aRPC --> w1-rpcPriv
        Supervisor1 -- fork --> Worker1
        Supervisor1 --> RemoteWorker2
        RemoteWorker2 -- aRPC --> w2-rpcPriv
        Supervisor1 -- fork --> Worker2
        Supervisor1 --> RemoteWorker3
        RemoteWorker3 -- aRPC --> w3-rpcPriv
        Supervisor1 -- fork --> Worker3
    end

    c2-RemoteWorker -- aRPC --> w2-rpcPub
    c2-RemoteSupervisor -- aRPC --> s1-rpcPub
```

More info in [`/pkg/node`](/pkg/node/README.md).