### PR TITLE
feat(am-dbg): release am-dbg v0.8.0

### DIFF
--- a/tools/debugger/handlers.go
+++ b/tools/debugger/handlers.go
@@ -4,6 +4,9 @@ package debugger
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"os"
 	"slices"
 	"time"
 
@@ -11,6 +14,8 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 
@@ -44,7 +49,7 @@ func (d *Debugger) StartState(e *am.Event) {
 		}
 
 		d.App.SetRoot(d.LayoutRoot, true)
-		d.App.SetFocus(d.sidebar)
+		d.App.SetFocus(d.clientList)
 		err := d.App.Run()
 		if err != nil {
 			d.Mach.AddErr(err, nil)
@@ -73,7 +78,7 @@ func (d *Debugger) StartState(e *am.Event) {
 			return
 		}
 
-		d.buildSidebar(-1)
+		d.buildClientList(-1)
 		if clientID == "" {
 			ids := maps.Keys(d.Clients)
 			clientID = ids[0]
@@ -97,6 +102,32 @@ func (d *Debugger) StartEnd(_ *am.Event) {
 	d.App.Stop()
 }
 
+func (d *Debugger) ReadyState(_ *am.Event) {
+	d.healthcheck = time.NewTicker(healthcheckInterval)
+
+	// unblock
+	go func() {
+		for {
+			select {
+			case <-d.healthcheck.C:
+				d.Mach.Add1(ss.Healthcheck, nil)
+
+			case <-d.Mach.Ctx().Done():
+				d.healthcheck.Stop()
+			}
+		}
+	}()
+}
+
+func (d *Debugger) ReadyEnd(_ *am.Event) {
+	d.healthcheck.Stop()
+}
+
+func (d *Debugger) HealthcheckState(_ *am.Event) {
+	d.Mach.Remove1(ss.Healthcheck, nil)
+	d.checkGcMsgs()
+}
+
 // AnyAny is a global handler
 func (d *Debugger) AnyAny(e *am.Event) {
 	tx := e.Transition()
@@ -112,7 +143,9 @@ func (d *Debugger) AnyAny(e *am.Event) {
 func (d *Debugger) StateNameSelectedState(e *am.Event) {
 	// TODO guard
 	d.C.SelectedState = e.Args["state"].(string)
-	switch d.Mach.Switch(ss.GroupViews...) {
+	d.lastSelectedState = d.C.SelectedState
+
+	switch d.Mach.Switch(ss.GroupViews) {
 
 	case ss.TreeLogView:
 		d.updateTree()
@@ -184,8 +217,15 @@ func (d *Debugger) PausedState(_ *am.Event) {
 }
 
 func (d *Debugger) TailModeState(_ *am.Event) {
-	d.C.CursorTx = d.filterTxCursor(d.C, len(d.C.MsgTxs), false)
+	d.SetCursor(d.filterTxCursor(d.C, len(d.C.MsgTxs), false))
+	d.updateMatrixRain()
+	d.updateClientList(true)
 	// needed bc tail mode if carried over via SelectingClient
+	d.RedrawFull(true)
+}
+
+func (d *Debugger) TailModeEnd(_ *am.Event) {
+	d.updateMatrixRain()
 	d.RedrawFull(true)
 }
 
@@ -208,12 +248,16 @@ func (d *Debugger) FwdState(e *am.Event) {
 	amount = max(amount, 1)
 
 	c := d.C
-	c.CursorTx = d.filterTxCursor(c, c.CursorTx+amount, true)
+	d.SetCursor(d.filterTxCursor(c, c.CursorTx+amount, true))
 	c.CursorStep = 0
 	d.handleTStepsScrolled()
 	if d.Mach.Is1(ss.Playing) && c.CursorTx == len(c.MsgTxs) {
 		d.Mach.Remove1(ss.Playing, nil)
 	}
+
+	d.memorizeTxTime(c)
+	// sidebar for errs
+	d.updateClientList(true)
 
 	d.RedrawFull(false)
 }
@@ -235,10 +279,14 @@ func (d *Debugger) BackState(e *am.Event) {
 	amount = max(amount, 1)
 
 	c := d.C
-	c.CursorTx = d.filterTxCursor(c, c.CursorTx-amount, false)
+	d.SetCursor(d.filterTxCursor(d.C, c.CursorTx-amount, false))
 	c.CursorStep = 0
-
 	d.handleTStepsScrolled()
+
+	d.memorizeTxTime(c)
+	// sidebar for errs
+	d.updateClientList(true)
+
 	d.RedrawFull(false)
 }
 
@@ -285,7 +333,7 @@ func (d *Debugger) BackStepState(_ *am.Event) {
 
 	// wrap if there's a prev tx
 	if d.C.CursorStep <= 0 {
-		d.C.CursorTx = d.filterTxCursor(d.C, d.C.CursorTx-1, false)
+		d.SetCursor(d.filterTxCursor(d.C, d.C.CursorTx-1, false))
 		d.updateLog(false)
 		nextTx := d.nextTx()
 		d.C.CursorStep = len(nextTx.Steps)
@@ -294,6 +342,7 @@ func (d *Debugger) BackStepState(_ *am.Event) {
 		d.C.CursorStep--
 	}
 
+	d.updateClientList(false)
 	d.handleTStepsScrolled()
 	d.RedrawFull(false)
 }
@@ -310,14 +359,53 @@ func (d *Debugger) handleTStepsScrolled() {
 }
 
 func (d *Debugger) TimelineStepsFocusedState(_ *am.Event) {
+	// keep in sync with initLayout()
+	// TODO support no reader
+	d.treeLogGrid.UpdateItem(d.tree, 0, 0, 1, 3, 0, 0, false)
+
+	if d.Mach.Is1(ss.LogReaderVisible) {
+		d.treeLogGrid.UpdateItem(d.log, 0, 3, 1, 2, 0, 0, false)
+		d.treeLogGrid.UpdateItem(d.logReader, 0, 5, 1, 1, 0, 0, false)
+	} else {
+		d.treeLogGrid.UpdateItem(d.log, 0, 3, 1, 3, 0, 0, false)
+	}
+
+	d.treeMatrixGrid.UpdateItem(d.tree, 0, 0, 1, 3, 0, 0, false)
+	d.treeMatrixGrid.UpdateItem(d.matrix, 0, 3, 1, 3, 0, 0, false)
+
 	d.RedrawFull(false)
 }
 
 func (d *Debugger) TimelineStepsFocusedEnd(_ *am.Event) {
+	// keep in sync with initLayout()
+	// TODO support no reader
+	d.treeLogGrid.UpdateItem(d.tree, 0, 0, 1, 2, 0, 0, false)
+
+	if d.Mach.Is1(ss.LogReaderVisible) {
+		d.treeLogGrid.UpdateItem(d.log, 0, 2, 1, 2, 0, 0, false)
+		d.treeLogGrid.UpdateItem(d.logReader, 0, 4, 1, 2, 0, 0, false)
+	} else {
+		d.treeLogGrid.UpdateItem(d.log, 0, 2, 1, 4, 0, 0, false)
+	}
+
+	d.treeMatrixGrid.UpdateItem(d.tree, 0, 0, 1, 2, 0, 0, false)
+	d.treeMatrixGrid.UpdateItem(d.matrix, 0, 2, 1, 4, 0, 0, false)
+
 	d.RedrawFull(false)
 }
 
-func (d *Debugger) FiltersFocusedState(_ *am.Event) {
+func (d *Debugger) FiltersFocusedEnter(e *am.Event) bool {
+	f, ok1 := e.Args["filter"]
+	_, ok2 := f.(FilterName)
+
+	// both or none
+	return ok1 && ok2 || (!ok1 && !ok2)
+}
+
+func (d *Debugger) FiltersFocusedState(e *am.Event) {
+	if filter, ok := e.Args["filter"].(FilterName); ok {
+		d.focusedFilter = filter
+	}
 	d.filtersBar.SetBackgroundColor(cview.Styles.MoreContrastBackgroundColor)
 	d.updateFiltersBar()
 }
@@ -345,7 +433,7 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 	// initial structure data
 	msg := e.Args["msg_struct"].(*telemetry.DbgMsgStruct)
 	connID := e.Args["conn_id"].(string)
-	c := d.Clients[msg.ID]
+	var c *Client
 
 	// cleanup removes all previous clients, if all are disconnected
 	cleanup := false
@@ -354,58 +442,31 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 		cleanup = d.doCleanOnConnect()
 	}
 
-	if c == nil {
-		// new client
-		c = &Client{
-			id:     msg.ID,
-			connID: connID,
-			Exportable: Exportable{
-				MsgStruct: msg,
-			},
-		}
-		c.connected.Store(true)
+	// always create a new client on struct msgs
+	// TODO rename and keep the old client
+	c = &Client{
+		id:     msg.ID,
+		connID: connID,
+		Exportable: Exportable{
+			MsgStruct: msg,
+		},
+	}
+	c.connected.Store(true)
 
-		d.Clients[msg.ID] = c
-		if !cleanup {
-			d.buildSidebar(-1)
-		}
-
-	} else {
-		// update the existing client
-		c = &Client{
-			id:     msg.ID,
-			connID: connID,
-			Exportable: Exportable{
-				MsgStruct: msg,
-			},
-		}
-		c.connected.Store(true)
-		d.Clients[msg.ID] = c
-
-		// currently selected - refresh the UI
-		if !cleanup {
-			if d.C != nil && d.C.id == msg.ID {
-				d.C = c
-				d.log.Clear()
-				d.updateTimelines()
-				d.updateTxBars()
-				// update the tree in case the struct changed
-				d.buildStatesTree()
-				d.updateBorderColor()
-			}
-			d.updateSidebar(true)
-		}
+	d.Clients[msg.ID] = c
+	if !cleanup {
+		d.buildClientList(-1)
 	}
 
-	// rebuild the UI in case of a cleanup
-	if cleanup {
+	// rebuild the UI in case of a cleanup or connect under the same ID
+	if cleanup || (d.C != nil && d.C.id == msg.ID) {
 		// select the new (and only) client
 		d.C = c
 		d.log.Clear()
 		d.updateTimelines()
 		d.updateTxBars()
 		d.updateBorderColor()
-		d.buildSidebar(0)
+		d.buildClientList(0)
 		// initial build of the states tree
 		d.buildStatesTree()
 		d.updateViews(false)
@@ -420,8 +481,9 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 		)
 		// TODO get time from msgs
 		for id, c := range d.Clients {
-			if c.lastActive.After(lastActiveTime) || lastActiveID == "" {
-				lastActiveTime = c.lastActive
+			active := c.lastActive()
+			if active.After(lastActiveTime) || lastActiveID == "" {
+				lastActiveTime = active
 				lastActiveID = id
 			}
 		}
@@ -438,6 +500,13 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 			// mark the origin
 			"from_connected": true,
 		})
+
+		// re-select the state
+		if d.lastSelectedState != "" {
+			d.Mach.Add1(ss.StateNameSelected, am.A{"state": d.lastSelectedState})
+			// TODO Keep in StateNameSelected behind a flag
+			d.selectTreeState(d.lastSelectedState)
+		}
 	}
 
 	// first client, tail mode
@@ -471,7 +540,7 @@ func (d *Debugger) DisconnectEventState(e *am.Event) {
 	}
 
 	d.updateBorderColor()
-	d.updateSidebar(true)
+	d.updateClientList(true)
 	d.draw()
 }
 
@@ -501,16 +570,23 @@ func (d *Debugger) ClientMsgState(e *am.Event) {
 	for _, msg := range msgs {
 
 		// TODO check tokens
-		c := d.Clients[msg.MachineID]
-		if _, ok := d.Clients[msg.MachineID]; !ok {
-			d.Mach.Log("Error: client not found: %s\n", msg.MachineID)
+		machId := msg.MachineID
+		c := d.Clients[machId]
+		if _, ok := d.Clients[machId]; !ok {
+			d.Mach.Log("Error: client not found: %s\n", machId)
 			continue
 		}
 
 		if c.MsgStruct == nil {
-			d.Mach.Log("Error: struct missing for %s, ignoring tx\n", msg.MachineID)
+			d.Mach.Log("Error: struct missing for %s, ignoring tx\n", machId)
 			continue
 		}
+
+		// optimize space
+		msg.CalledStatesIdxs = amhelp.StatesToIndexes(c.MsgStruct.StatesIndex,
+			msg.CalledStates)
+		msg.MachineID = ""
+		msg.CalledStates = nil
 
 		// TODO scalable storage (support filtering)
 		idx := len(c.MsgTxs)
@@ -545,11 +621,11 @@ func (d *Debugger) ClientMsgState(e *am.Event) {
 		}
 	}
 
-	d.updateSidebar(false)
 	// UI updates for the selected client
 	if updateTailMode {
 		// force the latest tx
-		d.C.CursorTx = d.filterTxCursor(d.C, len(d.C.MsgTxs), false)
+		d.SetCursor(d.filterTxCursor(d.C, len(d.C.MsgTxs), false))
+		// sidebar for errs
 		d.updateViews(false)
 	}
 
@@ -559,9 +635,20 @@ func (d *Debugger) ClientMsgState(e *am.Event) {
 	}
 
 	// timelines always change
+	d.updateClientList(false)
 	d.updateTimelines()
 
 	d.draw()
+}
+
+func (d *Debugger) SetCursor(cursor int) {
+	// TODO validate
+	d.C.CursorTx = cursor
+	if cursor == 0 {
+		d.lastScrolledTxTime = time.Time{}
+	} else {
+		d.lastScrolledTxTime = *d.currentTx().Time
+	}
 }
 
 func (d *Debugger) RemoveClientEnter(e *am.Event) bool {
@@ -581,12 +668,12 @@ func (d *Debugger) RemoveClientState(e *am.Event) {
 
 	// clean up
 	delete(d.Clients, cid)
-	c.MsgStruct = nil
-	c.MsgTxs = nil
-	c.logMsgs = nil
-	c.msgTxsParsed = nil
-	c.CursorTx = 0
-	c.CursorStep = 0
+	// c.MsgStruct = nil
+	// c.MsgTxs = nil
+	// c.logMsgs = nil
+	// c.msgTxsParsed = nil
+	// d.SetCursor(0)
+	// c.CursorStep = 0
 
 	// if currently selected, switch to the first one
 	if c == d.C {
@@ -598,9 +685,9 @@ func (d *Debugger) RemoveClientState(e *am.Event) {
 		if len(d.Clients) == 0 {
 			d.Mach.Remove1(ss.ClientSelected, nil)
 		}
-		d.buildSidebar(d.sidebar.GetCurrentItemIndex() - 1)
+		d.buildClientList(d.clientList.GetCurrentItemIndex() - 1)
 	} else {
-		d.buildSidebar(-1)
+		d.buildClientList(-1)
 	}
 
 	d.draw()
@@ -623,7 +710,7 @@ func (d *Debugger) SelectingClientEnter(e *am.Event) bool {
 func (d *Debugger) SelectingClientState(e *am.Event) {
 	clientID := e.Args["Client.id"].(string)
 	fromConnected, _ := e.Args["from_connected"].(bool)
-	fromPlaying := slices.Contains(e.Transition().StatesBefore, ss.Playing)
+	fromPlaying := slices.Contains(e.Transition().StatesBefore(), ss.Playing)
 
 	if d.Clients[clientID] == nil {
 		// TODO handle err, remove state
@@ -639,8 +726,9 @@ func (d *Debugger) SelectingClientState(e *am.Event) {
 	logRebuildEnd := len(d.C.logMsgs)
 	d.logRebuildEnd = logRebuildEnd
 	// remain in TailMode after the selection
-	wasTailMode := slices.Contains(e.Transition().StatesBefore, ss.TailMode)
+	wasTailMode := slices.Contains(e.Transition().StatesBefore(), ss.TailMode)
 
+	// TODO dont fork once progressive log rendering is in place
 	go func() {
 		if ctx.Err() != nil {
 			return // expired
@@ -650,28 +738,27 @@ func (d *Debugger) SelectingClientState(e *am.Event) {
 		d.filterClientTxs()
 
 		// scroll to the same place as the prev client
-		// TODO extract
 		match := false
 		if !wasTailMode {
-			match = d.scrollToTime(d.prevClientTxTime)
+			match = d.scrollToTime(d.lastScrolledTxTime, true)
 		}
 
 		// or scroll to the last one
 		if !match {
-			d.C.CursorTx = d.filterTxCursor(d.C, len(d.C.MsgTxs), false)
+			d.SetCursor(d.filterTxCursor(d.C, len(d.C.MsgTxs), false))
 		}
 		d.C.CursorStep = 0
 		d.updateTimelines()
 		d.updateTxBars()
-		d.updateSidebar(true)
+		d.updateClientList(true)
 
 		// scroll into view
 		selOffset := d.getSidebarCurrClientIdx()
-		offset, _ := d.sidebar.GetOffset()
-		_, _, _, lines := d.sidebar.GetInnerRect()
+		offset, _ := d.clientList.GetOffset()
+		_, _, _, lines := d.clientList.GetInnerRect()
 		if selOffset-offset > lines {
-			d.sidebar.SetCurrentItem(selOffset)
-			d.updateSidebar(false)
+			d.clientList.SetCurrentItem(selOffset)
+			d.updateClientList(false)
 		}
 
 		// initial build of the states tree
@@ -735,19 +822,19 @@ func (d *Debugger) ClientSelectedState(e *am.Event) {
 		d.Mach.Add1(ss.Playing, nil)
 	}
 
-	d.updateBorderColor()
+	// re-select the state
+	if d.lastSelectedState != "" {
+		d.Mach.Add1(ss.StateNameSelected, am.A{"state": d.lastSelectedState})
+		// TODO Keep in StateNameSelected behind a flag
+		d.selectTreeState(d.lastSelectedState)
+	}
 
+	go d.focusManager.Focus(d.clientList)
+	d.updateBorderColor()
 	d.draw()
 }
 
 func (d *Debugger) ClientSelectedEnd(e *am.Event) {
-	// memorize the current tx time
-	if d.C != nil {
-		if d.C.CursorTx > 0 && d.C.CursorTx <= len(d.C.MsgTxs) {
-			d.prevClientTxTime = *d.C.MsgTxs[d.C.CursorTx-1].Time
-		}
-	}
-
 	// clean up, except when switching to SelectingClient
 	if !e.Mutation().StateWasCalled(ss.SelectingClient) {
 		d.C = nil
@@ -765,7 +852,7 @@ func (d *Debugger) HelpDialogState(_ *am.Event) {
 }
 
 func (d *Debugger) HelpDialogEnd(e *am.Event) {
-	diff := am.DiffStates(ss.GroupDialog, e.Transition().TargetStates)
+	diff := am.DiffStates(ss.GroupDialog, e.Transition().TargetStates())
 	if len(diff) == len(ss.GroupDialog) {
 		// all dialogs closed, show main
 		d.LayoutRoot.SendToFront("main")
@@ -779,7 +866,7 @@ func (d *Debugger) ExportDialogState(_ *am.Event) {
 }
 
 func (d *Debugger) ExportDialogEnd(e *am.Event) {
-	diff := am.DiffStates(ss.GroupDialog, e.Transition().TargetStates)
+	diff := am.DiffStates(ss.GroupDialog, e.Transition().TargetStates())
 	if len(diff) == len(ss.GroupDialog) {
 		// all dialogs closed, show main
 		d.LayoutRoot.SendToFront("main")
@@ -817,9 +904,10 @@ func (d *Debugger) ScrollToTxState(e *am.Event) {
 	d.Mach.Remove1(ss.ScrollToTx, nil)
 
 	cursor := e.Args["Client.cursorTx"].(int)
-	d.C.CursorTx = d.filterTxCursor(d.C, cursor, true)
+	d.SetCursor(d.filterTxCursor(d.C, cursor, true))
 	// reset the step timeline
 	d.C.CursorStep = 0
+	d.updateClientList(false)
 	d.RedrawFull(false)
 }
 
@@ -828,30 +916,22 @@ func (d *Debugger) ToggleFilterState(_ *am.Event) {
 	filterTxs := false
 
 	switch d.focusedFilter {
+	// TODO move logic after toggle to handlers
 
 	case filterCanceledTx:
-		if d.Mach.Is1(ss.FilterCanceledTx) {
-			d.Mach.Remove1(ss.FilterCanceledTx, nil)
-		} else {
-			d.Mach.Add1(ss.FilterCanceledTx, nil)
-		}
+		d.Mach.Toggle1(ss.FilterCanceledTx)
 		filterTxs = true
 
 	case filterAutoTx:
-		if d.Mach.Is1(ss.FilterAutoTx) {
-			d.Mach.Remove1(ss.FilterAutoTx, nil)
-		} else {
-			d.Mach.Add1(ss.FilterAutoTx, nil)
-		}
+		d.Mach.Toggle1(ss.FilterAutoTx)
 		filterTxs = true
 
 	case filterEmptyTx:
-		if d.Mach.Is1(ss.FilterEmptyTx) {
-			d.Mach.Remove1(ss.FilterEmptyTx, nil)
-		} else {
-			d.Mach.Add1(ss.FilterEmptyTx, nil)
-		}
+		d.Mach.Toggle1(ss.FilterEmptyTx)
 		filterTxs = true
+
+	case FilterSummaries:
+		d.Mach.Toggle1(ss.FilterSummaries)
 
 	case filterLog0:
 		d.Opts.Filters.LogLevel = am.LogNothing
@@ -868,7 +948,7 @@ func (d *Debugger) ToggleFilterState(_ *am.Event) {
 	stateCtx := d.Mach.NewStateCtx(ss.ToggleFilter)
 
 	// process the filter change
-	go d.processFilterChange(stateCtx, filterTxs)
+	go d.ProcessFilterChange(stateCtx, filterTxs)
 }
 
 func (d *Debugger) SwitchingClientTxState(e *am.Event) {
@@ -925,9 +1005,20 @@ func (d *Debugger) ScrollToMutTxState(e *am.Event) {
 
 	for i := c.CursorTx + step; i > 0 && i < len(c.MsgTxs)+1; i = i + step {
 
-		parsed := c.msgTxsParsed[i-1]
-		if !slices.Contains(parsed.StatesAdded, state) &&
-			!slices.Contains(parsed.StatesRemoved, state) {
+		msgIdx := i - 1
+		parsed := c.msgTxsParsed[msgIdx]
+		tx := c.MsgTxs[msgIdx]
+
+		// check mutations and canceled
+		if !slices.Contains(c.indexesToStates(parsed.StatesAdded), state) &&
+			!slices.Contains(c.indexesToStates(parsed.StatesRemoved), state) &&
+			!slices.Contains(tx.CalledStateNames(c.MsgStruct.StatesIndex), state) {
+
+			continue
+		}
+
+		// skip filtered out
+		if d.isFiltered() && !slices.Contains(c.msgTxsFiltered, msgIdx) {
 			continue
 		}
 
@@ -935,4 +1026,120 @@ func (d *Debugger) ScrollToMutTxState(e *am.Event) {
 		d.Mach.Add1(ss.ScrollToTx, am.A{"Client.cursorTx": i})
 		break
 	}
+
+	d.memorizeTxTime(c)
+}
+
+// ExceptionState creates a log file with the error and stack trace, after
+// calling the super exception handler.
+func (d *Debugger) ExceptionState(e *am.Event) {
+	d.ExceptionHandler.ExceptionState(e)
+
+	trace := ""
+	if errTrace, ok := e.Args["err.trace"].(string); ok {
+		trace = errTrace
+	}
+
+	d.updateBorderColor()
+
+	// create a log file
+	s := fmt.Sprintf("%s\n%s\n\n%s", time.Now(), d.Mach.Err(), trace)
+	err := os.WriteFile("am-dbg-err.log", []byte(s), 0o644)
+	if err != nil {
+		d.Mach.Log("Error: %s\n", err)
+	}
+}
+
+// TODO Enter with ParseArgs
+
+func (d *Debugger) GcMsgsState(e *am.Event) {
+	// TODO log reader entries
+	d.Mach.Remove1(ss.GcMsgs, nil)
+	// TODO ParseArgs
+	clients := e.Args["[]*Clients"].([]*Client)
+	msgs := e.Args["msgCount"].(int)
+	ctx := d.Mach.NewStateCtx(ss.GcMsgs)
+
+	// get oldest clients
+	slices.SortFunc(clients, func(c1, c2 *Client) int {
+		if len(c1.MsgTxs) == 0 || len(c2.MsgTxs) == 0 {
+			return 0
+		}
+		if (*c1.MsgTxs[0].Time).After(*c2.MsgTxs[0].Time) {
+			return 1
+		} else {
+			return -1
+		}
+	})
+
+	round := 0
+	for msgs > d.Opts.MsgMaxAmount {
+		if round > 100 {
+			d.Mach.Log("Too many GC rounds")
+
+			break
+		}
+		round++
+
+		// delete a half per client
+		for _, c := range clients {
+			if ctx.Err() != nil {
+				d.Mach.Log("Context expired")
+
+				break
+			}
+			idx := len(c.MsgTxs) / 2
+			c.MsgTxs = c.MsgTxs[idx:]
+			c.msgTxsParsed = c.msgTxsParsed[idx:]
+			c.logMsgs = c.logMsgs[idx:]
+
+			// adjust the current client
+			if d.C == c {
+				err := d.rebuildLog(ctx, len(c.MsgTxs)-1)
+				if err != nil {
+					d.Mach.AddErr(err, nil)
+				}
+				c.CursorTx = int(math.Max(0, float64(c.CursorTx-idx)))
+				// re-filter
+				if d.isFiltered() {
+					d.filterClientTxs()
+				}
+			}
+
+			// delete small clients
+			if len(c.MsgTxs) < msgMaxThreshold {
+				d.Mach.Add1(ss.RemoveClient, am.A{"Client.id": c.id})
+				msgs -= len(c.MsgTxs)
+			} else {
+				msgs -= idx
+				c.mTimeSum = 0
+				for _, m := range c.msgTxsParsed {
+					c.mTimeSum += m.TimeSum
+				}
+			}
+		}
+	}
+
+	d.RedrawFull(false)
+}
+
+func (d *Debugger) LogReaderVisibleState(e *am.Event) {
+	if d.Mach.Not1(ss.TimelineStepsFocused) {
+		d.treeLogGrid.UpdateItem(d.log, 0, 2, 1, 2, 0, 0, false)
+		d.treeLogGrid.AddItem(d.logReader, 0, 4, 1, 2, 0, 0, false)
+	} else {
+		d.treeLogGrid.UpdateItem(d.log, 0, 3, 1, 2, 0, 0, false)
+		d.treeLogGrid.AddItem(d.logReader, 0, 5, 1, 1, 0, 0, false)
+	}
+	d.updateFocusable()
+}
+
+func (d *Debugger) LogReaderVisibleEnd(e *am.Event) {
+	if d.Mach.Not1(ss.TimelineStepsFocused) {
+		d.treeLogGrid.UpdateItem(d.log, 0, 2, 1, 4, 0, 0, false)
+	} else {
+		d.treeLogGrid.UpdateItem(d.log, 0, 3, 1, 3, 0, 0, false)
+	}
+	d.treeLogGrid.RemoveItem(d.logReader)
+	d.updateFocusable()
 }

--- a/tools/debugger/log.go
+++ b/tools/debugger/log.go
@@ -2,6 +2,7 @@ package debugger
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"strings"
@@ -10,12 +11,17 @@ import (
 	"github.com/pancsta/cview"
 	"golang.org/x/exp/maps"
 
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 )
 
 func (d *Debugger) updateLog(immediate bool) {
+	d.updateLogReader()
+
 	if immediate {
 		go d.doUpdateLog()
 		return
@@ -26,6 +32,7 @@ func (d *Debugger) updateLog(immediate bool) {
 	}
 
 	go func() {
+		// TODO amg.Wait
 		time.Sleep(logUpdateDebounce)
 		d.doUpdateLog()
 		d.draw()
@@ -46,7 +53,7 @@ func (d *Debugger) doUpdateLog() {
 		title := " Log:" + d.Opts.Filters.LogLevel.String() + " "
 		if tx != nil {
 			// TODO panic -1
-			t := strconv.Itoa(int(c.msgTxsParsed[c.CursorTx-1].Time))
+			t := strconv.Itoa(int(c.msgTxsParsed[c.CursorTx-1].TimeSum))
 			title += "Time:" + t + " "
 		}
 		d.log.SetTitle(title)
@@ -90,25 +97,34 @@ func (d *Debugger) doUpdateLog() {
 	}
 }
 
-func (d *Debugger) parseMsgLog(c *Client, msgTx *telemetry.DbgMsgTx) {
-	parsed := make([]*am.LogEntry, 0)
+func (d *Debugger) parseMsgLog(c *Client, msgTx *telemetry.DbgMsgTx, idx int) {
+	logEntries := make([]*am.LogEntry, 0)
+
+	tx := c.MsgTxs[idx]
+	var readerEntries []*logReaderEntryPtr
+	if idx > 0 {
+		readerEntries = slices.Clone(c.msgTxsParsed[idx-1].ReaderEntries)
+	}
 
 	// pre-tx log entries
 	for _, entry := range msgTx.PreLogEntries {
+		readerEntries = d.parseMsgReader(c, entry, readerEntries, tx)
 		if pe := d.parseMsgLogEntry(c, entry); pe != nil {
-			parsed = append(parsed, pe)
+			logEntries = append(logEntries, pe)
 		}
 	}
 
 	// tx log entries
 	for _, entry := range msgTx.LogEntries {
+		readerEntries = d.parseMsgReader(c, entry, readerEntries, tx)
 		if pe := d.parseMsgLogEntry(c, entry); pe != nil {
-			parsed = append(parsed, pe)
+			logEntries = append(logEntries, pe)
 		}
 	}
 
 	// store the parsed log
-	c.logMsgs = append(c.logMsgs, parsed)
+	c.logMsgs = append(c.logMsgs, logEntries)
+	c.msgTxsParsed[idx].ReaderEntries = readerEntries
 }
 
 func (d *Debugger) parseMsgLogEntry(
@@ -125,6 +141,7 @@ func (d *Debugger) parseMsgLogEntry(
 	return &am.LogEntry{Level: lvl, Text: t}
 }
 
+// TODO progressive rendering
 func (d *Debugger) rebuildLog(ctx context.Context, endIndex int) error {
 	d.log.Clear()
 	var buf []byte
@@ -181,10 +198,12 @@ func (d *Debugger) appendLogEntry(index int) error {
 func (d *Debugger) getLogEntryTxt(index int) []byte {
 	c := d.C
 	ret := ""
+	tx := c.MsgTxs[index]
 
-	if index > 0 {
-		msgTime := c.MsgTxs[index].Time
-		prevMsgTime := c.MsgTxs[index-1].Time
+	if index > 0 && d.Mach.Not1(ss.FilterSummaries) {
+		msgTime := tx.Time
+		prevMsg := c.MsgTxs[index-1]
+		prevMsgTime := prevMsg.Time
 		if prevMsgTime.Second() != msgTime.Second() {
 			// grouping labels (per second)
 			ret += `[grey]` + msgTime.Format(timeFormat) + "[-]\n"
@@ -210,8 +229,25 @@ func (d *Debugger) getLogEntryTxt(index int) []byte {
 	}
 
 	// create a highlight region (even for empty txs)
-	txId := c.MsgTxs[index].ID
+	txId := tx.ID
 	ret = `["` + txId + `"]` + ret + `[""]`
+
+	// state string
+	if d.Mach.Not1(ss.FilterSummaries) {
+		parsed := c.msgTxsParsed[index]
+		if len(parsed.StatesAdded) > 0 || len(parsed.StatesRemoved) > 0 {
+			str := tx.String(c.MsgStruct.StatesIndex)
+
+			// highlight new states
+			for _, name := range c.indexesToStates(parsed.StatesAdded) {
+				str = strings.ReplaceAll(
+					strings.ReplaceAll(str,
+						"("+name, "([::b]"+name+"[::-]"),
+					" "+name, " [::b]"+name+"[::-]")
+			}
+			ret += `[grey]` + str + "[-]\n"
+		}
+	}
 
 	return []byte(ret)
 }
@@ -232,16 +268,17 @@ func fmtLogEntry(entry string, machStruct am.Struct) string {
 		}
 
 		// color the first brackets per each line
+		// TODO color only the first line
 		s = strings.Replace(strings.Replace(s,
 			"]", prefixEnd, 1),
 			"[", "[yellow][", 1)
 		start := strings.Index(s, prefixEnd) + len(prefixEnd)
 		left, right := s[:start], s[start:]
-
+		if strings.Contains(s, "[test]") {
+			print("")
+		}
 		// escape the rest
-		ret += left + strings.ReplaceAll(strings.ReplaceAll(right,
-			"]", cview.Escape("]")),
-			"[", cview.Escape("[")) + "\n"
+		ret += left + cview.Escape(right) + "\n"
 	}
 
 	// highlight state names (in the msg body)
@@ -267,4 +304,534 @@ func fmtLogEntry(entry string, machStruct am.Struct) string {
 	}
 
 	return strings.Trim(ret, " \n	") + "\n"
+}
+
+// ///// LOG READER
+
+type logReaderKind int
+
+const (
+	logReaderCtx logReaderKind = iota + 1
+	logReaderWhen
+	logReaderWhenNot
+	logReaderWhenTime
+	logReaderWhenArgs
+	logReaderPipeIn
+	logReaderPipeOut
+	// TODO mentions of machine IDs
+	// logReaderMention
+)
+
+type logReaderEntry struct {
+	kind   logReaderKind
+	states []int
+	// createdAt is machine time when this entry was created
+	createdAt uint64
+	// closedAt is human time when this entry was closed, so it can be disposed.
+	closedAt time.Time
+
+	// per-type fields
+
+	// pipe is for logReaderPipeIn, logReaderPipeOut
+	pipe am.MutationType
+	// mach is for logReaderPipeIn, logReaderPipeOut, logReaderMention
+	mach string
+	// ticks is for logReaderWhenTime only
+	ticks am.Time
+	// args is for logReaderWhenArgs only
+	args string
+}
+
+type logReaderEntryPtr struct {
+	txId     string
+	entryIdx int
+}
+
+type logReaderTreeRef struct {
+	expanded bool
+
+	// refs
+	stateNames am.S
+	machId     string
+
+	// position
+	entry *logReaderEntryPtr
+	// child int // TODO
+}
+
+func (d *Debugger) initLogReader() *cview.TreeView {
+	root := cview.NewTreeNode("Extracted")
+	root.SetColor(colorHighlight3)
+	root.SetText("[grey]Extracted:")
+	root.SetIndent(0)
+	root.SetReference(&logReaderTreeRef{})
+
+	tree := cview.NewTreeView()
+	tree.SetRoot(root)
+	tree.SetCurrentNode(root)
+	// tree.SetHighlightColor(colorHighlight)
+
+	tree.SetChangedFunc(func(node *cview.TreeNode) {
+		ref := node.GetReference().(*logReaderTreeRef)
+
+		if d.C != nil {
+			d.C.SelectedReaderEntry = ref.entry
+		}
+
+		// state name
+		if len(ref.stateNames) < 1 {
+			d.Mach.Remove1(ss.StateNameSelected, nil)
+		} else {
+			d.Mach.Add1(ss.StateNameSelected, am.A{
+				"state": ref.stateNames[0],
+			})
+		}
+	})
+
+	tree.SetSelectedFunc(func(node *cview.TreeNode) {
+		ref := node.GetReference().(*logReaderTreeRef)
+		if ref.machId != "" {
+			d.Mach.Add1(ss.SelectingClient, am.A{"Client.id": ref.machId})
+		}
+
+		node.SetExpanded(!node.IsExpanded())
+	})
+
+	return tree
+}
+
+func (d *Debugger) updateLogReader() {
+	if d.Mach.Not1(ss.LogReaderVisible) {
+		return
+	}
+
+	root := d.logReader.GetRoot()
+	root.ClearChildren()
+
+	c := d.C
+	if c == nil || c.CursorTx < 1 {
+		return
+	}
+
+	tx := c.msgTxsParsed[c.CursorTx-1]
+	allStates := c.MsgStruct.StatesIndex
+
+	// parents
+	var parentCtx *cview.TreeNode
+	var parentWhen *cview.TreeNode
+	var parentWhenNot *cview.TreeNode
+	var parentWhenTime *cview.TreeNode
+	var parentWhenArgs *cview.TreeNode
+	var parentPipeIn *cview.TreeNode
+	var parentPipeOut *cview.TreeNode
+
+	for _, ptr := range tx.ReaderEntries {
+		entries, ok := c.logReader[ptr.txId]
+		var node *cview.TreeNode
+		if !ok || ptr.entryIdx >= len(entries) {
+			node = cview.NewTreeNode("err:GCed entry")
+			node.SetIndent(1)
+		} else {
+			entry := entries[ptr.entryIdx]
+			// create nodes and parents
+			switch entry.kind {
+
+			case logReaderCtx:
+				if parentCtx == nil {
+					parentCtx = cview.NewTreeNode("StateCtx")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					utils.J(states), entry.createdAt))
+				node.SetIndent(1)
+				// TODO
+				node.SetReference(&logReaderTreeRef{stateNames: states})
+				parentCtx.AddChild(node)
+
+			case logReaderWhen:
+				if parentWhen == nil {
+					parentWhen = cview.NewTreeNode("When")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					utils.J(states), entry.createdAt))
+				node.SetIndent(1)
+				parentWhen.AddChild(node)
+
+			case logReaderWhenNot:
+				if parentWhenNot == nil {
+					parentWhenNot = cview.NewTreeNode("WhenNot")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					utils.J(states), entry.createdAt))
+				node.SetIndent(1)
+				parentWhenNot.AddChild(node)
+
+			case logReaderWhenTime:
+				if parentWhenTime == nil {
+					parentWhenTime = cview.NewTreeNode("WhenTime")
+				}
+				txt := ""
+				for i, idx := range entry.states {
+					txt += fmt.Sprintf("[::b]%s[::-]:%d ", allStates[idx],
+						entry.ticks[i])
+				}
+				node = cview.NewTreeNode(d.P.Sprintf("%s[grey]t%d[-]", txt,
+					entry.createdAt))
+				node.SetIndent(1)
+				parentWhenTime.AddChild(node)
+
+			case logReaderWhenArgs:
+				if parentWhenArgs == nil {
+					parentWhenArgs = cview.NewTreeNode("WhenArgs")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					utils.J(states), entry.createdAt))
+				node2 := cview.NewTreeNode(d.P.Sprintf("%s", entry.args))
+				node2.SetIndent(1)
+				node2.SetReference(&logReaderTreeRef{entry: ptr})
+				node.SetIndent(1)
+				node.AddChild(node2)
+				parentWhenArgs.AddChild(node)
+
+			case logReaderPipeIn:
+				if parentPipeIn == nil {
+					parentPipeIn = cview.NewTreeNode("Pipe-in")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					states[0],
+					entry.createdAt))
+				node2 := cview.NewTreeNode(d.P.Sprintf("%-6s | %s",
+					capitalizeFirst(entry.pipe.String()), entry.mach))
+				node2.SetIndent(1)
+				node2.SetReference(&logReaderTreeRef{entry: ptr, machId: entry.mach})
+				node.SetIndent(1)
+				node.AddChild(node2)
+				parentPipeIn.AddChild(node)
+
+			case logReaderPipeOut:
+				if parentPipeOut == nil {
+					parentPipeOut = cview.NewTreeNode("Pipe-out")
+				}
+				states := amhelp.IndexesToStates(allStates, entry.states)
+				node = cview.NewTreeNode(d.P.Sprintf("[::b]%s[::-] [grey]t%d[-]",
+					states[0], entry.createdAt))
+				node2 := cview.NewTreeNode(d.P.Sprintf("%-6s | %s",
+					capitalizeFirst(entry.pipe.String()), entry.mach))
+				node2.SetIndent(1)
+				node2.SetReference(&logReaderTreeRef{entry: ptr, machId: entry.mach})
+				node.SetIndent(1)
+				node.AddChild(node2)
+				parentPipeOut.AddChild(node)
+
+			default:
+				continue
+			}
+
+			node.SetSelectable(true)
+			node.SetReference(&logReaderTreeRef{
+				stateNames: c.indexesToStates(entry.states),
+				machId:     entry.mach,
+				entry:      ptr,
+			})
+
+			sel := c.SelectedReaderEntry
+			if sel != nil && ptr.txId == sel.txId && ptr.entryIdx == sel.entryIdx {
+				d.logReader.SetCurrentNode(node)
+			}
+		}
+	}
+
+	addParent := func(parent *cview.TreeNode) {
+		count := len(parent.GetChildren())
+		parent.SetText(fmt.Sprintf("[%s]%s[-] (%d)", colorActive, parent.GetText(),
+			count))
+		parent.SetIndent(0)
+		parent.SetReference(&logReaderTreeRef{})
+		root.AddChild(parent)
+		if d.C.ReaderCollapsed {
+			parent.SetExpanded(false)
+		}
+	}
+
+	// append parents
+	if parentCtx != nil {
+		addParent(parentCtx)
+	}
+	if parentWhen != nil {
+		addParent(parentWhen)
+	}
+	if parentWhenNot != nil {
+		addParent(parentWhenNot)
+	}
+	if parentWhenTime != nil {
+		addParent(parentWhenTime)
+	}
+	if parentWhenArgs != nil {
+		addParent(parentWhenArgs)
+	}
+	if parentPipeIn != nil {
+		addParent(parentPipeIn)
+	}
+	if parentPipeOut != nil {
+		addParent(parentPipeOut)
+	}
+
+	// expand all nodes
+	root.CollapseAll()
+	root.Expand()
+}
+
+func (d *Debugger) parseMsgReader(
+	c *Client, log *am.LogEntry, txEntries []*logReaderEntryPtr,
+	tx *telemetry.DbgMsgTx,
+) []*logReaderEntryPtr {
+	// TODO pipes
+
+	// NEW
+
+	if strings.HasPrefix(log.Text, "[when:new] ") {
+
+		// [when:new] Foo,Bar
+		states := strings.Split(log.Text[len("[when:new] "):], " ")
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      logReaderWhen,
+			states:    c.statesToIndexes(states),
+			createdAt: c.mTimeSum,
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else if strings.HasPrefix(log.Text, "[whenNot:new] ") {
+
+		// [when:new] Foo,Bar
+		states := strings.Split(log.Text[len("[whenNot:new] "):], " ")
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      logReaderWhenNot,
+			states:    c.statesToIndexes(states),
+			createdAt: c.mTimeSum,
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else if strings.HasPrefix(log.Text, "[whenTime:new] ") {
+
+		// [whenTime:new] Foo,Bar [1 2]
+		msg := strings.Split(log.Text[len("[whenTime:new] "):], " ")
+		states := strings.Split(msg[0], ",")
+		ticksStr := strings.Split(msg[1], ",")
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      logReaderWhenTime,
+			states:    c.statesToIndexes(states),
+			ticks:     tickStrToTime(d.Mach, ticksStr),
+			createdAt: c.mTimeSum,
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else if strings.HasPrefix(log.Text, "[ctx:new] ") {
+
+		// [ctx:new] Foo
+		state := log.Text[len("[ctx:new] "):]
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      logReaderCtx,
+			states:    c.statesToIndexes(am.S{state}),
+			createdAt: c.mTimeSum,
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else if strings.HasPrefix(log.Text, "[whenArgs:new] ") {
+
+		// [whenArgs:match] Foo (arg1,arg2)
+		msg := strings.Split(log.Text[len("[whenArgs:new] "):], " ")
+		args := strings.Trim(msg[1], "()")
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      logReaderWhenArgs,
+			states:    c.statesToIndexes(am.S{msg[0]}),
+			createdAt: c.mTimeSum,
+			args:      args,
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else if strings.HasPrefix(log.Text, "[pipe-in:add] ") ||
+		strings.HasPrefix(log.Text, "[pipe-in:remove] ") ||
+		strings.HasPrefix(log.Text, "[pipe-out:add] ") ||
+		strings.HasPrefix(log.Text, "[pipe-out:remove] ") {
+
+		isAdd := strings.HasPrefix(log.Text, "[pipe-in:add] ") ||
+			strings.HasPrefix(log.Text, "[pipe-out:add] ")
+		isOut := strings.HasPrefix(log.Text, "[pipe-out")
+
+		// [add:pipe] Foo to Mach2
+		var msg []string
+		if isOut && isAdd {
+			msg = strings.Split(log.Text[len("[pipe-out:add] "):], " to ")
+		} else if !isOut && isAdd {
+			msg = strings.Split(log.Text[len("[pipe-in:add] "):], " from ")
+		} else if isOut && !isAdd {
+			msg = strings.Split(log.Text[len("[pipe-out:remove] "):], " to ")
+		} else if !isOut && !isAdd {
+			msg = strings.Split(log.Text[len("[pipe-in:remove] "):], " from ")
+		}
+		kind := logReaderPipeIn
+		if isOut {
+			kind = logReaderPipeOut
+		}
+		mut := am.MutationRemove
+		if isAdd {
+			mut = am.MutationAdd
+		}
+
+		idx := c.addReaderEntry(tx.ID, &logReaderEntry{
+			kind:      kind,
+			pipe:      mut,
+			states:    c.statesToIndexes(am.S{msg[0]}),
+			createdAt: c.mTimeSum,
+			mach:      msg[1],
+		})
+		txEntries = append(txEntries, &logReaderEntryPtr{tx.ID, idx})
+
+	} else
+
+	//
+
+	// MATCH (delete the oldest one)
+
+	//
+
+	if strings.HasPrefix(log.Text, "[when:match] ") {
+
+		// [when:match] Foo,Bar
+		states := strings.Split(log.Text[len("[when:match] "):], ",")
+		found := false
+
+		for i, ptr := range txEntries {
+			entry := c.getReaderEntry(ptr.txId, ptr.entryIdx)
+
+			// matched, delete and mark
+			if entry != nil && entry.kind == logReaderWhen &&
+				am.StatesEqual(states, c.indexesToStates(entry.states)) {
+
+				txEntries = slices.Delete(txEntries, i, i+1)
+				entry.closedAt = *tx.Time
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			d.Mach.Log("err: match missing: " + log.Text)
+		}
+
+	} else if strings.HasPrefix(log.Text, "[whenNot:match] ") {
+
+		// [whenNot:match] Foo,Bar
+		states := strings.Split(log.Text[len("[whenNot:match] "):], ",")
+		found := false
+
+		for i, ptr := range txEntries {
+			entry := c.getReaderEntry(ptr.txId, ptr.entryIdx)
+
+			// matched, delete and mark
+			if entry != nil && entry.kind == logReaderWhenNot &&
+				am.StatesEqual(states, c.indexesToStates(entry.states)) {
+
+				txEntries = slices.Delete(txEntries, i, i+1)
+				entry.closedAt = *tx.Time
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			d.Mach.Log("err: match missing: " + log.Text)
+		}
+
+	} else if strings.HasPrefix(log.Text, "[whenTime:match] ") {
+
+		// [whenTime:match] Foo,Bar [1 2]
+		msg := strings.Split(log.Text[len("[whenTime:match] "):], " ")
+		states := strings.Split(msg[0], ",")
+		ticksStr := strings.Split(strings.Trim(msg[1], "[]"), " ")
+		ticks := tickStrToTime(d.Mach, ticksStr)
+		found := false
+
+		for i, ptr := range txEntries {
+			entry := c.getReaderEntry(ptr.txId, ptr.entryIdx)
+
+			// matched, delete and mark
+			if entry != nil && entry.kind == logReaderWhenTime &&
+				am.StatesEqual(states, c.indexesToStates(entry.states)) &&
+				slices.Equal(ticks, entry.ticks) {
+
+				txEntries = slices.Delete(txEntries, i, i+1)
+				entry.closedAt = *tx.Time
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			d.Mach.Log("err: match missing: " + log.Text)
+		}
+
+	} else if strings.HasPrefix(log.Text, "[ctx:match] ") {
+
+		// [ctx:match] Foo
+		state := log.Text[len("[ctx:match] "):]
+		found := false
+
+		for i, ptr := range txEntries {
+			entry := c.getReaderEntry(ptr.txId, ptr.entryIdx)
+
+			// matched, delete and mark
+			if entry != nil && entry.kind == logReaderCtx &&
+				am.StatesEqual(am.S{state}, c.indexesToStates(entry.states)) {
+
+				txEntries = slices.Delete(txEntries, i, i+1)
+				entry.closedAt = *tx.Time
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			d.Mach.Log("err: match missing: " + log.Text)
+		}
+	} else if strings.HasPrefix(log.Text, "[whenArgs:match] ") {
+
+		// [whenArgs:match] Foo (arg1,arg2)
+		msg := strings.Split(log.Text[len("[whenArgs:match] "):], " ")
+		args := strings.Trim(msg[1], "()")
+		found := false
+
+		for i, ptr := range txEntries {
+			entry := c.getReaderEntry(ptr.txId, ptr.entryIdx)
+
+			// matched, delete and mark
+			// TODO match arg names
+			if entry != nil && entry.kind == logReaderWhenArgs &&
+				am.StatesEqual(am.S{msg[0]}, c.indexesToStates(entry.states)) &&
+				entry.args == args {
+
+				txEntries = slices.Delete(txEntries, i, i+1)
+				entry.closedAt = *tx.Time
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			d.Mach.Log("err: match missing: " + log.Text)
+		}
+	}
+
+	// TODO detached pipe handlers
+
+	return txEntries
 }

--- a/tools/debugger/utils.go
+++ b/tools/debugger/utils.go
@@ -4,8 +4,11 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"unicode"
 
 	"github.com/pancsta/cview"
+
+	"github.com/pancsta/asyncmachine-go/pkg/machine"
 
 	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
 )
@@ -21,8 +24,7 @@ type filter struct {
 	active bool
 }
 
-var humanSortRE = regexp.MustCompile(`[0-9]+`)
-
+// TODO migrate to Provide-Delivered
 func RpcGetter(d *Debugger) func(string) any {
 	// TODO make it panic-safe (check states and nils)
 	return func(name string) any {
@@ -56,6 +58,8 @@ func formatTxBarTitle(title string) string {
 	return "[::u]" + title + "[::-]"
 }
 
+var digitsRe = regexp.MustCompile(`[0-9]+`)
+
 func humanSort(strs []string) {
 	sort.Slice(strs, func(i, j int) bool {
 		// skip overlapping parts
@@ -68,16 +72,15 @@ func humanSort(strs []string) {
 			firstDiff++
 		}
 
-		// if no numbers - compare as strings
-		posI := humanSortRE.FindStringIndex(strs[i][firstDiff:])
-		posJ := humanSortRE.FindStringIndex(strs[j][firstDiff:])
-		if len(posI) <= 0 || len(posJ) <= 0 || posI[0] != posJ[0] {
+		// if the diff is a letter, compare as strings
+		if !unicode.IsDigit(getRuneAt(strs[i], firstDiff)) ||
+			!unicode.IsDigit(getRuneAt(strs[j], firstDiff)) {
 			return strs[i] < strs[j]
 		}
 
 		// if contains numbers - sort by numbers
-		numsI := humanSortRE.FindAllString(strs[i][firstDiff:], -1)
-		numsJ := humanSortRE.FindAllString(strs[j][firstDiff:], -1)
+		numsI := digitsRe.FindAllString(strs[i][firstDiff:], -1)
+		numsJ := digitsRe.FindAllString(strs[j][firstDiff:], -1)
 		numI, _ := strconv.Atoi(numsI[0])
 		numJ, _ := strconv.Atoi(numsJ[0])
 
@@ -89,6 +92,13 @@ func humanSort(strs []string) {
 		// If the numbers are the same, order lexicographically
 		return strs[i] < strs[j]
 	})
+}
+
+func getRuneAt(s string, pos int) rune {
+	if pos < 0 || pos >= len(s) {
+		return 0 // or handle the error as needed
+	}
+	return []rune(s)[pos]
 }
 
 func matrixCellVal(strVal string) string {
@@ -106,7 +116,42 @@ func matrixEmptyRow(d *Debugger, row, colsCount, highlightIndex int) {
 	for ii := 0; ii < colsCount; ii++ {
 		d.matrix.SetCellSimple(row, ii, "   ")
 		if ii == highlightIndex {
-			d.matrix.GetCell(row, ii).SetBackgroundColor(colorHighlight)
+			d.matrix.GetCell(row, ii).SetBackgroundColor(colorHighlight3)
 		}
 	}
+}
+
+// findFirstDiff returns the index of the first differing character between two
+// strings. If the strings are identical, it returns -1.
+func findFirstDiff(s1, s2 string) int {
+	minLen := len(s1)
+	if len(s2) < minLen {
+		minLen = len(s2)
+	}
+
+	for i := 0; i < minLen; i++ {
+		if s1[i] != s2[i] {
+			return i
+		}
+	}
+
+	if len(s1) != len(s2) {
+		return minLen
+	}
+
+	return -1
+}
+
+func tickStrToTime(mach *machine.Machine, ticksStr []string) machine.Time {
+	ticks := make(machine.Time, len(ticksStr))
+	for i, t := range ticksStr {
+		v, err := strconv.Atoi(t)
+		if err != nil {
+			mach.AddErr(err, nil)
+			continue
+		}
+		ticks[i] = uint64(v)
+	}
+
+	return ticks
 }


### PR DESCRIPTION
Highlights:
- error support
- log reader
- GC

This is a big release for the debugger, as requirements have risen with the introduction of `pkg/node` and an efficient error detection become neccessary. Log reader will show whats happening under the hood (subscription, pipes, ctxs), allowing to focus on `LogChanges` logs only, while garbadge collection of old messages allows the app to be open indefinitely.

![log reader](https://pancsta.github.io/assets/asyncmachine-go/am-dbg-reader.png)

![log reader](https://pancsta.github.io/assets/asyncmachine-go/am-dbg-rain.png)

Full changelog:
- fix: fix log highlights
- fix: fix filters
- feat: add state jump support filters
- feat: add state jump support called states
- feat: add rain view timestamps
- feat: state tree resize for steps
- feat: add hide summaries filter
- fix: fix [] escaping
- fix: skip collapsed nodes when tree type-search
- fix: make type-search start from current position
- feat: GC old messages
- feat: optimize space
- feat: mark errors on the rain
- feat: mark recent errors in the client list
- feat: mark Start and Ready in client list
- feat: preserve timeline position across clients
- feat: skip binding rpc with `-l -1`
- feat: show tx numbers till current H time in client list
- feat: align numbers in tree and sidebar
- feat: import data from URLs
- feat: add log reader
- fix: export to file not saving
- feat: support parents in client list
- feat: add rain support filters
