### PR TITLE
feat(am-dbg): add --fwd-data flag

### DIFF
--- a/tools/cmd/am-dbg/cmd_dbg.go
+++ b/tools/cmd/am-dbg/cmd_dbg.go
@@ -68,7 +68,7 @@ func cliRun(_ *cobra.Command, _ []string, p cli.Params) {
 
 	// rpc server
 	if p.ServerAddr != "-1" {
-		go server.StartRpc(dbg.Mach, p.ServerAddr, nil)
+		go server.StartRpc(dbg.Mach, p.ServerAddr, nil, p.FwdData)
 	}
 
 	// start and wait till the end


### PR DESCRIPTION
This little feature is actually very important, as it distributes indentical data across N number of instances. Some can be used in a dashbaord, and some to persist / process the data.

View the same (live) data in 2 instances of am-dbg:

- TTY1 - `am-dbg -l 1234`
- TTY2 - `am-dbg --fwd-data 1234`
- TTY3 - `env AM_DBG_ADDR=1 go run ./mach.go`

![ss-2024-12-13-19-00-57](https://github.com/user-attachments/assets/b1fbfd85-9020-40c0-b481-22e1bf68a0ea)
