### PR TITLE
feat(examples): add benchmark state source

### DIFF
--- a/examples/benchmark_state_source/Dockerfile
+++ b/examples/benchmark_state_source/Dockerfile
@@ -1,0 +1,28 @@
+# Use the official Golang image as the base image
+FROM golang:1.23-alpine AS builder
+
+# deps
+WORKDIR /app
+COPY asyncmachine-go/go.mod .
+RUN go mod tidy
+
+# code
+COPY . .
+WORKDIR /app/asyncmachine-go
+RUN go build -o ../main ./examples/tree_state_source
+
+# Start a new stage from scratch
+FROM alpine:latest
+
+# Set the Current Working Directory inside the container
+WORKDIR /root/
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/main .
+
+# Expose ports
+EXPOSE 19700
+EXPOSE 18700
+
+# Command to run the executable
+CMD ["./main"]

--- a/examples/benchmark_state_source/README.md
+++ b/examples/benchmark_state_source/README.md
@@ -1,0 +1,147 @@
+# <img src="https://pancsta.github.io/assets/asyncmachine-go/logo.png" height="25"/> /example/benchmark_state_source
+
+- [cd /](/)
+
+> [!NOTE]
+> **Asyncmachine-go** is an AOP Actor Model library for distributed workflows, built on top of a lightweight state
+> machine (nondeterministic, multi-state, clock-based, relational, optionally-accepting, and non-blocking). It has
+> atomic transitions, RPC, logging, TUI debugger, metrics, tracing, and soon diagrams.
+
+Benchmark of [`/examples/tree_state_source`](/examples/tree_state_source/README.md) using [go-wrk](https://github.com/tsliwowicz/go-wrk)
+and [Caddy](https://caddyserver.com/) in various tree configurations. Every node is a resource limiter container
+(0.1cpu, 64mb). Each run starts with a restart of the load balancer and a 1s warmup.
+
+```mermaid
+flowchart BT
+    Root
+    Replicant-1 -- aRPC --> Root
+    Replicant-2 -- aRPC --> Root
+
+    Replicant-1-1 -- aRPC --> Replicant-1
+    Replicant-1-2 -- aRPC --> Replicant-1
+    Replicant-1-3 -- aRPC --> Replicant-1
+
+    Replicant-2-1 -- aRPC --> Replicant-2
+    Replicant-2-2 -- aRPC --> Replicant-2
+    Replicant-2-3 -- aRPC --> Replicant-2
+
+    Caddy[Caddy Load Balancer]
+    Caddy -- HTTP --> Replicant-1-1
+    Caddy -- HTTP --> Replicant-1-2
+    Caddy -- HTTP --> Replicant-1-3
+    Caddy -- HTTP --> Replicant-2-1
+    Caddy -- HTTP --> Replicant-2-2
+    Caddy -- HTTP --> Replicant-2-3
+
+    Benchmark[Benchmark go-wrt]
+    Benchmark -- HTTP --> Caddy
+```
+
+## Results
+
+### root only
+
+```text
+bench-1  | Running 10s test @ http://caddy
+bench-1  |   512 goroutine(s) running concurrently
+bench-1  | 5908 requests in 3.605675983s, 4.46MB read
+bench-1  | Requests/sec:                1638.53
+bench-1  | Transfer/sec:                1.24MB
+bench-1  | Overall Requests/sec:        535.39
+bench-1  | Overall Transfer/sec:        413.49KB
+bench-1  | Fastest Request:     255µs
+bench-1  | Avg Req Time:                312.475ms
+bench-1  | Slowest Request:     1.054591s
+bench-1  | Number of Errors:    3471
+bench-1  | Error Counts:                net/http: timeout awaiting response headers=3471
+bench-1  | 10%:                 324µs
+bench-1  | 50%:                 490µs
+bench-1  | 75%:                 544µs
+bench-1  | 99%:                 604µs
+bench-1  | 99.9%:                       605µs
+bench-1  | 99.9999%:            605µs
+bench-1  | 99.99999%:           605µs
+bench-1  | stddev:                      306.059ms
+```
+
+### 2 direct replicants (1st level)
+
+```text
+bench-1  | Running 10s test @ http://caddy
+bench-1  |   512 goroutine(s) running concurrently
+bench-1  | 12443 requests in 6.876868235s, 9.37MB read
+bench-1  | Requests/sec:                1809.40
+bench-1  | Transfer/sec:                1.36MB
+bench-1  | Overall Requests/sec:        1128.51
+bench-1  | Overall Transfer/sec:        869.83KB
+bench-1  | Fastest Request:     217µs
+bench-1  | Avg Req Time:                282.966ms
+bench-1  | Slowest Request:     1.246847s
+bench-1  | Number of Errors:    1619
+bench-1  | Error Counts:                net/http: timeout awaiting response headers=1619
+bench-1  | 10%:                 316µs
+bench-1  | 50%:                 405µs
+bench-1  | 75%:                 453µs
+bench-1  | 99%:                 493µs
+bench-1  | 99.9%:                       493µs
+bench-1  | 99.9999%:            493µs
+bench-1  | 99.99999%:           493µs
+bench-1  | stddev:                      267.944ms
+```
+
+### 4 indirect replicants (2nd level)
+
+```text
+
+bench-1  | Running 10s test @ http://caddy
+bench-1  |   512 goroutine(s) running concurrently
+bench-1  | 26584 requests in 9.726687548s, 20.54MB read
+bench-1  | Requests/sec:                2733.10
+bench-1  | Transfer/sec:                2.11MB
+bench-1  | Overall Requests/sec:        2452.13
+bench-1  | Overall Transfer/sec:        1.89MB
+bench-1  | Fastest Request:     245µs
+bench-1  | Avg Req Time:                187.333ms
+bench-1  | Slowest Request:     1.002079s
+bench-1  | Number of Errors:    220
+bench-1  | Error Counts:                net/http: timeout awaiting response headers=220
+bench-1  | 10%:                 411µs
+bench-1  | 50%:                 699µs
+bench-1  | 75%:                 817µs
+bench-1  | 99%:                 918µs
+bench-1  | 99.9%:                       920µs
+bench-1  | 99.9999%:            920µs
+bench-1  | 99.99999%:           920µs
+bench-1  | stddev:                      192.651ms
+```
+
+### 6 indirect replicants (2nd level)
+
+```text
+bench-1  | Running 10s test @ http://caddy
+bench-1  |   512 goroutine(s) running concurrently
+bench-1  | 73815 requests in 10.04096714s, 55.45MB read
+bench-1  | Requests/sec:                7351.38
+bench-1  | Transfer/sec:                5.52MB
+bench-1  | Overall Requests/sec:        6914.62
+bench-1  | Overall Transfer/sec:        5.19MB
+bench-1  | Fastest Request:     226µs
+bench-1  | Avg Req Time:                69.646ms
+bench-1  | Slowest Request:     499.103ms
+bench-1  | Number of Errors:    0
+bench-1  | 10%:                 380µs
+bench-1  | 50%:                 601µs
+bench-1  | 75%:                 709µs
+bench-1  | 99%:                 810µs
+bench-1  | 99.9%:                       812µs
+bench-1  | 99.9999%:            813µs
+bench-1  | 99.99999%:           813µs
+bench-1  | stddev:                      61.523ms
+```
+
+## Running
+
+1. Clone
+2. `cd /examples/benchmark_state_source`
+3. `task start`
+4. `task bench`

--- a/examples/benchmark_state_source/Taskfile.yml
+++ b/examples/benchmark_state_source/Taskfile.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+tasks:
+
+  start:
+    cmds:
+      - cd bench && ln -sfn Caddyfile-root Caddyfile
+      - docker-compose up --detach --force-recreate --build
+      - docker-compose stop bench
+
+  stop:
+    cmd: docker-compose down
+
+  bench:
+    cmds:
+      - cd bench && ln -sfn Caddyfile-root Caddyfile
+      - docker-compose restart caddy bench
+      - sleep 25
+      - task: logs
+
+      - cd bench && ln -sfn Caddyfile-root-2 Caddyfile
+      - docker-compose restart caddy bench
+      - sleep 25
+      - task: logs
+
+      - cd bench && ln -sfn Caddyfile-root-2-4 Caddyfile
+      - docker-compose restart caddy bench
+      - sleep 25
+      - task: logs
+
+      - cd bench && ln -sfn Caddyfile-root-2-6 Caddyfile
+      - docker-compose restart caddy bench
+      - sleep 25
+      - task: logs
+
+  logs:
+    cmd: docker-compose logs --tail 22 bench

--- a/examples/benchmark_state_source/bench/.gitignore
+++ b/examples/benchmark_state_source/bench/.gitignore
@@ -1,0 +1,1 @@
+Caddyfile

--- a/examples/benchmark_state_source/bench/Caddyfile-root
+++ b/examples/benchmark_state_source/bench/Caddyfile-root
@@ -1,0 +1,10 @@
+:80 {
+    #
+    # root only
+    #
+    reverse_proxy /* root:18700
+
+    log {
+        output discard
+    }
+}

--- a/examples/benchmark_state_source/bench/Caddyfile-root-2
+++ b/examples/benchmark_state_source/bench/Caddyfile-root-2
@@ -1,0 +1,12 @@
+:80 {
+    #
+    # 2 direct replicants
+    #
+    reverse_proxy /* rep-1:18700 rep-2:18700 {
+        lb_policy least_conn
+    }
+
+    log {
+        output discard
+    }
+}

--- a/examples/benchmark_state_source/bench/Caddyfile-root-2-4
+++ b/examples/benchmark_state_source/bench/Caddyfile-root-2-4
@@ -1,0 +1,12 @@
+:80 {
+    #
+    # 4 indirect replicants
+    #
+    reverse_proxy /* rep-1-1:18700 rep-1-2:18700 rep-2-1:18700 rep-2-2:18700 {
+        lb_policy least_conn
+    }
+
+    log {
+        output discard
+    }
+}

--- a/examples/benchmark_state_source/bench/Caddyfile-root-2-6
+++ b/examples/benchmark_state_source/bench/Caddyfile-root-2-6
@@ -1,0 +1,12 @@
+:80 {
+    #
+    # 6 indirect replicants
+    #
+    reverse_proxy /* rep-1-1:18700 rep-1-2:18700 rep-1-3:18700 rep-2-1:18700 rep-2-2:18700 rep-2-3:18700 {
+        lb_policy least_conn
+    }
+
+    log {
+        output discard
+    }
+}

--- a/examples/benchmark_state_source/bench/Dockerfile
+++ b/examples/benchmark_state_source/bench/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.20-alpine
+
+WORKDIR /app
+RUN go install github.com/tsliwowicz/go-wrk@latest
+
+CMD ["/app/go-wrk.sh"]

--- a/examples/benchmark_state_source/bench/go-wrk.sh
+++ b/examples/benchmark_state_source/bench/go-wrk.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+echo "----- WARMUP"
+echo "----- WARMUP"
+echo "----- WARMUP"
+go-wrk -c 512 -d 1 "http://caddy"
+sleep 3
+
+echo "----- BENCHMARK"
+echo "----- BENCHMARK"
+echo "----- BENCHMARK"
+echo $(date)
+go-wrk -c 512 -d 10 "http://caddy"

--- a/examples/benchmark_state_source/docker-compose.yml
+++ b/examples/benchmark_state_source/docker-compose.yml
@@ -1,0 +1,207 @@
+services:
+
+  # LEVEL 0
+
+  root:
+    build:
+      # TODO remove go.mod rewrite
+#      context: ../..
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+
+  # LEVEL 1
+
+  rep-1:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - root
+
+  rep-2:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - root
+
+  # LEVEL 2
+
+  rep-1-1:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-1
+
+  rep-1-2:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-1
+
+  rep-1-3:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-1
+
+  rep-2-1:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-2
+
+  rep-2-2:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-2
+
+  rep-2-3:
+    build:
+      # TODO remove go.mod rewrite
+      context: ../../..
+      dockerfile: ./asyncmachine-go/examples/benchmark_state_source/Dockerfile
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64MB
+        reservations:
+          cpus: '0.1'
+          memory: 64MB
+    environment:
+      - TST_ADDR=:19700
+      - TST_HTTP_ADDR=:18700
+    depends_on:
+      - rep-2
+
+  # BENCHMARK
+
+  caddy:
+    image: caddy:latest
+    depends_on:
+      - root
+
+      - rep-1
+      - rep-2
+
+      - rep-1-1
+      - rep-1-2
+      - rep-1-3
+
+      - rep-2-1
+      - rep-2-2
+      - rep-2-3
+    ports:
+      - "18700:80"
+    volumes:
+      - ./bench/Caddyfile:/etc/caddy/Caddyfile
+
+  bench:
+    build:
+      context: ./bench
+    volumes:
+      - ./bench/go-wrk.sh:/app/go-wrk.sh
+    depends_on:
+      - caddy


### PR DESCRIPTION
Another RPC benchmark, this time showing how to distribute state-read load across a tree of nodes. Spoiler: it gets faster with more nodes.

See [/examples/benchmark_state_source](/examples/benchmark_state_source/README.md).