### PR TITLE
feat(machine): add AMerge for log args

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1732,6 +1732,20 @@ type A struct {
 }
 ```
 
+// TODO merging log args
+
+```go
+func LogArgs(args am.A) map[string]string {
+	a1 := amnode.ParseArgs(args)
+	a2 := ParseArgs(args)
+	if a1 == nil && a2 == nil {
+		return nil
+	}
+
+	return am.AMerge(amhelp.ArgsToLogMap(a1), amhelp.ArgsToLogMap(a2))
+}
+```
+
 ### Tracing and Metrics
 
 Asyncmachine offers several telemetry exporters for logging, tracing, and metrics. Please refer to [`pkg/telemetry`](/pkg/telemetry/README.md)

--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -294,6 +294,20 @@ func MockClock(mach *Machine, clock Clock) {
 	mach.clock = clock
 }
 
+// AMerge merges 2 or more maps into 1. Useful for passing args from many
+// packages.
+func AMerge[K comparable, V any](maps ...map[K]V) map[K]V {
+	out := map[K]V{}
+
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
 // ///// ///// /////
 
 // ///// UTILS

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -129,12 +129,13 @@ func PassRpc(args *A) am.A {
 	return am.A{"am_node": amhelp.ArgsToArgs(args, &ARpc{})}
 }
 
-// LogArgs is an args logger for A.
+// LogArgs is an args logger for A and rpc.A.
 func LogArgs(args am.A) map[string]string {
-	a := ParseArgs(args)
-	if a == nil {
+	a1 := rpc.ParseArgs(args)
+	a2 := ParseArgs(args)
+	if a1 == nil && a2 == nil {
 		return nil
 	}
 
-	return amhelp.ArgsToLogMap(a)
+	return am.AMerge(amhelp.ArgsToLogMap(a1), amhelp.ArgsToLogMap(a2))
 }


### PR DESCRIPTION
Syntax sugar for inheriting log args from a dependency.

```go
a1 := amnode.ParseArgs(args)
a2 := ParseArgs(args)
// ...
return am.AMerge(amhelp.ArgsToLogMap(a1), amhelp.ArgsToLogMap(a2))
```