### PR TITLE
feat(machine): allow for partial auto states via handlers

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -82,7 +82,7 @@ func (h *Handlers) AnyFoo(e *am.Event) {}
 
 ```go
 // always called as a transition from Any state to Any state
-func (h *Handlers) AnyAny(e *am.Event) bool {}
+func (h *Handlers) AnyEnter(e *am.Event) bool {}
 ```
 
 ## Global final handler

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -392,8 +392,6 @@ func (e *handler) dispose() {
 const (
 	// Exception is a name the Exception state.
 	Exception = "Exception"
-	// Any is a name of a meta state used in catch-all handlers.
-	Any = "Any"
 )
 
 // ExceptionArgsPanic is an optional argument ["panic"] for the Exception state

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -25,7 +25,13 @@ const (
 	// EnvAmTestDebug activates debugging in tests.
 	EnvAmTestDebug = "AM_TEST_DEBUG"
 	// HandlerGlobal is the name of a global transition handler.
-	HandlerGlobal = "AnyAny"
+	HandlerGlobal = "AnyEnter"
+	// Any is a name of a meta state used in catch-all handlers.
+	Any         = "Any"
+	SuffixEnter = "Enter"
+	SuffixExit  = "Exit"
+	SuffixState = "State"
+	SuffixEnd   = "End"
 )
 
 // S (state names) is a string list of state names.

--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -135,6 +135,7 @@ func StateAdd(source State, overlay State) State {
 
 // StateSet replaces passed relations and properties of the source state.
 // Only relations in the overlay state are replaced, the rest is preserved.
+// If [overlay] has all fields `nil`, then only [auto] and [multi] get applied.
 func StateSet(source State, auto, multi bool, overlay State) State {
 	// TODO example
 	// TODO test
@@ -250,7 +251,9 @@ func ListHandlers(handlers any, states S) ([]string, error) {
 }
 
 // TODO prevent using these names as state names
-var handlerSuffixes = []string{"Enter", "Exit", "State", "End", Any}
+var handlerSuffixes = []string{
+	SuffixEnter, SuffixExit, SuffixState, SuffixEnd, Any,
+}
 
 // IsHandler checks if a method name is a handler method, by returning a state
 // name.
@@ -269,7 +272,7 @@ func IsHandler(states S, method string) (string, string) {
 
 	// AnyFoo
 	if strings.HasPrefix(method, Any) && len(method) != len(Any) &&
-		method != Any+"State" {
+		method != Any+SuffixState {
 		return method[len(Any):], ""
 	}
 

--- a/pkg/machine/utils_test.go
+++ b/pkg/machine/utils_test.go
@@ -12,9 +12,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO bind via Tracer, not handlers
 type History struct {
 	Order   []string
 	Counter map[string]int
+}
+
+// Global
+
+func (h *History) AnyEnter(e *Event) {
+	h.event("AnyEnter")
+}
+
+func (h *History) AnyState(e *Event) {
+	h.event("AnyState")
 }
 
 // A
@@ -31,12 +42,12 @@ func (h *History) AExit(e *Event) {
 	h.event("AExit")
 }
 
-func (h *History) AA(e *Event) {
-	h.event("AA")
+func (h *History) AEnd(e *Event) {
+	h.event("AEnd")
 }
 
-func (h *History) AAny(e *Event) {
-	h.event("AAny")
+func (h *History) AA(e *Event) {
+	h.event("AA")
 }
 
 func (h *History) AState(e *Event) {
@@ -53,16 +64,16 @@ func (h *History) BEnter(e *Event) {
 	h.event("BEnter")
 }
 
+func (h *History) BEnd(e *Event) {
+	h.event("BEnd")
+}
+
 func (h *History) BState(e *Event) {
 	h.event("BState")
 }
 
 func (h *History) BB(e *Event) {
 	h.event("BB")
-}
-
-func (h *History) AnyB(e *Event) {
-	h.event("AnyB")
 }
 
 func (h *History) BExit(e *Event) {
@@ -83,10 +94,6 @@ func (h *History) BC(e *Event) {
 	h.event("BC")
 }
 
-func (h *History) AnyC(e *Event) {
-	h.event("AnyC")
-}
-
 func (h *History) CEnter(e *Event) {
 	h.event("CEnter")
 }
@@ -96,10 +103,6 @@ func (h *History) CState(e *Event) {
 }
 
 // D
-
-func (h *History) AnyD(e *Event) {
-	h.event("AnyD")
-}
 
 func (h *History) DEnter(e *Event) {
 	h.event("DEnter")
@@ -119,6 +122,7 @@ func (h *History) event(name string) {
 	h.Counter[name]++
 }
 
+// TODO bind via Tracer, not handlers
 func trackTransitions(mach *Machine) *History {
 	history := &History{
 		Order:   []string{},

--- a/pkg/states/README.md
+++ b/pkg/states/README.md
@@ -13,6 +13,7 @@ offers tooling for "piping" states between state machines.
 
 - [BasicStatesDef](/pkg/states/ss_basic.go): Start, Ready, Healthcheck
 - [ConnectedStatesDef](/pkg/states/ss_connected.go): Client connection in 4 states
+- [DisposedStatesDef](/pkg/states/ss_disposed.go): Async disposal
 
 ## Installation States
 

--- a/pkg/states/ss_basic.go
+++ b/pkg/states/ss_basic.go
@@ -2,11 +2,12 @@
 //
 // - basic
 // - connected
+// - disposed
 package states
 
 import am "github.com/pancsta/asyncmachine-go/pkg/machine"
 
-// BasicStatesDef contains all the states of the Basic state machine.
+// BasicStatesDef contains all the basic states.
 type BasicStatesDef struct {
 	*am.StatesBase
 

--- a/pkg/states/ss_connected.go
+++ b/pkg/states/ss_connected.go
@@ -4,7 +4,7 @@ import (
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 )
 
-// ConnectedStatesDef contains all the states of the Connected state machine.
+// ConnectedStatesDef contains states for a connection status.
 type ConnectedStatesDef struct {
 	Connecting    string
 	Connected     string

--- a/pkg/states/states_utils.go
+++ b/pkg/states/states_utils.go
@@ -5,7 +5,7 @@ import am "github.com/pancsta/asyncmachine-go/pkg/machine"
 // S is a type alias for a list of state names.
 type S = am.S
 
-// State is a type alias for a state definition.
+// State is a type alias for a state definition. See [am.State].
 type State = am.State
 
 // SAdd is a func alias for merging lists of states.

--- a/tools/generator/states/ss_generator.go
+++ b/tools/generator/states/ss_generator.go
@@ -8,14 +8,20 @@ import (
 type GeneratorStatesDef struct {
 	*am.StatesBase
 
-	InheritBasic      string
-	InheritConnected  string
+	// pkg/states
+	InheritBasic     string
+	InheritConnected string
+	InheritDisposed  string
+
+	// pkg/*
 	InheritRpcWorker  string
 	InheritNodeWorker string
-	Inherit           string
-	GroupsLocal       string
-	GroupsInherited   string
-	Groups            string
+
+	// rest
+	Inherit         string
+	GroupsLocal     string
+	GroupsInherited string
+	Groups          string
 }
 
 // GeneratorGroupsDef contains all the state groups %s state machine.
@@ -25,17 +31,20 @@ type GeneratorGroupsDef struct {
 
 // GeneratorStruct represents all relations and properties of GeneratorStates.
 var GeneratorStruct = am.Struct{
-	ssG.InheritBasic:      {},
-	ssG.InheritConnected:  {Add: S{ssG.GroupsInherited}},
-	ssG.InheritRpcWorker:  {},
+	ssG.InheritBasic:     {},
+	ssG.InheritConnected: {Add: S{ssG.GroupsInherited}},
+	ssG.InheritDisposed:  {},
+
+	ssG.InheritRpcWorker: {},
 	ssG.InheritNodeWorker: {
-		Add: S{ssG.GroupsInherited},
+		Add:    S{ssG.GroupsInherited},
 		Remove: S{ssG.InheritRpcWorker},
 	},
-	ssG.Inherit:           {Auto: true},
-	ssG.GroupsLocal:       {},
-	ssG.GroupsInherited:   {},
-	ssG.Groups:            {Auto: true},
+
+	ssG.Inherit:         {Auto: true},
+	ssG.GroupsLocal:     {},
+	ssG.GroupsInherited: {},
+	ssG.Groups:          {Auto: true},
 }
 
 // EXPORTS AND GROUPS
@@ -44,7 +53,7 @@ var (
 	ssG = am.NewStates(GeneratorStatesDef{})
 	sgG = am.NewStateGroups(GeneratorGroupsDef{
 		Inherit: S{ssG.InheritBasic, ssG.InheritConnected, ssG.InheritRpcWorker,
-			ssG.InheritNodeWorker},
+			ssG.InheritNodeWorker, ssG.InheritDisposed},
 	})
 
 	// GeneratorStates contains all the states for the Generator machine.

--- a/tools/generator/states_file.go
+++ b/tools/generator/states_file.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/lithammer/dedent"
 
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	"github.com/pancsta/asyncmachine-go/tools/generator/cli"
 	"github.com/pancsta/asyncmachine-go/tools/generator/states"
@@ -48,6 +50,8 @@ func (g *Generator) parseParams(p cli.SFParams) {
 				g.Mach.Add1(ssG.InheritBasic, nil)
 			case "connected":
 				g.Mach.Add1(ssG.InheritConnected, nil)
+			case "disposed":
+				g.Mach.Add1(ssG.InheritDisposed, nil)
 			case "rpc/worker":
 				g.Mach.Add1(ssG.InheritRpcWorker, nil)
 			case "node/worker":
@@ -353,6 +357,7 @@ func NewSFGenerator(
 	if err != nil {
 		return nil, err
 	}
+	amhelp.MachDebugEnv(mach)
 
 	g.Mach = mach
 	g.parseParams(param)
@@ -361,7 +366,7 @@ func NewSFGenerator(
 }
 
 func GenUtilsFile() string {
-	return dedent.Dedent(`
+	return strings.Trim(dedent.Dedent(`
 		package states
 		
 		import am "github.com/pancsta/asyncmachine-go/pkg/machine"
@@ -387,7 +392,7 @@ func GenUtilsFile() string {
 
 		// Exception is a type alias for the exception state.
 		var Exception = am.Exception
-	`)
+	`), "\n")
 }
 
 func capitalizeFirstLetter(s string) string {


### PR DESCRIPTION
Until now, partial auto states were accepted only from resolving relation (via Remove). Now, handlers for auto states can also remove that state from target states of a transition.

These will remove `Foo` in auto transitions:

- `FooEnter`
- `BarFoo`
