### PR TITLE
fix(node): migrate to lock-less workers map

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -22,6 +22,17 @@ const (
 	EnvAmNodeLogClient = "AM_NODE_LOG_CLIENT"
 )
 
+// states of a worker
+type WorkerState string
+
+const (
+	StateIniting WorkerState = "initing"
+	StateRpc     WorkerState = "rpc"
+	StateIdle    WorkerState = "idle"
+	StateBusy    WorkerState = "busy"
+	StateReady   WorkerState = "ready"
+)
+
 // ///// ///// /////
 
 // ///// ERRORS
@@ -81,6 +92,8 @@ func AddErrRpc(mach *am.Machine, err error, args am.A) error {
 	return wrappedErr
 }
 
+// ///// ///// /////
+
 // ///// ARGS
 
 // ///// ///// /////
@@ -89,9 +102,9 @@ func AddErrRpc(mach *am.Machine, err error, args am.A) error {
 type A struct {
 	// Id is a machine ID.
 	Id string `log:"id"`
-	// PublicAddr is the public address of a Supervisor or Worker.
+	// PublicAddr is the public address of a Supervisor or WorkerRpc.
 	PublicAddr string `log:"public_addr"`
-	// LocalAddr is the public address of a Supervisor or Worker.
+	// LocalAddr is the public address of a Supervisor or WorkerRpc.
 	LocalAddr string `log:"local_addr"`
 	// BootAddr is the local address of the Bootstrap machine.
 	BootAddr string `log:"boot_addr"`
@@ -104,12 +117,20 @@ type A struct {
 
 	// non-rpc fields
 
-	// Worker is the RPC client connected to a Worker.
-	Worker *rpc.Client
-	// Bootstrap is the RPC machine used to connect Worker to the Supervisor.
+	// WorkerRpc is the RPC client connected to a WorkerRpc.
+	WorkerRpc *rpc.Client
+	// Bootstrap is the RPC machine used to connect WorkerRpc to the Supervisor.
 	Bootstrap *bootstrap
-	// Dispose the worker
+	// Dispose the worker.
 	Dispose bool
+	// WorkerAddr is an index for WorkerInfo.
+	WorkerAddr string
+	// WorkerInfo describes a worker.
+	WorkerInfo *workerInfo
+	// WorkersCh returns a list of workers. This channel has to be buffered.
+	WorkersCh chan<- []*workerInfo
+	// WorkerState is a requested state of workers, eg for listings.
+	WorkerState WorkerState
 }
 
 // ARpc is a subset of A, that can be passed over RPC.

--- a/pkg/node/states/ss_supervisor.go
+++ b/pkg/node/states/ss_supervisor.go
@@ -42,6 +42,11 @@ type SupervisorStatesDef struct {
 
 	// worker
 
+	// ListWorkers is a getter returning a list of workers via a channel, with
+	// filters.
+	ListWorkers string
+	// SetWorker is a setter for a worker, which can also delete worker entries.
+	SetWorker string
 	// ForkWorker - Supervisor starts forking a new worker by creating a new aRPC
 	// server.
 	ForkWorker string
@@ -68,7 +73,7 @@ type SupervisorStatesDef struct {
 	// ProvideWorker - Client requests a new worker.
 	ProvideWorker string
 	// WorkerIssues - Client complains about the worker.
-	WorkerIssues      string
+	WorkerIssues string
 	// ClientSendPayload - payload delivered to the RPC server with for clients
 	// as mutation args.
 	ClientSendPayload string
@@ -79,7 +84,7 @@ type SupervisorStatesDef struct {
 	SuperDisconnected string
 	// SuperSendPayload - payload delivered to the RPC server for supervisors
 	// as mutation args.
-	SuperSendPayload  string
+	SuperSendPayload string
 
 	// inherit from WorkerStatesDef
 	*ssrpc.WorkerStatesDef
@@ -172,6 +177,15 @@ var SupervisorStruct = StructMerge(
 		ssS.WorkersAvailable: {Require: S{ssS.PoolReady}},
 
 		// worker
+
+		ssS.ListWorkers: {
+			Multi:   true,
+			Require: S{ssS.Start},
+		},
+		ssS.SetWorker: {
+			Multi:   true,
+			Require: S{ssS.Start},
+		},
 
 		ssS.ForkWorker: {
 			Multi:   true,

--- a/pkg/node/supervisor_misc.go
+++ b/pkg/node/supervisor_misc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -160,7 +159,6 @@ type workerInfo struct {
 	localAddr  string
 	errs       *cache.Cache
 	errsRecent *cache.Cache
-	mx         sync.RWMutex
 }
 
 func newWorkerInfo(s *Supervisor, proc *os.Process) *workerInfo {

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -185,7 +185,7 @@ func TestAddMany(t *testing.T) {
 	bytesCount := <-counter
 	assert.LessOrEqual(t, 16_300, int(bytesCount),
 		"Client called handshake (2) and A,C (500) and D(1)")
-	assert.GreaterOrEqual(t, 16_500, int(bytesCount),
+	assert.GreaterOrEqual(t, 16_700, int(bytesCount),
 		"Client called handshake (2) and A,C (500) and D(1)")
 
 	disposeTest(t, c, s, true)


### PR DESCRIPTION
Instead of using a concurrent map and per-record RW locks, everything now goes via `ListWorkers` and `SetWorker` states and the `Supervisor.Workers()` getter, while in-handler access is via a regular `map[string]*workerInfo`.