### PR TITLE
feat(telemetry): add metrics for state activations

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,7 +149,9 @@ tasks:
           ./tools/debugger/test/remote {{.CLI_ARGS}}
 
   precommit:
-    cmd: .git/hooks/pre-commit
+    cmds:
+      - task: format
+      - .git/hooks/pre-commit
 
   clean:
     cmd: go clean -testcache

--- a/examples/tree_state_source/Taskfile.yml
+++ b/examples/tree_state_source/Taskfile.yml
@@ -104,6 +104,7 @@ tasks:
       --ids root,rm-root,rs-root-0,rs-root-1,rs-root-2
       --grafana-url {{.GRAFANA_URL}}
       --source tree_state_source_root
+      --added-states root:Flight1Departed,root:Flight2Departed,root:Flight3Departed,root:Flight4Departed,root:Flight5Departed
 
   gen-grafana-rep:
     internal: true

--- a/examples/tree_state_source/cmd_state_node.go
+++ b/examples/tree_state_source/cmd_state_node.go
@@ -189,7 +189,17 @@ func exportTelemetry(node *Node, mach am.Api) {
 
 	// prom metrics
 	if node.Prom != nil {
-		metrics := amprom.BindMach(mach)
+
+		// monitor specific states only for state sources
+		var states am.S
+		if mach.Id() == "root" {
+			states = am.S{
+				ss.Ready, ss.Flight1Departed, ss.Flight2Departed, ss.Flight3Departed,
+				ss.Flight4Departed, ss.Flight5Departed,
+			}
+		}
+
+		metrics := amprom.BindMach(mach, states)
 		amprom.BindToPusher(metrics, node.Prom)
 		node.Metrics = append(node.Metrics, metrics)
 	}

--- a/examples/tree_state_source/config.env
+++ b/examples/tree_state_source/config.env
@@ -1,0 +1,23 @@
+# copy to .env and paste the token
+
+GRAFANA_URL=http://localhost:3000
+GRAFANA_TOKEN=
+
+# metrics
+
+PUSH_GATEWAY_URL=http://localhost:9091
+LOKI_ADDR=localhost:3100
+AM_LOG=2
+
+#AM_DEBUG=1
+#AM_DBG_ADDR=:6831
+#AM_HEALTHCHECK=1
+#
+#AM_RPC_LOG_SERVER=1
+#AM_RPC_LOG_CLIENT=1
+#AM_RPC_LOG_MUX=1
+#
+#AM_NODE_LOG_SUPERVISOR=1
+#AM_NODE_LOG_CLIENT=1
+#AM_NODE_LOG_WORKER=1
+#

--- a/tools/generator/cli/cli.go
+++ b/tools/generator/cli/cli.go
@@ -50,16 +50,18 @@ const (
 
 	// grafana
 
-	pGIds             = "ids"
-	pGIdsShort        = "i"
-	pGGrafanaUrl      = "grafana-url"
-	pGGrafanaUrlShort = "g"
-	pGName            = "name"
-	pGNameShort       = "n"
-	pGFolder          = "folder"
-	pGFolderShort     = "f"
-	pGSource          = "source"
-	pGSourceShort     = "s"
+	pGIds              = "ids"
+	pGIdsShort         = "i"
+	pGGrafanaUrl       = "grafana-url"
+	pGGrafanaUrlShort  = "g"
+	pGName             = "name"
+	pGNameShort        = "n"
+	pGFolder           = "folder"
+	pGFolderShort      = "f"
+	pGSource           = "source"
+	pGSourceShort      = "s"
+	pGAddedStates      = "added-states"
+	pGAddedStatesShort = "a"
 )
 
 func AddGrafanaFlags(cmd *cobra.Command) {
@@ -74,54 +76,59 @@ func AddGrafanaFlags(cmd *cobra.Command) {
 		"Dashboard name. Required.")
 	f.StringP(pGSource, pGSourceShort, "",
 		"$source variable (service_name or job). Required.")
-
+	f.StringP(pGAddedStates, pGAddedStatesShort, "",
+		"Count activations of these states (eg mach-id:StateName," +
+		"mach-id2:StateName2). Optional.")
 }
 
 // GrafanaParams are params for the grafana command.
 type GrafanaParams struct {
-	Ids        string
-	GrafanaUrl string
-	Folder     string
-	Name       string
-	Token      string
-	Source     string
+	Ids         string
+	GrafanaUrl  string
+	Folder      string
+	Name        string
+	Token       string
+	Source      string
+	AddedStates string
 	// TODO interval
 	// Interval   string
 }
 
 func ParseGrafanaParams(cmd *cobra.Command, _ []string) GrafanaParams {
 	ids := strings.Trim(cmd.Flag(pGIds).Value.String(), "\n ")
-	sync := strings.Trim(cmd.Flag(pGGrafanaUrl).Value.String(), "\n ")
+	grafanaUrl := strings.Trim(cmd.Flag(pGGrafanaUrl).Value.String(), "\n ")
 	folder := strings.Trim(cmd.Flag(pGFolder).Value.String(), "\n ")
 	name := strings.Trim(cmd.Flag(pGName).Value.String(), "\n ")
 	source := strings.Trim(cmd.Flag(pGSource).Value.String(), "\n ")
+	addStates := strings.Trim(cmd.Flag(pGAddedStates).Value.String(), "\n ")
 
 	if ids == "" || strings.Contains(ids, " ") || strings.Contains(ids, ",,") {
-		fmt.Println("Error: ids invalid")
+		fmt.Println("Error: ids invalid: "+ ids)
 		os.Exit(1)
 	}
 
-	if sync == "" || strings.Contains(sync, " ") {
-		fmt.Println("Error: sync invalid")
+	if grafanaUrl == "" || strings.Contains(grafanaUrl, " ") {
+		fmt.Println("Error: grafana url invalid: "+" "+ grafanaUrl)
 		os.Exit(1)
 	}
 
 	if name == "" || strings.Contains(name, " ") {
-		fmt.Println("Error: name invalid")
+		fmt.Println("Error: name invalid: " + name)
 		os.Exit(1)
 	}
 
 	if source == "" || strings.Contains(source, " ") {
-		fmt.Println("Error: source invalid")
+		fmt.Println("Error: source invalid: "+source)
 		os.Exit(1)
 	}
 
 	return GrafanaParams{
-		Ids:        ids,
-		GrafanaUrl: sync,
-		Folder:     folder,
-		Name:       name,
-		Source:     source,
+		Ids:         ids,
+		GrafanaUrl:  grafanaUrl,
+		Folder:      folder,
+		Name:        name,
+		Source:      source,
+		AddedStates: addStates,
 	}
 }
 
@@ -178,8 +185,8 @@ func AddStatesFlags(cmd *cobra.Command) {
 	f.StringP(pSFStates, pSFStatesShort, "",
 		"State names to generate. Eg: State1,State2")
 	f.StringP(pSFInherit, pSFInheritShort, "",
-		"Inherit from a built-in states machine: " +
-		"basic,connected,rpc/worker,node/worker")
+		"Inherit from a built-in states machine: "+
+			"basic,connected,rpc/worker,node/worker")
 	f.StringP(pSFGroups, pSFGroupsShort, "",
 		"Groups to generate. Eg: Group1,Group2")
 	f.StringP(pSFName, pSFNameShort, "",

--- a/tools/generator/grafana.go
+++ b/tools/generator/grafana.go
@@ -14,6 +14,8 @@ import (
 	"github.com/K-Phoen/grabana/target/prometheus"
 	"github.com/K-Phoen/grabana/timeseries"
 
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
 	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	"github.com/pancsta/asyncmachine-go/tools/generator/cli"
 )
@@ -23,113 +25,152 @@ func GenDashboard(p cli.GrafanaParams) (*dashboard.Builder, error) {
 	source := telemetry.NormalizeId(p.Source)
 
 	for _, id := range strings.Split(p.Ids, ",") {
-		pId := telemetry.NormalizeId(id)
+		machId := telemetry.NormalizeId(id)
 
-		options = append(options, dashboard.Row("Mach: "+id,
+		// extract added states per machine
+		var addedStates am.S
+		for _, name := range strings.Split(p.AddedStates, ",") {
+			stateName, found := strings.CutPrefix(name, id+":")
+			if !found {
+				continue
+			}
+			// TODO fix
+			addedStates = append(addedStates, stateName)
+		}
 
-			row.WithTimeSeries(
-				"Transitions",
+		// optional panel for state activations
+		if len(addedStates) == 0 {
+			// MAIN PANEL
+			options = append(options, dashboard.Row("Mach: "+id,
+
+				row.WithTimeSeries("Number of Transitions",
+					timeseries.Span(12),
+					timeseries.DataSource("Prometheus"),
+					timeseries.WithPrometheusTarget(
+						`am_transitions_`+machId+`{job="`+source+`"}`,
+						prometheus.Legend("Number of transitions"),
+					),
+				),
+			))
+		} else {
+
+			statesOpts := []timeseries.Option{
 				timeseries.Span(12),
 				timeseries.DataSource("Prometheus"),
-				timeseries.WithPrometheusTarget(
-					`am_transitions_`+pId+`{job="`+source+`"}`,
-					prometheus.Legend("Number of transitions"),
+			}
+			for _, name := range addedStates {
+				statesOpts = append(statesOpts, timeseries.WithPrometheusTarget(
+					`am_state_added_`+name+`_`+machId+`{job="`+source+`"}`,
+					prometheus.Legend(name),
+				))
+			}
+
+			// MAIN PANEL AND STATES PANEL
+			options = append(options, dashboard.Row("Mach: "+id,
+
+				row.WithTimeSeries("Number of Transitions",
+					timeseries.Span(12),
+					timeseries.DataSource("Prometheus"),
+					timeseries.WithPrometheusTarget(
+						`am_transitions_`+machId+`{job="`+source+`"}`,
+						prometheus.Legend("Number of transitions"),
+					),
 				),
-			),
-		), dashboard.Row(
+
+				row.WithTimeSeries("State Activations", statesOpts...),
+			))
+		}
+
+		// DETAILED PANELS (collapsed)
+		options = append(options, dashboard.Row(
 			"Details: "+id,
 			row.Collapse(),
 
-			row.WithTimeSeries(
-				"Transition Mutations",
+			row.WithTimeSeries("Transition Mutations",
 				timeseries.Span(12),
 				timeseries.DataSource("Prometheus"),
 				timeseries.FillOpacity(0),
 				timeseries.WithPrometheusTarget(
-					`am_queue_size_`+pId+`{job="`+source+`"}`,
+					`am_queue_size_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg queue size"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_handlers_`+pId+`{job="`+source+`"}`,
+					`am_handlers_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg handlers ran"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_states_added_`+pId+`{job="`+source+`"}`,
+					`am_states_added_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg states added"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_states_removed_`+pId+`{job="`+source+`"}`,
+					`am_states_removed_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg states removed"),
 				),
 			),
 
-			row.WithTimeSeries(
-				"Transition Details",
+			row.WithTimeSeries("Transition Details",
 				timeseries.Span(12),
 				timeseries.DataSource("Prometheus"),
 				timeseries.FillOpacity(0),
 				timeseries.WithPrometheusTarget(
-					`am_tx_ticks_`+pId+`{job="`+source+`"}`,
+					`am_tx_ticks_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg machine time taken (ticks)"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_steps_`+pId+`{job="`+source+`"}`,
+					`am_steps_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg number of steps"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_states_touched_`+pId+`{job="`+source+`"}`,
+					`am_states_touched_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg states touched"),
 				),
 			),
 
-			row.WithTimeSeries(
-				"States and Relations",
+			row.WithTimeSeries("States and Relations",
 				timeseries.Span(12),
 				timeseries.DataSource("Prometheus"),
 				timeseries.FillOpacity(0),
 				timeseries.WithPrometheusTarget(
-					`am_ref_states_`+pId+`{job="`+source+`"}`,
+					`am_ref_states_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("States referenced in relations"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_relations_`+pId+
-						`{job="`+source+`"} / am_states_`+pId+`{job="`+source+`"}`,
+					`am_relations_`+machId+
+						`{job="`+source+`"} / am_states_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Avg number of relations per state"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_relations_`+pId+`{job="`+source+`"}`,
+					`am_relations_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Number of relations"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_states_active_`+pId+
+					`am_states_active_`+machId+
 						`{job="`+source+`"}`,
 					prometheus.Legend("Avg active states"),
 				),
 				timeseries.WithPrometheusTarget(
-					`am_states_inactive_`+pId+
+					`am_states_inactive_`+machId+
 						`{job="`+source+`"}`,
 					prometheus.Legend("Avg inactive states"),
 				),
 			),
 
-			row.WithHeatmap(
-				"Average transition time",
+			row.WithHeatmap("Average transition time",
 				heatmap.Span(12),
 				heatmap.Height("150px"),
 				heatmap.DataSource("Prometheus"),
 				heatmap.WithPrometheusTarget(
-					`am_tx_time_`+pId+`{job="`+source+`"}`,
+					`am_tx_time_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Human time (μs)"),
 				),
 			),
 
-			row.WithHeatmap(
-				"Transition errors",
+			row.WithHeatmap("Transition errors",
 				heatmap.Span(12),
 				heatmap.Height("150px"),
 				heatmap.DataSource("Prometheus"),
 				heatmap.WithPrometheusTarget(
-					`am_exceptions_`+pId+`{job="`+source+`"}`,
+					`am_exceptions_`+machId+`{job="`+source+`"}`,
 					prometheus.Legend("Exception"),
 				),
 			),


### PR DESCRIPTION
It's now possible to get metrics for important state activations right out of the box via `--added-states`, eg

```text
am-gen grafana
      --name root
      --folder tree_state_source
      --ids root,rm-root,rs-root-0,rs-root-1,rs-root-2
      --source tree_state_source_root
      --added-states root:Flight1Departed,root:Flight2Departed,root:Flight3Departed,root:Flight4Departed,root:Flight5Departed
```

States need to be monitored first via `amprom.BindMach(mach, states)`. Screen from [/examples/tree_state_source](/examples/tree_state_source/README.md).

![ss-2024-11-22-14-32-59](https://github.com/user-attachments/assets/bab282fb-6f61-401e-8596-5634e4907bb9)
