### PR TITLE
feat(machine): improve exception handling

### DIFF
--- a/pkg/machine/typesafe.go
+++ b/pkg/machine/typesafe.go
@@ -139,11 +139,14 @@ func copyFields(src, dst interface{}) {
 // AT represents typed arguments of pkg/machine, extracted from Event.Args
 // via ParseArgs, or created manually to for Pass.
 type AT struct {
-	Err      error
-	ErrTrace string
-	Panic    *ExceptionArgsPanic
-	// TODO
-	// Event
+	Err          error
+	ErrTrace     string
+	Panic        *ExceptionArgsPanic
+	TargetStates S
+	CalledStates S
+	TimeBefore   Time
+	TimeAfter    Time
+	Event        *Event
 }
 
 // ParseArgs extracts AT from A.


### PR DESCRIPTION
Error mutations will now pass through the queue limit (when needed). 

`ExceptionState` now understands richer context from arguments:
- TargetStates
- CalledStates
- TimeBefore
- TimeAfter
- Event

Still needs to be implemented in `EvAddErrState`.