### PR TITLE
feat(machine): improve state-state handlers (eg FooBar)

### DIFF
--- a/.github/workflows/go-helpers.yml
+++ b/.github/workflows/go-helpers.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-history.yml
+++ b/.github/workflows/go-history.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-machine.yml
+++ b/.github/workflows/go-machine.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-node.yml
+++ b/.github/workflows/go-node.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-rpc.yml
+++ b/.github/workflows/go-rpc.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-states.yml
+++ b/.github/workflows/go-states.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-telemetry.yml
+++ b/.github/workflows/go-telemetry.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-tools.yml
+++ b/.github/workflows/go-tools.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,9 @@ jobs:
 
       # set up
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ and [Actor Model](https://en.wikipedia.org/wiki/Actor_model) through a **[clock-
 It has atomic transitions, relations, [transparent RPC](/pkg/rpc/README.md), [TUI debugger](/tools/cmd/am-dbg/README.md),
 [telemetry](/pkg/telemetry/README.md), [workers](/pkg/node/README.md), and soon diagrams.
 
-Its main purpose is workflows (both in-process and distributed), although it can be used for a wide range of
-applications - UIs, bots, agents, stateful firewalls, consensus algos, etc. **asyncmachine** can precisely (and
+Its main purpose is workflows (in-process or distributed), although it can be used for a wide range of
+stateful applications - daemons, UIs, bots, agents, firewalls, consensus algos, etc. **asyncmachine** can precisely (and
 transparently) target a specific point in a scenario and easily bring structure to event-based systems. It takes care of
 most contexts, `select` statements, and panics.
 
-It will enable you to create autonomous workflows with organic control flow and stateful APIs.
+It aims at creating **autonomous** workflows with **organic** control flow and **stateful** APIs.
 
 ## Stack
+
+Top layers depend on the bottom ones.
 
 <table>
   <tr>
@@ -139,18 +141,19 @@ client.WorkerRpc.Worker.Add1(ssW.WorkRequested, Pass(&A{
     Input: 2}))
 // WaitFor* wraps select statements
 err := amhelp.WaitForAll(ctx, time.Second,
+    // post-mutation subscription
     mach2.When1(ss.BasicStatesDef.Ready, nil),
+    // pre-mutation subscription
     whenPayload)
 // check cancellation
 if ctx.Err() != nil {
-    // state ctx expired
-    return
+    return // state ctx expired
 }
 // check error
 if err != nil {
     // mutation
     client.Mach.AddErr(err, nil)
-    return
+    return // no err required
 }
 // client/WorkerPayload and mach2/Ready activated
 ```
@@ -162,7 +165,7 @@ if err != nil {
 func (h *Handlers) FooEnter(e *am.Event) bool {
     return true
 }
-// can Foo activate while Bar de-activates?
+// when Foo active, can Bar activate?
 func (h *Handlers) FooBar(e *am.Event) bool {
     return true
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@
 - rpc handlers
 - go1.22 traces
 - inference
+- better support for updating states struct
 - optimizations
 - manual updated to a spec
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,8 +145,9 @@ tasks:
     env:
       AM_TEST_RUNNER: 1
     cmds:
-      - task test -- -coverprofile=coverage.txt -covermode=atomic >
-          coverage.sum.txt
+      - task test -p 1 --parallel 1 -- 
+          -coverprofile=coverage.txt -covermode=atomic >
+            coverage.sum.txt
       - go tool cover -func=coverage.txt | grep total | awk '{print $3}' >
           coverage.sum.txt
 
@@ -155,7 +156,8 @@ tasks:
       AM_TEST_RUNNER: 1
     cmds:
       - task: clean
-      - go test -p 1 ./pkg/... -coverprofile=coverage-pkg.txt -covermode=atomic
+      - go test -p 1 --parallel 1 ./pkg/... 
+          -coverprofile=coverage-pkg.txt -covermode=atomic
       - go tool cover -func=coverage-pkg.txt | grep total | awk '{print $3}' >
           coverage-pkg.sum.txt
 
@@ -165,7 +167,7 @@ tasks:
     desc: Run all local tests in a series
     cmds:
       - task: clean
-      - go test -p 1 ./... {{.CLI_ARGS}}
+      - go test -p 1 --parallel 1 ./... {{.CLI_ARGS}}
 
   test-race:
     env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,7 +145,8 @@ tasks:
     env:
       AM_TEST_RUNNER: 1
     cmds:
-      - task test -p 1 --parallel 1 -- 
+      - task test --  
+          -p 1 --parallel 1
           -coverprofile=coverage.txt -covermode=atomic >
             coverage.sum.txt
       - go tool cover -func=coverage.txt | grep total | awk '{print $3}' >

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -582,19 +582,25 @@ goroutine, with a timeout of [`Machine.HandlerTimeout`](https://pkg.go.dev/githu
 **Example** - handlers for the state Foo
 
 ```go
+// can Foo activate?
 func (h *Handlers) FooEnter(e *am.Event) bool {}
+// when Foo active, can Bar activate?
+func (h *Handlers) FooBar(e *am.Event) {}
+// Foo activates
 func (h *Handlers) FooState(e *am.Event) {}
+// can Foo de-activate?
 func (h *Handlers) FooExit(e *am.Event) bool {}
+// Foo de-activates
 func (h *Handlers) FooEnd(e *am.Event) {}
 ```
 
 List of handlers during a transition from `Foo` to `Bar`, in the order of execution:
 
 - `FooExit` - [negotiation handler](#negotiation-handlers)
-- `FooBar` - [negotiation handler](#negotiation-handlers)
 - `FooAny` - [negotiation handler](#negotiation-handlers)
 - `AnyBar` - [negotiation handler](#negotiation-handlers)
 - `BarEnter` - [negotiation handler](#negotiation-handlers)
+- `FooBar` - [negotiation handler](#negotiation-handlers)
 - `FooEnd` - [final handler](#final-handlers)
 - `BarState` - [final handler](#final-handlers)
 

--- a/pkg/helpers/README.md
+++ b/pkg/helpers/README.md
@@ -20,11 +20,12 @@ Highlights:
 - [test helpers](#test-helpers)
 - [miscellaneous utils](#miscellaneous-utils)
 
-## Import
+## Installation
 
 ```go
+// prod
 import amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
-// for tests
+// tests
 import amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
 ```
 

--- a/pkg/history/README.md
+++ b/pkg/history/README.md
@@ -12,10 +12,10 @@ role in making informed decision about state flow. Besides providing a log of ch
 
 - [`History.ActivatedRecently(state, duration)`](https://pkg.go.dev/github.com/pancsta/asyncmachine-go/pkg/history#History.ActivatedRecently)
 
-## Import
+### Installation
 
 ```go
-import "github.com/pancsta/asyncmachine-go/pkg/history"
+import amhist "github.com/pancsta/asyncmachine-go/pkg/states/history"
 ```
 
 ## Usage

--- a/pkg/machine/README.md
+++ b/pkg/machine/README.md
@@ -119,10 +119,12 @@ flowchart LR
     HandlersMutation --> HandlersAfter
     HandlersMutation --> AnyB
     HandlersMutation --> BEnter
+    HandlersMutation --> AB
     HandlersMutation --> BState
     subgraph Handlers
         AnyB[["AnyB()"]]
         BEnter[["BEnter()"]]
+        AB[["AB()"]]
         BState[["BState()"]]
     end
 ```
@@ -149,11 +151,13 @@ flowchart LR
     NegotiationMutation --> AnyB
     NegotiationMutation --> BEnter
     BEnter == return ==> false
+    NegotiationMutation  -. canceled .-x  AB
     NegotiationMutation -. canceled .-x BState
     subgraph Negotiation
         false[[false]]
         AnyB[["AnyB()"]]
         BEnter[["BEnter()"]]
+        AB[["AB()"]]
         BState[["BState()"]]
     end
 ```
@@ -175,7 +179,7 @@ flowchart LR
 
 ### [Subscriptions](/docs/manual.md#waiting)
 
-Goroutine-free waiting on clock values.
+Channel-broadcast waiting on clock values.
 
 ```mermaid
 flowchart LR
@@ -607,6 +611,23 @@ func TestWhenArgs(t *testing.T) {
 ## Status
 
 Release Candidate, semantically versioned, not optimized yet.
+
+## Concepts
+
+**asyncmachine** is loosely based on the following concepts:
+
+- [NFA nondeterministic state machines](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton)
+- [EDA event emitters](https://en.wikipedia.org/wiki/Event-driven_architecture)
+- [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type))
+- [AOP aspect oriented programming](https://en.wikipedia.org/wiki/Aspect-oriented_programming)
+- [SQL relations](https://en.wikipedia.org/wiki/SQL)
+- [Paxos negotiation](https://en.wikipedia.org/wiki/Paxos_(computer_science))
+- [Non-blocking](https://en.wikipedia.org/wiki/Non-blocking_algorithm)
+- [Actor Model](https://en.wikipedia.org/wiki/Actor_model)
+- [DAG dependency graph](https://en.wikipedia.org/wiki/Dependency_graph)
+- [logical clock](https://en.wikipedia.org/wiki/Logical_clock)
+- [causal inference](https://en.wikipedia.org/wiki/Causal_inference)
+- [declarative logic](https://en.wikipedia.org/wiki/Declarative_programming)
 
 ## monorepo
 

--- a/pkg/machine/utils_test.go
+++ b/pkg/machine/utils_test.go
@@ -170,7 +170,7 @@ func assertOrder(t *testing.T, history *History, handlers []string) {
 func assertEventCountsMin(t *testing.T, history *History, expected int) {
 	// assert event counts
 	for event, count := range history.Counter {
-		assert.GreaterOrEqual(t, expected, count, "event %s call count", event)
+		assert.GreaterOrEqual(t, count, expected, "event %s call count", event)
 	}
 }
 

--- a/pkg/node/README.md
+++ b/pkg/node/README.md
@@ -10,6 +10,12 @@
 supervision, as well as state machines for workers and clients. All actors communicate via [aRPC](/pkg/rpc/README.md),
 as each worker is started in a separate OS process.
 
+### Installation
+
+```go
+import amnode "github.com/pancsta/asyncmachine-go/pkg/node"
+```
+
 ## Workflow Rules
 
 - worker can serve only **1 client**

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -419,6 +419,7 @@ func TestRetryCall(t *testing.T) {
 	c.Worker.Add1(sstest.A, nil)
 	amhelpt.WaitForAll(t, "RetryingCall", ctx, 2*time.Second, whenRetrying)
 
+	//.TODO amtest
 	assert.True(t, s.Mach.Is1(ssrpc.ServerStates.Ready), "Server ready")
 	assert.True(t, s.Mach.Is1(ssrpc.ClientStates.Ready), "Client ready")
 
@@ -443,6 +444,7 @@ func TestRetryCall(t *testing.T) {
 
 	wg.Wait()
 
+	// TODO amtest asserts
 	assert.True(t, w.Is1(sstest.D), "Worker state set")
 	assert.True(t, s.Mach.Is1(ssrpc.ServerStates.Ready), "Server ready")
 	assert.True(t, s.Mach.Is1(ssrpc.ClientStates.Ready), "Client ready")

--- a/pkg/states/README.md
+++ b/pkg/states/README.md
@@ -14,30 +14,28 @@ offers tooling for "piping" states between state machines.
 - [BasicStatesDef](/pkg/states/ss_basic.go): Start, Ready, Healthcheck
 - [ConnectedStatesDef](/pkg/states/ss_connected.go): Client connection in 4 states
 
+## Installation States
+
+```go
+import ssam "github.com/pancsta/asyncmachine-go/pkg/states"
+```
+
 ## Examples
 
 ### Inherit from BasicStatesDef manually
 
 ```go
-import (
-    "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
-)
-
 // inherit from RPC worker
-ssStruct := am.StructMerge(states.BasicStruct, am.Struct{
+ssStruct := am.StructMerge(ssam.BasicStruct, am.Struct{
     "Foo": {Require: am.S{"Bar"}},
     "Bar": {},
 })
-ssNames := am.SAdd(states.BasicStates.Names(), am.S{"Foo", "Bar"})
+ssNames := am.SAdd(ssam.BasicStates.Names(), am.S{"Foo", "Bar"})
 ```
 
 ### Inherit from BasicStatesDef via a definition
 
 ```go
-import (
-    ss "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
-)
-
 // MyMachStatesDef contains all the states of the MyMach state machine.
 type MyMachStatesDef struct {
     *am.StatesBase
@@ -83,26 +81,21 @@ Each module can export their own pipes, like [`/pkg/rpc`](/pkg/rpc) and [`/pkg/n
 - `BindErr`
 - `BindReady`
 
-### Using Pipes
+### Installation Pipes
 
 ```go
 import ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+```
 
-// ...
+### Using Pipes
 
+```go
 ampipe.BindReady(rpcClient.Mach, myMach, "RpcReady", "")
 ```
 
 ### Piping Manually
 
 ```go
-import (
-    am "github.com/pancsta/asyncmachine-go/pkg/machine"
-    ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
-)
-
-// ...
-
 var source *am.Machine
 var target *am.Machine
 

--- a/pkg/telemetry/README.md
+++ b/pkg/telemetry/README.md
@@ -133,7 +133,6 @@ Loki is the easiest way to persist distributed logs from asyncmachine. You'll ne
 ```go
 import (
     "github.com/ic2hrmk/promtail"
-
     am "github.com/pancsta/asyncmachine-go/pkg/machine"
     amtele "github.com/pancsta/asyncmachine-go/pkg/telemetry"
 )

--- a/tools/generator/states_file.go
+++ b/tools/generator/states_file.go
@@ -41,16 +41,21 @@ type Generator struct {
 
 // TODO return err
 func (g *Generator) parseParams(p cli.SFParams) {
-	for _, inherit := range strings.Split(p.Inherit, ",") {
-		switch inherit {
-		case "basic":
-			g.Mach.Add1(ssG.InheritBasic, nil)
-		case "connected":
-			g.Mach.Add1(ssG.InheritConnected, nil)
-		case "rpc/worker":
-			g.Mach.Add1(ssG.InheritRpcWorker, nil)
-		case "node/worker":
-			g.Mach.Add1(ssG.InheritNodeWorker, nil)
+	if p.Inherit != "" {
+		for _, inherit := range strings.Split(p.Inherit, ",") {
+			switch inherit {
+			case "basic":
+				g.Mach.Add1(ssG.InheritBasic, nil)
+			case "connected":
+				g.Mach.Add1(ssG.InheritConnected, nil)
+			case "rpc/worker":
+				g.Mach.Add1(ssG.InheritRpcWorker, nil)
+			case "node/worker":
+				g.Mach.Add1(ssG.InheritNodeWorker, nil)
+			default:
+				// TODO err
+				panic(fmt.Sprintf("unknown inherit: %s", inherit))
+			}
 		}
 	}
 


### PR DESCRIPTION
`FooBar` (aka state-state) handlers were previously only fired between states exit-enter. This left holes in negotiation, as all currently active states should be asked about new ones (not just the ones being de-activated).

This is a very small breaking change (order changed and the handler is called more often).