### PR TITLE
feat(am-dbg): add address bar & tags

### DIFF
--- a/tools/debugger/keyboard.go
+++ b/tools/debugger/keyboard.go
@@ -298,32 +298,8 @@ func (d *Debugger) getKeystrokes() map[string]func(
 
 		// prev tx
 		"left": func(ev *tcell.EventKey) *tcell.EventKey {
-			// filters - switch inner focus
-			// TODO extract
-			if d.Mach.Is1(ss.FiltersFocused) {
-				switch d.focusedFilter {
-				case filterCanceledTx:
-					d.focusedFilter = filterLog4
-				case filterAutoTx:
-					d.focusedFilter = filterCanceledTx
-				case filterEmptyTx:
-					d.focusedFilter = filterCanceledTx
-				case FilterSummaries:
-					d.focusedFilter = filterEmptyTx
-				case filterLog0:
-					d.focusedFilter = FilterSummaries
-				case filterLog1:
-					d.focusedFilter = filterLog0
-				case filterLog2:
-					d.focusedFilter = filterLog1
-				case filterLog3:
-					d.focusedFilter = filterLog2
-				case filterLog4:
-					d.focusedFilter = filterLog3
-				}
-				d.updateFiltersBar()
-
-				return nil
+			if d.Mach.Any1(ss.AddressFocused, ss.FiltersFocused) {
+				return ev
 			}
 
 			if d.Mach.Not1(ss.ClientSelected) {
@@ -351,32 +327,8 @@ func (d *Debugger) getKeystrokes() map[string]func(
 
 		// next tx
 		"right": func(ev *tcell.EventKey) *tcell.EventKey {
-			// filters - switch inner focus
-			// TODO extract
-			if d.Mach.Is1(ss.FiltersFocused) {
-				switch d.focusedFilter {
-				case filterCanceledTx:
-					d.focusedFilter = filterAutoTx
-				case filterAutoTx:
-					d.focusedFilter = filterEmptyTx
-				case filterEmptyTx:
-					d.focusedFilter = FilterSummaries
-				case FilterSummaries:
-					d.focusedFilter = filterLog0
-				case filterLog0:
-					d.focusedFilter = filterLog1
-				case filterLog1:
-					d.focusedFilter = filterLog2
-				case filterLog2:
-					d.focusedFilter = filterLog3
-				case filterLog3:
-					d.focusedFilter = filterLog4
-				case filterLog4:
-					d.focusedFilter = filterCanceledTx
-				}
-				d.updateFiltersBar()
-
-				return nil
+			if d.Mach.Any1(ss.AddressFocused, ss.FiltersFocused) {
+				return ev
 			}
 
 			if d.Mach.Not1(ss.ClientSelected) {
@@ -530,7 +482,7 @@ func (d *Debugger) getKeystrokes() map[string]func(
 			if d.Mach.Not1(ss.ClientSelected) {
 				return nil
 			}
-			d.SetCursor(d.filterTxCursor(d.C, 0, true))
+			d.SetCursor(d.filterTxCursor(d.C, 0, true), false)
 			d.Mach.Remove(am.S{ss.TailMode, ss.Playing}, nil)
 			// sidebar for errs
 			d.updateClientList(true)
@@ -544,7 +496,7 @@ func (d *Debugger) getKeystrokes() map[string]func(
 			if d.Mach.Not1(ss.ClientSelected) {
 				return nil
 			}
-			d.SetCursor(d.filterTxCursor(d.C, len(d.C.MsgTxs), false))
+			d.SetCursor(d.filterTxCursor(d.C, len(d.C.MsgTxs), false), false)
 			d.Mach.Remove(am.S{ss.TailMode, ss.Playing}, nil)
 			// sidebar for errs
 			d.updateClientList(true)
@@ -689,21 +641,21 @@ func (d *Debugger) updateFocusable() {
 
 	case ss.MatrixView:
 		d.focusable = []*cview.Box{
-			d.clientList.Box, d.matrix.Box, d.timelineTxs.Box, d.timelineSteps.Box,
+			d.addressBar.Box, d.clientList.Box, d.matrix.Box, d.timelineTxs.Box, d.timelineSteps.Box,
 			d.filtersBar.Box,
 		}
 		prims = []cview.Primitive{
-			d.clientList, d.matrix, d.timelineTxs,
+			d.addressBar, d.clientList, d.matrix, d.timelineTxs,
 			d.timelineSteps, d.filtersBar,
 		}
 
 	case ss.TreeMatrixView:
 		d.focusable = []*cview.Box{
-			d.clientList.Box, d.tree.Box, d.matrix.Box, d.timelineTxs.Box,
+			d.addressBar.Box, d.clientList.Box, d.tree.Box, d.matrix.Box, d.timelineTxs.Box,
 			d.timelineSteps.Box, d.filtersBar.Box,
 		}
 		prims = []cview.Primitive{
-			d.clientList, d.tree, d.matrix, d.timelineTxs,
+			d.addressBar, d.clientList, d.tree, d.matrix, d.timelineTxs,
 			d.timelineSteps, d.filtersBar,
 		}
 
@@ -713,21 +665,21 @@ func (d *Debugger) updateFocusable() {
 		if d.Mach.Is1(ss.LogReaderVisible) {
 
 			d.focusable = []*cview.Box{
-				d.clientList.Box, d.tree.Box, d.log.Box, d.logReader.Box,
+				d.addressBar.Box, d.clientList.Box, d.tree.Box, d.log.Box, d.logReader.Box,
 				d.timelineTxs.Box, d.timelineSteps.Box, d.filtersBar.Box,
 			}
 			prims = []cview.Primitive{
-				d.clientList, d.tree, d.log, d.logReader, d.timelineTxs,
+				d.addressBar, d.clientList, d.tree, d.log, d.logReader, d.timelineTxs,
 				d.timelineSteps, d.filtersBar,
 			}
 		} else {
 
 			d.focusable = []*cview.Box{
-				d.clientList.Box, d.tree.Box, d.log.Box, d.timelineTxs.Box,
+				d.addressBar.Box, d.clientList.Box, d.tree.Box, d.log.Box, d.timelineTxs.Box,
 				d.timelineSteps.Box, d.filtersBar.Box,
 			}
 			prims = []cview.Primitive{
-				d.clientList, d.tree, d.log, d.timelineTxs,
+				d.addressBar, d.clientList, d.tree, d.log, d.timelineTxs,
 				d.timelineSteps, d.filtersBar,
 			}
 		}
@@ -772,6 +724,8 @@ func (d *Debugger) updateFocusable() {
 		d.focusManager.Focus(d.timelineSteps)
 	case ss.FiltersFocused:
 		d.focusManager.Focus(d.filtersBar)
+	case ss.AddressFocused:
+		d.focusManager.Focus(d.addressBar)
 	default:
 		d.focusManager.Focus(d.clientList)
 	}

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -53,6 +53,7 @@ var States = am.Struct{
 		Require: S{LogReaderVisible},
 		Remove:  GroupFocused,
 	},
+	AddressFocused: {Remove: GroupFocused},
 
 	StateNameSelected:     {Require: S{ClientSelected}},
 	TimelineStepsScrolled: {Require: S{ClientSelected}},
@@ -73,10 +74,11 @@ var States = am.Struct{
 	FilterCanceledTx: {},
 	FilterEmptyTx:    {},
 	FilterSummaries:  {},
+	FilterHealthcheck:  {},
 
 	// ///// Actions
 
-	Start: {Add: S{FilterSummaries}},
+	Start: {Add: S{FilterSummaries, FilterHealthcheck, FilterEmptyTx}},
 	Healthcheck: {
 		Multi:   true,
 		Require: S{Start},
@@ -155,7 +157,7 @@ var (
 	GroupFocused = S{
 		TreeFocused, LogFocused, TimelineTxsFocused,
 		TimelineStepsFocused, SidebarFocused, MatrixFocused, DialogFocused,
-		FiltersFocused, LogReaderFocused,
+		FiltersFocused, LogReaderFocused, AddressFocused,
 	}
 	GroupPlaying = S{
 		Playing, Paused, TailMode,
@@ -170,7 +172,7 @@ var (
 		SwitchingClientTx, SwitchedClientTx,
 	}
 	GroupFilters = S{
-		FilterAutoTx, FilterCanceledTx, FilterEmptyTx,
+		FilterAutoTx, FilterCanceledTx, FilterEmptyTx, FilterHealthcheck,
 	}
 )
 
@@ -187,6 +189,11 @@ const (
 	DialogFocused         = "DialogFocused"
 	FiltersFocused        = "FiltersFocused"
 	LogReaderFocused      = "LogReaderFocused"
+	AddressFocused      = "AddressFocused"
+	// SidebarFocused is client list focused.
+	// TODO rename to ClientListFocused
+	SidebarFocused   = "SidebarFocused"
+
 	TimelineStepsScrolled = "TimelineStepsScrolled"
 
 	ClientMsg = "ClientMsg"
@@ -219,8 +226,6 @@ const (
 	BackStep        = "BackStep"
 	ConnectEvent    = "ConnectEvent"
 	DisconnectEvent = "DisconnectEvent"
-	// SidebarFocused is client list focused.
-	SidebarFocused   = "SidebarFocused"
 	RemoveClient     = "RemoveClient"
 	ClientSelected   = "ClientSelected"
 	SelectingClient  = "SelectingClient"
@@ -237,6 +242,7 @@ const (
 	Ready            = "Ready"
 	FilterCanceledTx = "FilterCanceledTx"
 	FilterAutoTx     = "FilterAutoTx"
+	FilterHealthcheck     = "FilterHealthcheck"
 	// FilterEmptyTx is a filter for txes which didn't change state and didn't
 	// run any self handler either
 	FilterEmptyTx   = "FilterEmptyTx"

--- a/tools/debugger/utils.go
+++ b/tools/debugger/utils.go
@@ -19,9 +19,9 @@ type Focusable struct {
 }
 
 type filter struct {
-	id     string
+	id     FilterName
 	label  string
-	active bool
+	active func() bool
 }
 
 // TODO migrate to Provide-Delivered


### PR DESCRIPTION
This PR adds an address bar built using a table, and re-builds the filter bar in the similar fashion. Keyboard support comes from the table.

Each machine has 2 history entries (enter & exit) and switching is done via the client list and "Source" in the reader pane. Clipboard support imported from [micro-editor](https://github.com/zyedidia/clipper).

![ss-2024-12-14-20-57-12](https://github.com/user-attachments/assets/ccc4cd15-f2c6-4f67-a34d-974533bf1f73)
