### PR TITLE
feat(examples): add tree state source

### DIFF
--- a/examples/tree_state_source/Procfile
+++ b/examples/tree_state_source/Procfile
@@ -1,0 +1,9 @@
+root: task root
+
+rep-1: task rep-1
+rep-2: task rep-2
+
+rep-1-1: task rep-1-1
+rep-1-2: task rep-1-2
+rep-2-1: task rep-2-1
+rep-2-2: task rep-2-2

--- a/examples/tree_state_source/Taskfile.yml
+++ b/examples/tree_state_source/Taskfile.yml
@@ -1,0 +1,115 @@
+version: '3'
+
+dotenv: [ '.env' ]
+
+tasks:
+  root:
+    env:
+      TST_ADDR: :19700
+      TST_HTTP_ADDR: :18700
+    cmd: go run ./
+
+  # :19700
+  rep-1:
+    env:
+      TST_PARENT_ADDR: :19700
+      TST_NAME: rep-1
+      TST_ADDR: :19701
+      TST_HTTP_ADDR: :18701
+    cmd: go run ./
+
+  rep-2:
+    env:
+      TST_PARENT_ADDR: :19700
+      TST_NAME: rep-2
+      TST_ADDR: :19702
+      TST_HTTP_ADDR: :18702
+    cmd: go run ./
+
+  # :19701
+  rep-1-1:
+    env:
+      TST_PARENT_ADDR: :19701
+      TST_NAME: rep-1-1
+      TST_ADDR: :19703
+      TST_HTTP_ADDR: :18703
+    cmd: go run ./
+
+  rep-1-2:
+    env:
+      TST_PARENT_ADDR: :19701
+      TST_NAME: rep-1-2
+      TST_ADDR: :19704
+      TST_HTTP_ADDR: :18704
+    cmd: go run ./
+
+  # :19702
+  rep-2-1:
+    env:
+      TST_PARENT_ADDR: :19702
+      TST_NAME: rep-2-1
+      TST_ADDR: :19705
+      TST_HTTP_ADDR: :18705
+    cmd: go run ./
+
+  rep-2-2:
+    env:
+      TST_PARENT_ADDR: :19702
+      TST_NAME: rep-2-2
+      TST_ADDR: :19706
+      TST_HTTP_ADDR: :18706
+    cmd: go run ./
+
+  start:
+    desc: Start the example
+    cmd: goreman start
+
+  web-metrics:
+    dir: ../..
+    cmd: task web-metrics
+
+  gen-grafanas:
+    cmds:
+      - task: gen-grafana-root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_1
+          PARENT: root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_2
+          PARENT: root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_1_1
+          PARENT: rep_1_root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_1_2
+          PARENT: rep_1_root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_2_1
+          PARENT: rep_2_root
+      - task: gen-grafana-rep
+        vars:
+          NAME: rep_2_2
+          PARENT: rep_2_root
+
+  gen-grafana-root:
+    internal: true
+    cmd: go run ../../tools/cmd/am-gen grafana
+      --name root
+      --folder tree_state_source
+      --ids root,rm-root,rs-root-0,rs-root-1,rs-root-2
+      --grafana-url {{.GRAFANA_URL}}
+      --source tree_state_source_root
+
+  gen-grafana-rep:
+    internal: true
+    cmd: go run ../../tools/cmd/am-gen grafana
+      --name {{.NAME}}
+      --folder tree_state_source
+      --ids {{.NAME}}_{{.PARENT}},rc_{{.NAME}},rm_{{.NAME}},rs_{{.NAME}}_0,rs_{{.NAME}}_1,rs_{{.NAME}}_2
+      --grafana-url {{.GRAFANA_URL}}
+      --source tree_state_source_{{.NAME}}

--- a/examples/tree_state_source/cmd_state_node.go
+++ b/examples/tree_state_source/cmd_state_node.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ic2hrmk/promtail"
+	"github.com/joho/godotenv"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/sethvargo/go-envconfig"
+
+	"github.com/pancsta/asyncmachine-go/examples/tree_state_source/states"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	amtele "github.com/pancsta/asyncmachine-go/pkg/telemetry"
+	amprom "github.com/pancsta/asyncmachine-go/pkg/telemetry/prometheus"
+)
+
+var ss = states.FlightsStates
+
+const (
+	serviceName = "tree_state_source"
+	// promPushFreq is the frequency of pushing metrics to Prometheus.
+	promPushFreq = 15 * time.Second
+	mutationFreq = 500 * time.Millisecond
+)
+
+type Node struct {
+	// config
+	Name       string `env:"TST_NAME"`
+	ParentAddr string `env:"TST_PARENT_ADDR"`
+	Addr       string `env:"TST_ADDR"`
+	HttpAddr   string `env:"TST_HTTP_ADDR"`
+
+	// telemetry
+	LokiAddr       string `env:"LOKI_ADDR"`
+	PushGatewayUrl string `env:"PUSH_GATEWAY_URL"`
+
+	Service string
+	Loki    promtail.Client
+	Metrics []*amprom.Metrics
+	Prom    *push.Pusher
+}
+
+func init() {
+	// load .env
+	_ = godotenv.Load()
+
+	// am-dbg is required for debugging, go run it
+	// go run github.com/pancsta/asyncmachine-go/tools/cmd/am-dbg@latest
+	// amhelp.EnableDebugging(false)
+	// amhelp.SetLogLevel(am.LogChanges)
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	node := ReadEnv(ctx)
+
+	if node.Addr == "" {
+		panic("TST_ADDR required")
+	}
+
+	// handle exit
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+
+	initTelemetry(node)
+
+	// STATE SOURCE
+
+	var mach am.Api
+	// RPC source
+	if node.ParentAddr == "" {
+		var err error
+		mach, err = localWorker(ctx, node)
+		if err != nil {
+			panic(err)
+		}
+
+	} else {
+		// RPC repeater
+		client, err := replicant(ctx, node)
+		if err != nil {
+			panic(err)
+		}
+		mach = client.Worker
+	}
+
+	// EXPORT
+
+	exportState(ctx, node, mach)
+	go httpServer(ctx, node, mach)
+
+	// RAND TRAFFIC
+
+	blockEcho(ctx, node, mach)
+
+	// EXIT
+
+	if node.Prom != nil {
+
+		time.Sleep(500 * time.Millisecond)
+		err := node.Prom.Push()
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if node.Loki != nil {
+		node.Loki.Close()
+	}
+
+	println("bye")
+}
+
+func ReadEnv(ctx context.Context) *Node {
+	config := &Node{}
+	err := envconfig.Process(ctx, config)
+	if err != nil {
+		panic("Failed to load config: " + err.Error())
+	}
+
+	if config.ParentAddr == "" {
+		config.Name = "root"
+	}
+
+	config.Service = serviceName
+	if config.Name != "" {
+		config.Service += "_" + config.Name
+	}
+
+	return config
+}
+
+func localWorker(ctx context.Context, node *Node) (*am.Machine, error) {
+	// worker state machine
+	worker, err := am.NewCommon(ctx, node.Name, states.FlightsStruct,
+		ss.Names(), nil, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	exportTelemetry(node, worker)
+	worker.Add1(ss.Ready, nil)
+
+	return worker, err
+}
+
+func replicant(ctx context.Context, node *Node) (*arpc.Client, error) {
+	// RPC client
+	client, err := arpc.NewClient(ctx, node.ParentAddr, node.Name, states.FlightsStruct, states.FlightsStates.Names(), nil)
+	if err != nil {
+		panic(err)
+	}
+	exportTelemetry(node, client.Mach)
+	fmt.Println("Connecting to " + node.ParentAddr)
+	client.Start()
+	err = amhelp.WaitForAll(ctx, 5*time.Second,
+		client.Mach.When1(ssrpc.ClientStates.Ready, ctx))
+	if err != nil {
+		panic(err)
+	}
+	exportTelemetry(node, client.Worker)
+
+	return client, err
+}
+
+func exportTelemetry(node *Node, mach am.Api) {
+	amhelp.MachDebugEnv(mach)
+
+	if node.Loki != nil {
+		amtele.BindLokiLogger(mach, node.Loki)
+	}
+
+	// prom metrics
+	if node.Prom != nil {
+		metrics := amprom.BindMach(mach)
+		amprom.BindToPusher(metrics, node.Prom)
+		node.Metrics = append(node.Metrics, metrics)
+	}
+}
+
+func initTelemetry(node *Node) {
+	var err error
+
+	// loki logging
+	if node.LokiAddr != "" {
+		identifiers := map[string]string{
+			"service_name": amtele.NormalizeId(node.Service),
+		}
+		node.Loki, err = promtail.NewJSONv1Client(node.LokiAddr, identifiers)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// prometheus metrics
+	if node.PushGatewayUrl != "" {
+		node.Prom = push.New(node.PushGatewayUrl, amtele.NormalizeId(node.Service))
+	} else {
+		// envconfig magic...
+		node.Prom = nil
+	}
+}
+
+func exportState(ctx context.Context, node *Node, mach am.Api) {
+	// RPC repeater via mux
+	mux, err := arpc.NewMux(ctx, node.Name, nil, &arpc.MuxOpts{Parent: mach})
+	if err != nil {
+		panic(err)
+	}
+	mux.NewServerFn = func(num int, conn net.Conn) (*arpc.Server, error) {
+		srvName := fmt.Sprintf("%s-%d", node.Name, num)
+		s, err := arpc.NewServer(ctx, node.Addr, srvName, mach, &arpc.ServerOpts{Parent: mux.Mach})
+		if err != nil {
+			return nil, err
+		}
+		exportTelemetry(node, s.Mach)
+
+		return s, nil
+	}
+	mux.Addr = node.Addr
+	exportTelemetry(node, mux.Mach)
+	fmt.Println("Starting on " + node.Addr)
+	mux.Start()
+}
+
+// blockEcho blocks and:
+// - creates a random mutation (for the root state machine only)
+// - prints the current machine time
+// - pushes to prometheus
+func blockEcho(ctx context.Context, node *Node, mach am.Api) {
+	var lastPush time.Time
+	t := time.NewTicker(mutationFreq)
+	c := 0
+
+	for ctx.Err() == nil {
+		c++
+
+		select {
+		case <-ctx.Done():
+
+		case <-t.C:
+			// mutate only the root source machine
+			if mach.Id() == "root" {
+				randMut(mach)
+			}
+
+			// push prom for all machines
+			if time.Since(lastPush) < promPushFreq {
+				continue
+			}
+			fmt.Printf("Time: %d\n", mach.TimeSum(nil))
+			lastPush = time.Now()
+			if node.Prom == nil {
+				continue
+			}
+			for _, m := range node.Metrics {
+				m.Sync()
+			}
+			err := node.Prom.Push()
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+// randMut causes a random Add mutation of 2 states.
+func randMut(mach am.Api) {
+	amount := len(ss.Names())
+
+	pick := rand.Intn(amount)
+	state1 := ss.Names()[pick]
+	pick = rand.Intn(amount)
+	state2 := ss.Names()[pick]
+	pick = rand.Intn(amount)
+	state3 := ss.Names()[pick]
+
+	skip := am.S{am.Exception, ssrpc.WorkerStates.SendPayload}
+	for _, s := range skip {
+		if state1 == s || state2 == s || state3 == s {
+			return
+		}
+	}
+
+	mach.Add(am.S{state1, state2, state3}, nil)
+	if mach.IsErr() {
+		fmt.Printf("Error: %s", mach.Err())
+		mach.Remove1(am.Exception, nil)
+	}
+}
+
+func httpServer(ctx context.Context, node *Node, worker am.Api) {
+	if node.HttpAddr == "" {
+		return
+	}
+
+	server := &http.Server{
+		Addr:    node.HttpAddr,
+		Handler: http.DefaultServeMux,
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, worker.ActiveStates())
+	})
+
+	go func() {
+		fmt.Println("Starting http on " + node.HttpAddr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	<-ctx.Done()
+	_ = server.Shutdown(context.Background())
+}

--- a/examples/tree_state_source/gen-grafana.sh
+++ b/examples/tree_state_source/gen-grafana.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# root
+go ../../tools/cmd/am-gen grafana
+  --name root
+  --folder tree_state_source
+  --ids root,_rm-root,_rs-root-0,_rs-root-1,_rs-root-2
+  --grafana-url http://localhost:3000
+  --source tree_state_source_root
+
+# replicant 1
+go ../../tools/cmd/am-gen grafana
+  --name rep-1
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_1
+
+# replicant 2
+go ../../tools/cmd/am-gen grafana
+  --name rep-2
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_2
+
+# replicant 1 of replicant 1
+go ../../tools/cmd/am-gen grafana
+  --name rep-1-1
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_1_1
+
+# replicant 2 of replicant 1
+go ../../tools/cmd/am-gen grafana
+  --name rep-1-2
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_1_2
+
+# replicant 1 of replicant 2
+go ../../tools/cmd/am-gen grafana
+  --name rep-2-1
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_2_1
+
+# replicant 2 of replicant 2
+go ../../tools/cmd/am-gen grafana
+  --name rep-2-2
+  --folder tree_state_source
+  --grafana-url http://localhost:3000
+  --source tree_state_source_rep_2_2

--- a/examples/tree_state_source/gen_states/gen_states.go
+++ b/examples/tree_state_source/gen_states/gen_states.go
@@ -1,0 +1,101 @@
+/*
+# Schema
+
+Flight1GoToGate
+
+Status:
+	Flight1OnTime
+	Flight1Delayed
+	Flight1Departed
+	Flight1Arrived
+	Flight1Scheduled
+
+Direction:
+	Flight1Inbound
+	Flight1Outbound
+
+Gates:
+	Flight1GateUnknown
+	Flight1Gate1
+	Flight1Gate2
+	Flight1Gate3
+*/
+
+
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pancsta/asyncmachine-go/tools/generator"
+	"github.com/pancsta/asyncmachine-go/tools/generator/cli"
+)
+
+const (
+	flights = 10
+	gates   = 5
+)
+
+func main() {
+	ctx := context.Background()
+
+	// TODO am.Struct to cli.SFParams converter
+	params := cli.SFParams{
+		Name:    "Flights",
+		Inherit: "rpc/worker",
+	}
+
+	for i := 1; i <= flights; i++ {
+		numF := strconv.Itoa(i)
+		flight := "Flight" + numF
+		params.States += ","
+		params.Groups += ","
+
+		// Status
+		params.States += flight + "OnTime:remove(_" + flight + "Status)," +
+			flight + "Delayed:remove(_" + flight + "Status)," +
+			flight + "Departed:remove(_" + flight + "Status;" + flight + "GoToGate)," +
+			flight + "Arrived:remove(_" + flight + "Status)," +
+			flight + "Scheduled:auto:remove(_" + flight + "Status)," +
+			// Direction
+			flight + "Inbound:remove(_" + flight + "Direction)," +
+			flight + "Outbound:remove(_" + flight + "Direction)," +
+			// Gates
+			flight + "GoToGate:require(" + flight + "Outbound)," +
+			flight + "GateUnknown:auto,"
+
+		// Direction
+		params.Groups += flight + "Direction(" +
+			flight + "Inbound;" + flight + "Outbound),"
+
+		// Status
+		params.Groups += flight + "Status(" +
+			flight + "OnTime;" + flight + "Delayed;" + flight + "Departed;" + flight + "Arrived;" + flight + "Scheduled),"
+
+		// Gates
+		params.Groups += flight + "Gates("
+		for ii := 1; ii <= gates; ii++ {
+			numG := strconv.Itoa(ii)
+			gate := flight + "Gate" + numG
+
+			params.States += gate + ":remove(_"+flight+"Gates),"
+			params.Groups += gate + ";"
+		}
+		params.Groups = strings.TrimRight(params.Groups, ";") + "),"
+	}
+
+	gen, err := generator.NewSFGenerator(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+
+	// save to ../states/ss_random_data.go
+	out := gen.Output()
+	err = os.WriteFile("../states/ss_flights.go", []byte(out), 0644)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/examples/tree_state_source/states/ss_flights.go
+++ b/examples/tree_state_source/states/ss_flights.go
@@ -1,0 +1,670 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+// FlightsStatesDef contains all the states of the Flights state machine.
+type FlightsStatesDef struct {
+	*am.StatesBase
+
+	Flight1OnTime string
+	Flight1Delayed string
+	Flight1Departed string
+	Flight1Arrived string
+	Flight1Scheduled string
+	Flight1Inbound string
+	Flight1Outbound string
+	Flight1GoToGate string
+	Flight1GateUnknown string
+	Flight1Gate1 string
+	Flight1Gate2 string
+	Flight1Gate3 string
+	Flight1Gate4 string
+	Flight1Gate5 string
+	Flight2OnTime string
+	Flight2Delayed string
+	Flight2Departed string
+	Flight2Arrived string
+	Flight2Scheduled string
+	Flight2Inbound string
+	Flight2Outbound string
+	Flight2GoToGate string
+	Flight2GateUnknown string
+	Flight2Gate1 string
+	Flight2Gate2 string
+	Flight2Gate3 string
+	Flight2Gate4 string
+	Flight2Gate5 string
+	Flight3OnTime string
+	Flight3Delayed string
+	Flight3Departed string
+	Flight3Arrived string
+	Flight3Scheduled string
+	Flight3Inbound string
+	Flight3Outbound string
+	Flight3GoToGate string
+	Flight3GateUnknown string
+	Flight3Gate1 string
+	Flight3Gate2 string
+	Flight3Gate3 string
+	Flight3Gate4 string
+	Flight3Gate5 string
+	Flight4OnTime string
+	Flight4Delayed string
+	Flight4Departed string
+	Flight4Arrived string
+	Flight4Scheduled string
+	Flight4Inbound string
+	Flight4Outbound string
+	Flight4GoToGate string
+	Flight4GateUnknown string
+	Flight4Gate1 string
+	Flight4Gate2 string
+	Flight4Gate3 string
+	Flight4Gate4 string
+	Flight4Gate5 string
+	Flight5OnTime string
+	Flight5Delayed string
+	Flight5Departed string
+	Flight5Arrived string
+	Flight5Scheduled string
+	Flight5Inbound string
+	Flight5Outbound string
+	Flight5GoToGate string
+	Flight5GateUnknown string
+	Flight5Gate1 string
+	Flight5Gate2 string
+	Flight5Gate3 string
+	Flight5Gate4 string
+	Flight5Gate5 string
+	Flight6OnTime string
+	Flight6Delayed string
+	Flight6Departed string
+	Flight6Arrived string
+	Flight6Scheduled string
+	Flight6Inbound string
+	Flight6Outbound string
+	Flight6GoToGate string
+	Flight6GateUnknown string
+	Flight6Gate1 string
+	Flight6Gate2 string
+	Flight6Gate3 string
+	Flight6Gate4 string
+	Flight6Gate5 string
+	Flight7OnTime string
+	Flight7Delayed string
+	Flight7Departed string
+	Flight7Arrived string
+	Flight7Scheduled string
+	Flight7Inbound string
+	Flight7Outbound string
+	Flight7GoToGate string
+	Flight7GateUnknown string
+	Flight7Gate1 string
+	Flight7Gate2 string
+	Flight7Gate3 string
+	Flight7Gate4 string
+	Flight7Gate5 string
+	Flight8OnTime string
+	Flight8Delayed string
+	Flight8Departed string
+	Flight8Arrived string
+	Flight8Scheduled string
+	Flight8Inbound string
+	Flight8Outbound string
+	Flight8GoToGate string
+	Flight8GateUnknown string
+	Flight8Gate1 string
+	Flight8Gate2 string
+	Flight8Gate3 string
+	Flight8Gate4 string
+	Flight8Gate5 string
+	Flight9OnTime string
+	Flight9Delayed string
+	Flight9Departed string
+	Flight9Arrived string
+	Flight9Scheduled string
+	Flight9Inbound string
+	Flight9Outbound string
+	Flight9GoToGate string
+	Flight9GateUnknown string
+	Flight9Gate1 string
+	Flight9Gate2 string
+	Flight9Gate3 string
+	Flight9Gate4 string
+	Flight9Gate5 string
+	Flight10OnTime string
+	Flight10Delayed string
+	Flight10Departed string
+	Flight10Arrived string
+	Flight10Scheduled string
+	Flight10Inbound string
+	Flight10Outbound string
+	Flight10GoToGate string
+	Flight10GateUnknown string
+	Flight10Gate1 string
+	Flight10Gate2 string
+	Flight10Gate3 string
+	Flight10Gate4 string
+	Flight10Gate5 string
+
+	// inherit from rpc/WorkerStatesDef
+	*ssrpc.WorkerStatesDef
+}
+
+// FlightsGroupsDef contains all the state groups Flights state machine.
+type FlightsGroupsDef struct {
+	Flight1Direction S
+	Flight1Status S
+	Flight1Gates S
+	Flight2Direction S
+	Flight2Status S
+	Flight2Gates S
+	Flight3Direction S
+	Flight3Status S
+	Flight3Gates S
+	Flight4Direction S
+	Flight4Status S
+	Flight4Gates S
+	Flight5Direction S
+	Flight5Status S
+	Flight5Gates S
+	Flight6Direction S
+	Flight6Status S
+	Flight6Gates S
+	Flight7Direction S
+	Flight7Status S
+	Flight7Gates S
+	Flight8Direction S
+	Flight8Status S
+	Flight8Gates S
+	Flight9Direction S
+	Flight9Status S
+	Flight9Gates S
+	Flight10Direction S
+	Flight10Status S
+	Flight10Gates S
+}
+
+// FlightsStruct represents all relations and properties of FlightsStates.
+var FlightsStruct = StructMerge(
+	// inherit from rpc/WorkerStruct
+	ssrpc.WorkerStruct,
+	am.Struct{
+
+		ssF.Flight1OnTime: {
+			Remove: SAdd(sgF.Flight1Status),
+		},
+		ssF.Flight1Delayed: {
+			Remove: SAdd(sgF.Flight1Status),
+		},
+		ssF.Flight1Departed: {
+			Remove: SAdd(sgF.Flight1Status,S{ssF.Flight1GoToGate}),
+		},
+		ssF.Flight1Arrived: {
+			Remove: SAdd(sgF.Flight1Status),
+		},
+		ssF.Flight1Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight1Status),
+		},
+		ssF.Flight1Inbound: {
+			Remove: SAdd(sgF.Flight1Direction),
+		},
+		ssF.Flight1Outbound: {
+			Remove: SAdd(sgF.Flight1Direction),
+		},
+		ssF.Flight1GoToGate: {
+			Require: S{ssF.Flight1Outbound},
+		},
+		ssF.Flight1GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight1Gate1: {
+			Remove: SAdd(sgF.Flight1Gates),
+		},
+		ssF.Flight1Gate2: {
+			Remove: SAdd(sgF.Flight1Gates),
+		},
+		ssF.Flight1Gate3: {
+			Remove: SAdd(sgF.Flight1Gates),
+		},
+		ssF.Flight1Gate4: {
+			Remove: SAdd(sgF.Flight1Gates),
+		},
+		ssF.Flight1Gate5: {
+			Remove: SAdd(sgF.Flight1Gates),
+		},
+		ssF.Flight2OnTime: {
+			Remove: SAdd(sgF.Flight2Status),
+		},
+		ssF.Flight2Delayed: {
+			Remove: SAdd(sgF.Flight2Status),
+		},
+		ssF.Flight2Departed: {
+			Remove: SAdd(sgF.Flight2Status,S{ssF.Flight2GoToGate}),
+		},
+		ssF.Flight2Arrived: {
+			Remove: SAdd(sgF.Flight2Status),
+		},
+		ssF.Flight2Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight2Status),
+		},
+		ssF.Flight2Inbound: {
+			Remove: SAdd(sgF.Flight2Direction),
+		},
+		ssF.Flight2Outbound: {
+			Remove: SAdd(sgF.Flight2Direction),
+		},
+		ssF.Flight2GoToGate: {
+			Require: S{ssF.Flight2Outbound},
+		},
+		ssF.Flight2GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight2Gate1: {
+			Remove: SAdd(sgF.Flight2Gates),
+		},
+		ssF.Flight2Gate2: {
+			Remove: SAdd(sgF.Flight2Gates),
+		},
+		ssF.Flight2Gate3: {
+			Remove: SAdd(sgF.Flight2Gates),
+		},
+		ssF.Flight2Gate4: {
+			Remove: SAdd(sgF.Flight2Gates),
+		},
+		ssF.Flight2Gate5: {
+			Remove: SAdd(sgF.Flight2Gates),
+		},
+		ssF.Flight3OnTime: {
+			Remove: SAdd(sgF.Flight3Status),
+		},
+		ssF.Flight3Delayed: {
+			Remove: SAdd(sgF.Flight3Status),
+		},
+		ssF.Flight3Departed: {
+			Remove: SAdd(sgF.Flight3Status,S{ssF.Flight3GoToGate}),
+		},
+		ssF.Flight3Arrived: {
+			Remove: SAdd(sgF.Flight3Status),
+		},
+		ssF.Flight3Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight3Status),
+		},
+		ssF.Flight3Inbound: {
+			Remove: SAdd(sgF.Flight3Direction),
+		},
+		ssF.Flight3Outbound: {
+			Remove: SAdd(sgF.Flight3Direction),
+		},
+		ssF.Flight3GoToGate: {
+			Require: S{ssF.Flight3Outbound},
+		},
+		ssF.Flight3GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight3Gate1: {
+			Remove: SAdd(sgF.Flight3Gates),
+		},
+		ssF.Flight3Gate2: {
+			Remove: SAdd(sgF.Flight3Gates),
+		},
+		ssF.Flight3Gate3: {
+			Remove: SAdd(sgF.Flight3Gates),
+		},
+		ssF.Flight3Gate4: {
+			Remove: SAdd(sgF.Flight3Gates),
+		},
+		ssF.Flight3Gate5: {
+			Remove: SAdd(sgF.Flight3Gates),
+		},
+		ssF.Flight4OnTime: {
+			Remove: SAdd(sgF.Flight4Status),
+		},
+		ssF.Flight4Delayed: {
+			Remove: SAdd(sgF.Flight4Status),
+		},
+		ssF.Flight4Departed: {
+			Remove: SAdd(sgF.Flight4Status,S{ssF.Flight4GoToGate}),
+		},
+		ssF.Flight4Arrived: {
+			Remove: SAdd(sgF.Flight4Status),
+		},
+		ssF.Flight4Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight4Status),
+		},
+		ssF.Flight4Inbound: {
+			Remove: SAdd(sgF.Flight4Direction),
+		},
+		ssF.Flight4Outbound: {
+			Remove: SAdd(sgF.Flight4Direction),
+		},
+		ssF.Flight4GoToGate: {
+			Require: S{ssF.Flight4Outbound},
+		},
+		ssF.Flight4GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight4Gate1: {
+			Remove: SAdd(sgF.Flight4Gates),
+		},
+		ssF.Flight4Gate2: {
+			Remove: SAdd(sgF.Flight4Gates),
+		},
+		ssF.Flight4Gate3: {
+			Remove: SAdd(sgF.Flight4Gates),
+		},
+		ssF.Flight4Gate4: {
+			Remove: SAdd(sgF.Flight4Gates),
+		},
+		ssF.Flight4Gate5: {
+			Remove: SAdd(sgF.Flight4Gates),
+		},
+		ssF.Flight5OnTime: {
+			Remove: SAdd(sgF.Flight5Status),
+		},
+		ssF.Flight5Delayed: {
+			Remove: SAdd(sgF.Flight5Status),
+		},
+		ssF.Flight5Departed: {
+			Remove: SAdd(sgF.Flight5Status,S{ssF.Flight5GoToGate}),
+		},
+		ssF.Flight5Arrived: {
+			Remove: SAdd(sgF.Flight5Status),
+		},
+		ssF.Flight5Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight5Status),
+		},
+		ssF.Flight5Inbound: {
+			Remove: SAdd(sgF.Flight5Direction),
+		},
+		ssF.Flight5Outbound: {
+			Remove: SAdd(sgF.Flight5Direction),
+		},
+		ssF.Flight5GoToGate: {
+			Require: S{ssF.Flight5Outbound},
+		},
+		ssF.Flight5GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight5Gate1: {
+			Remove: SAdd(sgF.Flight5Gates),
+		},
+		ssF.Flight5Gate2: {
+			Remove: SAdd(sgF.Flight5Gates),
+		},
+		ssF.Flight5Gate3: {
+			Remove: SAdd(sgF.Flight5Gates),
+		},
+		ssF.Flight5Gate4: {
+			Remove: SAdd(sgF.Flight5Gates),
+		},
+		ssF.Flight5Gate5: {
+			Remove: SAdd(sgF.Flight5Gates),
+		},
+		ssF.Flight6OnTime: {
+			Remove: SAdd(sgF.Flight6Status),
+		},
+		ssF.Flight6Delayed: {
+			Remove: SAdd(sgF.Flight6Status),
+		},
+		ssF.Flight6Departed: {
+			Remove: SAdd(sgF.Flight6Status,S{ssF.Flight6GoToGate}),
+		},
+		ssF.Flight6Arrived: {
+			Remove: SAdd(sgF.Flight6Status),
+		},
+		ssF.Flight6Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight6Status),
+		},
+		ssF.Flight6Inbound: {
+			Remove: SAdd(sgF.Flight6Direction),
+		},
+		ssF.Flight6Outbound: {
+			Remove: SAdd(sgF.Flight6Direction),
+		},
+		ssF.Flight6GoToGate: {
+			Require: S{ssF.Flight6Outbound},
+		},
+		ssF.Flight6GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight6Gate1: {
+			Remove: SAdd(sgF.Flight6Gates),
+		},
+		ssF.Flight6Gate2: {
+			Remove: SAdd(sgF.Flight6Gates),
+		},
+		ssF.Flight6Gate3: {
+			Remove: SAdd(sgF.Flight6Gates),
+		},
+		ssF.Flight6Gate4: {
+			Remove: SAdd(sgF.Flight6Gates),
+		},
+		ssF.Flight6Gate5: {
+			Remove: SAdd(sgF.Flight6Gates),
+		},
+		ssF.Flight7OnTime: {
+			Remove: SAdd(sgF.Flight7Status),
+		},
+		ssF.Flight7Delayed: {
+			Remove: SAdd(sgF.Flight7Status),
+		},
+		ssF.Flight7Departed: {
+			Remove: SAdd(sgF.Flight7Status,S{ssF.Flight7GoToGate}),
+		},
+		ssF.Flight7Arrived: {
+			Remove: SAdd(sgF.Flight7Status),
+		},
+		ssF.Flight7Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight7Status),
+		},
+		ssF.Flight7Inbound: {
+			Remove: SAdd(sgF.Flight7Direction),
+		},
+		ssF.Flight7Outbound: {
+			Remove: SAdd(sgF.Flight7Direction),
+		},
+		ssF.Flight7GoToGate: {
+			Require: S{ssF.Flight7Outbound},
+		},
+		ssF.Flight7GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight7Gate1: {
+			Remove: SAdd(sgF.Flight7Gates),
+		},
+		ssF.Flight7Gate2: {
+			Remove: SAdd(sgF.Flight7Gates),
+		},
+		ssF.Flight7Gate3: {
+			Remove: SAdd(sgF.Flight7Gates),
+		},
+		ssF.Flight7Gate4: {
+			Remove: SAdd(sgF.Flight7Gates),
+		},
+		ssF.Flight7Gate5: {
+			Remove: SAdd(sgF.Flight7Gates),
+		},
+		ssF.Flight8OnTime: {
+			Remove: SAdd(sgF.Flight8Status),
+		},
+		ssF.Flight8Delayed: {
+			Remove: SAdd(sgF.Flight8Status),
+		},
+		ssF.Flight8Departed: {
+			Remove: SAdd(sgF.Flight8Status,S{ssF.Flight8GoToGate}),
+		},
+		ssF.Flight8Arrived: {
+			Remove: SAdd(sgF.Flight8Status),
+		},
+		ssF.Flight8Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight8Status),
+		},
+		ssF.Flight8Inbound: {
+			Remove: SAdd(sgF.Flight8Direction),
+		},
+		ssF.Flight8Outbound: {
+			Remove: SAdd(sgF.Flight8Direction),
+		},
+		ssF.Flight8GoToGate: {
+			Require: S{ssF.Flight8Outbound},
+		},
+		ssF.Flight8GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight8Gate1: {
+			Remove: SAdd(sgF.Flight8Gates),
+		},
+		ssF.Flight8Gate2: {
+			Remove: SAdd(sgF.Flight8Gates),
+		},
+		ssF.Flight8Gate3: {
+			Remove: SAdd(sgF.Flight8Gates),
+		},
+		ssF.Flight8Gate4: {
+			Remove: SAdd(sgF.Flight8Gates),
+		},
+		ssF.Flight8Gate5: {
+			Remove: SAdd(sgF.Flight8Gates),
+		},
+		ssF.Flight9OnTime: {
+			Remove: SAdd(sgF.Flight9Status),
+		},
+		ssF.Flight9Delayed: {
+			Remove: SAdd(sgF.Flight9Status),
+		},
+		ssF.Flight9Departed: {
+			Remove: SAdd(sgF.Flight9Status,S{ssF.Flight9GoToGate}),
+		},
+		ssF.Flight9Arrived: {
+			Remove: SAdd(sgF.Flight9Status),
+		},
+		ssF.Flight9Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight9Status),
+		},
+		ssF.Flight9Inbound: {
+			Remove: SAdd(sgF.Flight9Direction),
+		},
+		ssF.Flight9Outbound: {
+			Remove: SAdd(sgF.Flight9Direction),
+		},
+		ssF.Flight9GoToGate: {
+			Require: S{ssF.Flight9Outbound},
+		},
+		ssF.Flight9GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight9Gate1: {
+			Remove: SAdd(sgF.Flight9Gates),
+		},
+		ssF.Flight9Gate2: {
+			Remove: SAdd(sgF.Flight9Gates),
+		},
+		ssF.Flight9Gate3: {
+			Remove: SAdd(sgF.Flight9Gates),
+		},
+		ssF.Flight9Gate4: {
+			Remove: SAdd(sgF.Flight9Gates),
+		},
+		ssF.Flight9Gate5: {
+			Remove: SAdd(sgF.Flight9Gates),
+		},
+		ssF.Flight10OnTime: {
+			Remove: SAdd(sgF.Flight10Status),
+		},
+		ssF.Flight10Delayed: {
+			Remove: SAdd(sgF.Flight10Status),
+		},
+		ssF.Flight10Departed: {
+			Remove: SAdd(sgF.Flight10Status,S{ssF.Flight10GoToGate}),
+		},
+		ssF.Flight10Arrived: {
+			Remove: SAdd(sgF.Flight10Status),
+		},
+		ssF.Flight10Scheduled: {
+			Auto: true,
+			Remove: SAdd(sgF.Flight10Status),
+		},
+		ssF.Flight10Inbound: {
+			Remove: SAdd(sgF.Flight10Direction),
+		},
+		ssF.Flight10Outbound: {
+			Remove: SAdd(sgF.Flight10Direction),
+		},
+		ssF.Flight10GoToGate: {
+			Require: S{ssF.Flight10Outbound},
+		},
+		ssF.Flight10GateUnknown: {
+			Auto: true,
+		},
+		ssF.Flight10Gate1: {
+			Remove: SAdd(sgF.Flight10Gates),
+		},
+		ssF.Flight10Gate2: {
+			Remove: SAdd(sgF.Flight10Gates),
+		},
+		ssF.Flight10Gate3: {
+			Remove: SAdd(sgF.Flight10Gates),
+		},
+		ssF.Flight10Gate4: {
+			Remove: SAdd(sgF.Flight10Gates),
+		},
+		ssF.Flight10Gate5: {
+			Remove: SAdd(sgF.Flight10Gates),
+		},
+})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssF = am.NewStates(FlightsStatesDef{})
+	sgF = am.NewStateGroups(FlightsGroupsDef{
+		Flight1Direction: S{ssF.Flight1Inbound, ssF.Flight1Outbound},
+		Flight1Status: S{ssF.Flight1OnTime, ssF.Flight1Delayed, ssF.Flight1Departed, ssF.Flight1Arrived, ssF.Flight1Scheduled},
+		Flight1Gates: S{ssF.Flight1Gate1, ssF.Flight1Gate2, ssF.Flight1Gate3, ssF.Flight1Gate4, ssF.Flight1Gate5},
+		Flight2Direction: S{ssF.Flight2Inbound, ssF.Flight2Outbound},
+		Flight2Status: S{ssF.Flight2OnTime, ssF.Flight2Delayed, ssF.Flight2Departed, ssF.Flight2Arrived, ssF.Flight2Scheduled},
+		Flight2Gates: S{ssF.Flight2Gate1, ssF.Flight2Gate2, ssF.Flight2Gate3, ssF.Flight2Gate4, ssF.Flight2Gate5},
+		Flight3Direction: S{ssF.Flight3Inbound, ssF.Flight3Outbound},
+		Flight3Status: S{ssF.Flight3OnTime, ssF.Flight3Delayed, ssF.Flight3Departed, ssF.Flight3Arrived, ssF.Flight3Scheduled},
+		Flight3Gates: S{ssF.Flight3Gate1, ssF.Flight3Gate2, ssF.Flight3Gate3, ssF.Flight3Gate4, ssF.Flight3Gate5},
+		Flight4Direction: S{ssF.Flight4Inbound, ssF.Flight4Outbound},
+		Flight4Status: S{ssF.Flight4OnTime, ssF.Flight4Delayed, ssF.Flight4Departed, ssF.Flight4Arrived, ssF.Flight4Scheduled},
+		Flight4Gates: S{ssF.Flight4Gate1, ssF.Flight4Gate2, ssF.Flight4Gate3, ssF.Flight4Gate4, ssF.Flight4Gate5},
+		Flight5Direction: S{ssF.Flight5Inbound, ssF.Flight5Outbound},
+		Flight5Status: S{ssF.Flight5OnTime, ssF.Flight5Delayed, ssF.Flight5Departed, ssF.Flight5Arrived, ssF.Flight5Scheduled},
+		Flight5Gates: S{ssF.Flight5Gate1, ssF.Flight5Gate2, ssF.Flight5Gate3, ssF.Flight5Gate4, ssF.Flight5Gate5},
+		Flight6Direction: S{ssF.Flight6Inbound, ssF.Flight6Outbound},
+		Flight6Status: S{ssF.Flight6OnTime, ssF.Flight6Delayed, ssF.Flight6Departed, ssF.Flight6Arrived, ssF.Flight6Scheduled},
+		Flight6Gates: S{ssF.Flight6Gate1, ssF.Flight6Gate2, ssF.Flight6Gate3, ssF.Flight6Gate4, ssF.Flight6Gate5},
+		Flight7Direction: S{ssF.Flight7Inbound, ssF.Flight7Outbound},
+		Flight7Status: S{ssF.Flight7OnTime, ssF.Flight7Delayed, ssF.Flight7Departed, ssF.Flight7Arrived, ssF.Flight7Scheduled},
+		Flight7Gates: S{ssF.Flight7Gate1, ssF.Flight7Gate2, ssF.Flight7Gate3, ssF.Flight7Gate4, ssF.Flight7Gate5},
+		Flight8Direction: S{ssF.Flight8Inbound, ssF.Flight8Outbound},
+		Flight8Status: S{ssF.Flight8OnTime, ssF.Flight8Delayed, ssF.Flight8Departed, ssF.Flight8Arrived, ssF.Flight8Scheduled},
+		Flight8Gates: S{ssF.Flight8Gate1, ssF.Flight8Gate2, ssF.Flight8Gate3, ssF.Flight8Gate4, ssF.Flight8Gate5},
+		Flight9Direction: S{ssF.Flight9Inbound, ssF.Flight9Outbound},
+		Flight9Status: S{ssF.Flight9OnTime, ssF.Flight9Delayed, ssF.Flight9Departed, ssF.Flight9Arrived, ssF.Flight9Scheduled},
+		Flight9Gates: S{ssF.Flight9Gate1, ssF.Flight9Gate2, ssF.Flight9Gate3, ssF.Flight9Gate4, ssF.Flight9Gate5},
+		Flight10Direction: S{ssF.Flight10Inbound, ssF.Flight10Outbound},
+		Flight10Status: S{ssF.Flight10OnTime, ssF.Flight10Delayed, ssF.Flight10Departed, ssF.Flight10Arrived, ssF.Flight10Scheduled},
+		Flight10Gates: S{ssF.Flight10Gate1, ssF.Flight10Gate2, ssF.Flight10Gate3, ssF.Flight10Gate4, ssF.Flight10Gate5},
+	})
+
+	// FlightsStates contains all the states for the Flights machine.
+	FlightsStates = ssF
+	// FlightsGroups contains all the state groups for the Flights machine.
+	FlightsGroups = sgF
+)

--- a/examples/tree_state_source/states/states_utils.go
+++ b/examples/tree_state_source/states/states_utils.go
@@ -1,0 +1,23 @@
+
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names. See [am.S].
+type S = am.S
+
+// State is a type alias for a state definition. See [am.State].
+type State = am.State
+
+// SAdd is a func alias for merging lists of states. See [am.SAdd].
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition. See [am.StateAdd].
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition. See [am.StateSet].
+var StateSet = am.StateSet
+
+// StructMerge is a func alias for extending an existing state structure. See [am.StructMerge].
+var StructMerge = am.StructMerge


### PR DESCRIPTION
The biggest example so far, has it's own state generator and can be used to stress test telemetry, but most of all it's an interesting distributed concept.

```mermaid
flowchart BT
    Root
    Replicant-1 -- aRPC --> Root
    Replicant-2 -- aRPC --> Root

    Replicant-1-1 -- aRPC --> Replicant-1
    Replicant-1-2 -- aRPC --> Replicant-1
    Replicant-1-3 -- aRPC --> Replicant-1

    Replicant-2-1 -- aRPC --> Replicant-2
    Replicant-2-2 -- aRPC --> Replicant-2
    Replicant-2-3 -- aRPC --> Replicant-2
```

See [/examples/tree_state_source](/examples/tree_state_source/README.md).