### PR TITLE
test: add source param to /pkg/helpers

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -148,9 +148,11 @@ tasks:
       - go test -tags test_worker
           ./tools/debugger/test/remote {{.CLI_ARGS}}
 
+  precommit:
+    cmd: .git/hooks/pre-commit
+
   clean:
-    cmds:
-      - go clean -testcache
+    cmd: go clean -testcache
 
   cloc-go:
     cmd: gocloc --output-type json . |

--- a/pkg/helpers/testing/test_help.go
+++ b/pkg/helpers/testing/test_help.go
@@ -42,7 +42,9 @@ func MachDebugEnv(t *stdtest.T, mach am.Api) {
 
 // Wait is a test version of [amhelp.Wait], which errors instead of returning
 // false.
-func Wait(t *stdtest.T, ctx context.Context, length time.Duration) {
+func Wait(
+	t *stdtest.T, errMsg string, ctx context.Context, length time.Duration,
+) {
 	if !amhelp.Wait(ctx, length) {
 		t.Fatal("ctx expired")
 	}
@@ -51,31 +53,33 @@ func Wait(t *stdtest.T, ctx context.Context, length time.Duration) {
 // WaitForAll is a test version of [amhelp.WaitForAll], which errors instead of
 // returning an error.
 func WaitForAll(
-	t *stdtest.T, ctx context.Context, timeout time.Duration,
+	t *stdtest.T, source string, ctx context.Context, timeout time.Duration,
 	chans ...<-chan struct{},
 ) {
 	if err := amhelp.WaitForAll(ctx, timeout, chans...); err != nil {
-		t.Fatal(err)
+		t.Fatal("error for " + source + ": " + err.Error())
 	}
 }
 
 // WaitForErrAll is a test version of [amhelp.WaitForErrAll], which errors
 // instead of returning an error.
 func WaitForErrAll(
-	t *stdtest.T, ctx context.Context, mach *am.Machine, timeout time.Duration,
-	chans ...<-chan struct{},
+	t *stdtest.T, source string, ctx context.Context, mach *am.Machine,
+	timeout time.Duration, chans ...<-chan struct{},
 ) {
 	if err := amhelp.WaitForErrAll(ctx, timeout, mach, chans...); err != nil {
-		t.Fatal(err)
+		t.Fatal("error for " + source + ": " + err.Error())
 	}
 }
 
 // WaitForAny is a test version of [amhelp.WaitForAny], which errors instead of
 // returning an error.
-func WaitForAny(t *stdtest.T, ctx context.Context, timeout time.Duration,
-	chans ...<-chan struct{}) {
+func WaitForAny(
+	t *stdtest.T, source string, ctx context.Context, timeout time.Duration,
+	chans ...<-chan struct{},
+) {
 	if err := amhelp.WaitForAny(ctx, timeout, chans...); err != nil {
-		t.Fatal(err)
+		t.Fatal("error for " + source + ": " + err.Error())
 	}
 }
 

--- a/pkg/node/node_worker.go
+++ b/pkg/node/node_worker.go
@@ -52,6 +52,8 @@ type Worker struct {
 	PublicRpc *rpc.Server
 }
 
+// NewWorker initializes a new Worker instance and returns it, or an error if
+// validation fails.
 func NewWorker(ctx context.Context, kind string, workerStruct am.Struct,
 	stateNames am.S, opts *WorkerOpts,
 ) (*Worker, error) {
@@ -284,10 +286,13 @@ func (w *Worker) SendPayloadEnter(e *am.Event) bool {
 
 // ///// ///// /////
 
+// Start initiates the worker state machine with the given local address.
 func (w *Worker) Start(localAddr string) am.Result {
 	return w.Mach.Add1(ssW.Start, Pass(&A{LocalAddr: localAddr}))
 }
 
+// Stop halts the worker's state machine and optionally disposes of its
+// resources based on the dispose flag.
 func (w *Worker) Stop(dispose bool) {
 	w.Mach.Remove1(ssW.Start, Pass(&A{Dispose: dispose}))
 }

--- a/pkg/node/supervisor.go
+++ b/pkg/node/supervisor.go
@@ -113,6 +113,8 @@ type Supervisor struct {
 	SuperSendPayloadState  am.HandlerFinal
 }
 
+// NewSupervisor initializes and returns a new Supervisor instance with
+// specified context, worker attributes, and options.
 func NewSupervisor(
 	ctx context.Context, workerKind string, workerBin []string,
 	workerStruct am.Struct, workerSNames am.S, opts *SupervisorOpts,

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -417,7 +417,7 @@ func TestRetryCall(t *testing.T) {
 	c.tmpTestErr = fmt.Errorf("IGNORE MOCK ERR")
 	whenRetrying := c.Mach.When1(ssrpc.ClientStates.RetryingCall, nil)
 	c.Worker.Add1(sstest.A, nil)
-	amhelpt.WaitForAll(t, ctx, 2*time.Second, whenRetrying)
+	amhelpt.WaitForAll(t, "RetryingCall", ctx, 2*time.Second, whenRetrying)
 
 	assert.True(t, s.Mach.Is1(ssrpc.ServerStates.Ready), "Server ready")
 	assert.True(t, s.Mach.Is1(ssrpc.ClientStates.Ready), "Client ready")
@@ -473,7 +473,7 @@ func TestRetryConn(t *testing.T) {
 
 	// client ready
 	c.Start()
-	amhelpt.WaitForAll(t, ctx, 3*time.Second,
+	amhelpt.WaitForAll(t, "client-server Ready", ctx, 3*time.Second,
 		c.Mach.When1(ssC.Ready, ctx),
 		s.Mach.When1(ssS.Ready, ctx))
 
@@ -710,7 +710,7 @@ func TestMux(t *testing.T) {
 	amhelpt.MachDebugEnv(t, mux.Mach)
 	mux.Listener = listener
 	mux.Start()
-	amhelpt.WaitForAll(t, ctx, 2*time.Second,
+	amhelpt.WaitForAll(t, "mux Ready", ctx, 2*time.Second,
 		mux.Mach.When1(ssM.Ready, nil))
 
 	var clients []*Client
@@ -727,7 +727,7 @@ func TestMux(t *testing.T) {
 	}
 
 	// wait for all clients to be ready
-	amhelpt.WaitForAll(t, ctx, 2*time.Second,
+	amhelpt.WaitForAll(t, "group Ready", ctx, 2*time.Second,
 		amhelpt.GroupWhen1(t, clientsApi, ssC.Ready, nil)...)
 
 	for _, w := range cWorkers {
@@ -739,7 +739,7 @@ func TestMux(t *testing.T) {
 	clients[0].Worker.Add1(sstest.C, nil)
 
 	// wait for all clients to get the new state
-	amhelpt.WaitForAll(t, ctx, 2*time.Second,
+	amhelpt.WaitForAll(t, "cWorkers A", ctx, 2*time.Second,
 		// TODO use v2 state def
 		amhelpt.GroupWhen1(t, cWorkers, sstest.A, nil)...)
 
@@ -829,11 +829,12 @@ func NewTest(
 
 	// server start
 	s.Start()
-	amhelpt.WaitForAll(t, ctx, 3*time.Second, s.Mach.When1(ssS.RpcReady, ctx))
+	amhelpt.WaitForAll(t, "RpcReady", ctx, 3*time.Second,
+		s.Mach.When1(ssS.RpcReady, ctx))
 
 	// client ready
 	c.Start()
-	amhelpt.WaitForAll(t, ctx, 3*time.Second,
+	amhelpt.WaitForAll(t, "client-server Ready", ctx, 3*time.Second,
 		c.Mach.When1(ssC.Ready, ctx),
 		s.Mach.When1(ssS.Ready, ctx))
 


### PR DESCRIPTION
Fixes ambiguous timeout msgs in test logs.