### PR TITLE
feat(am-dbg): show tx handlers in log reader

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -35,6 +35,7 @@ type Machine struct {
 	// Maximum number of mutations that can be queued. Default: 1000.
 	QueueLimit int
 	// If true, the machine has been Disposed and is no-op. Read-only.
+	// TODO refac: priv
 	Disposed atomic.Bool
 
 	// Unique ID of this machine. Default: random. Read-only.
@@ -369,6 +370,7 @@ func (m *Machine) dispose(force bool) {
 	m.tracers = nil
 	go func() {
 		time.Sleep(100 * time.Millisecond)
+		// TODO races with handlerLoop
 		closeSafe(m.handlerEnd)
 		closeSafe(m.handlerPanic)
 		closeSafe(m.handlerStart)
@@ -1306,7 +1308,7 @@ func (m *Machine) BindHandlers(handlers any) error {
 		var err error
 		methodNames, err = ListHandlers(handlers, m.stateNames)
 		if err != nil {
-			return err
+			return fmt.Errorf("error listing handlers: %w", err)
 		}
 	}
 

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -822,8 +822,8 @@ func (h *TestHandlerStateInfoHandlers) DEnter(e *Event) {
 		"provide the target states of the transition")
 	assert.True(t, e.Mutation().StateWasCalled("D"),
 		"provide the called states of the transition")
-	txStrExp := "D -> requested\nD -> set\nA -> remove\nAhandler   (AExit)\n" +
-		"D -> Ahandler   (AD)\nAny -> Ahandler   (AAny)\nD -> Anyhandler   (AnyD)"
+	txStrExp := "D (requested)\nD (set)\nA (remove)\nA (handler)\n" +
+		"A -> D (handler)\nA -> Any (handler)\nAny -> D (handler)"
 	txStr := e.Transition().String()
 	assert.Equal(t, txStrExp, txStr,
 		"provide a string version of the transition")

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -227,23 +227,22 @@ func (t *Transition) LogArgs() string {
 
 // String representation of the transition and the steps taken so far.
 func (t *Transition) String() string {
+	// TODO infer handler names
 	var lines []string
-	for k := range t.Steps {
+	for _, step := range t.Steps {
 
-		touch := t.Steps[k]
-		line := ""
-		if touch.ToState != "" {
-			line += touch.ToState + " -> "
+		var line string
+		if step.FromState != "" && step.ToState != "" {
+			line += step.FromState + " -> " + step.ToState
+		} else {
+			name := step.FromState
+			if name == "" {
+				name = step.ToState
+			}
+			line = name
 		}
 
-		line += touch.FromState
-		if touch.Type > 0 {
-			line += touch.Type.String()
-		}
-		if touch.Data != nil {
-			line += "   (" + touch.Data.(string) + ")"
-		}
-
+		line += " (" + step.Type.String() + ")"
 		lines = append(lines, line)
 	}
 
@@ -287,7 +286,7 @@ func (t *Transition) emitSelfEvents() Result {
 			continue
 		}
 		name := s + s
-		step := newStep(s, "", StepHandler, name)
+		step := newStep(s, "", StepHandler, nil)
 		step.IsSelf = true
 		ret, handlerCalled = m.handle(name, t.Mutation.Args, step, false)
 		if handlerCalled {
@@ -340,7 +339,7 @@ func (t *Transition) emitExitEvents() Result {
 }
 
 func (t *Transition) emitHandler(from, to, event string, args A) Result {
-	step := newStep(from, to, StepHandler, event)
+	step := newStep(from, to, StepHandler, nil)
 	t.latestStep = step
 	ret, handlerCalled := t.Machine.handle(event, args, step, false)
 	if handlerCalled {
@@ -364,7 +363,7 @@ func (t *Transition) emitFinalEvents() Result {
 			handler = s + "End"
 		}
 
-		step := newStep(s, "", StepHandler, handler)
+		step := newStep(s, "", StepHandler, nil)
 		step.IsFinal = true
 		step.IsEnter = isEnter
 		t.latestStep = step

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -355,19 +355,19 @@ type Step struct {
 	IsEnter bool
 }
 
-// TODO optimize make optional
 func newStep(from string, to string, stepType StepType,
 	data any,
 ) *Step {
+	// TODO optimize with state indexes
 	return &Step{
 		FromState: from,
 		ToState:   to,
 		Type:      stepType,
-		Data:      data,
+		// TODO refac to RelType
+		Data: data,
 	}
 }
 
-// TODO optimize make optional
 func newSteps(from string, toStates S, stepType StepType,
 	data any,
 ) []*Step {

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -244,37 +244,38 @@ type Debugger struct {
 	// printer for numbers
 	P *message.Printer
 
-	tree                   *cview.TreeView
-	treeRoot               *cview.TreeNode
-	log                    *cview.TextView
-	timelineTxs            *cview.ProgressBar
-	timelineSteps          *cview.ProgressBar
-	focusable              []*cview.Box
-	playTimer              *time.Ticker
-	currTxBarRight         *cview.TextView
-	currTxBarLeft          *cview.TextView
-	nextTxBarLeft          *cview.TextView
-	nextTxBarRight         *cview.TextView
-	helpDialog             *cview.Flex
-	keyBar                 *cview.TextView
-	clientList             *cview.List
-	mainGrid               *cview.Grid
-	logRebuildEnd          int
-	lastScrolledTxTime     time.Time
-	repaintScheduled       atomic.Bool
-	updateSidebarScheduled atomic.Bool
-	lastKeystroke          tcell.Key
-	lastKeystrokeTime      time.Time
-	updateLogScheduled     atomic.Bool
-	matrix                 *cview.Table
-	focusManager           *cview.FocusManager
-	exportDialog           *cview.Modal
-	contentPanels          *cview.Panels
-	filtersBar             *cview.TextView
-	focusedFilter          FilterName
-	treeLogGrid            *cview.Grid
-	treeMatrixGrid         *cview.Grid
-	lastSelectedState      string
+	tree               *cview.TreeView
+	treeRoot           *cview.TreeNode
+	log                *cview.TextView
+	timelineTxs        *cview.ProgressBar
+	timelineSteps      *cview.ProgressBar
+	focusable          []*cview.Box
+	playTimer          *time.Ticker
+	currTxBarRight     *cview.TextView
+	currTxBarLeft      *cview.TextView
+	nextTxBarLeft      *cview.TextView
+	nextTxBarRight     *cview.TextView
+	helpDialog         *cview.Flex
+	keyBar             *cview.TextView
+	clientList         *cview.List
+	mainGrid           *cview.Grid
+	logRebuildEnd      int
+	lastScrolledTxTime time.Time
+	repaintScheduled   atomic.Bool
+	// update client list scheduled
+	updateCLScheduled  atomic.Bool
+	lastKeystroke      tcell.Key
+	lastKeystrokeTime  time.Time
+	updateLogScheduled atomic.Bool
+	matrix             *cview.Table
+	focusManager       *cview.FocusManager
+	exportDialog       *cview.Modal
+	contentPanels      *cview.Panels
+	filtersBar         *cview.TextView
+	focusedFilter      FilterName
+	treeLogGrid        *cview.Grid
+	treeMatrixGrid     *cview.Grid
+	lastSelectedState  string
 	// TODO should be a redraw, not before
 	redrawCallback func()
 	healthcheck    *time.Ticker
@@ -965,7 +966,7 @@ func (d *Debugger) updateClientList(immediate bool) {
 		return
 	}
 
-	if !d.updateSidebarScheduled.CompareAndSwap(false, true) {
+	if !d.updateCLScheduled.CompareAndSwap(false, true) {
 		// debounce non-forced updates
 		return
 	}
@@ -1029,7 +1030,7 @@ func (d *Debugger) doUpdateClientList(immediate bool) {
 		d.Mach.Eval("doUpdateClientList", update, nil)
 	}
 
-	d.updateSidebarScheduled.Store(false)
+	d.updateCLScheduled.Store(false)
 	d.draw()
 }
 
@@ -1092,7 +1093,7 @@ func (d *Debugger) buildClientList(selectedIndex int) {
 		" Machines:%d T:%v ", len(d.Clients), totalSum))
 
 	// sort TODO blinks anyway
-	// d.doUpdateClientList(true)
+	d.doUpdateClientList(true)
 }
 
 type sidebarRef struct {

--- a/tools/debugger/handlers.go
+++ b/tools/debugger/handlers.go
@@ -45,6 +45,7 @@ func (d *Debugger) StartState(e *am.Event) {
 		if stateCtx.Err() != nil {
 			return // expired
 		}
+		d.Mach.PanicToErr(nil)
 
 		d.App.SetRoot(d.LayoutRoot, true)
 		d.App.SetFocus(d.clientList)


### PR DESCRIPTION
- executed handlers of the current transition are now pinned to the top of the reader
- handler names aren't send over with steps any more

![ss-2024-11-19-16-35-54](https://github.com/user-attachments/assets/8a56dce2-17df-4154-bb48-b92d21882d13)