### PR TITLE
feat(machine): allow events as mutation sources eg EvAdd()

### DIFF
--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -87,6 +87,10 @@ func newTransition(m *Machine, item *Mutation) *Transition {
 	} else {
 		m.log(LogOps, "[%s] %s%s", mutType, j(states), logArgs)
 	}
+	src := item.Source
+	if src != nil {
+		m.log(LogOps, "[source] %s/%s/%d", src.MachId, src.TxId, src.MachTime)
+	}
 
 	statesToSet := S{}
 	switch mutType {

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -112,6 +112,13 @@ type Api interface {
 	AddErr(err error, args A) Result
 	AddErrState(state string, err error, args A) Result
 
+	EvAdd1(event *Event, state string, args A) Result
+	EvAdd(event *Event, states S, args A) Result
+	EvRemove1(event *Event, state string, args A) Result
+	EvRemove(event *Event, states S, args A) Result
+	EvAddErr(event *Event, err error, args A) Result
+	EvAddErrState(event *Event, state string, err error, args A) Result
+
 	// Waiting (remote)
 
 	WhenArgs(state string, args A, ctx context.Context) <-chan struct{}
@@ -251,6 +258,13 @@ func (r Result) String() string {
 	return ""
 }
 
+type MutSource struct {
+	MachId string
+	TxId   string
+	// Machine time of the source machine BEFORE the event.
+	MachTime uint64
+}
+
 // MutationType enum
 type MutationType int
 
@@ -287,6 +301,8 @@ type Mutation struct {
 	Args A
 	// this mutation has been triggered by an auto state
 	Auto bool
+	// Source is the source event for this mutation.
+	Source *MutSource
 	// specific context for this mutation (optional)
 	ctx context.Context
 	// optional eval func, only for mutationEval


### PR DESCRIPTION
Handlers can now use `*Event` as a source with prefixed methods. This allows for distributed tracing / state trace.

- `EvAdd`
- `EvAdd1`
- `EvRemove`
- `EvRemove1`