### PR TITLE
fix(machine): improve timeouts (eg add EvalTimeout)

### DIFF
--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -296,6 +296,29 @@ func (e *Event) Transition() *Transition {
 	return e.Machine().t.Load()
 }
 
+// IsValid confirm this event should still be processed. Useful for negotiation
+// handlers, which can't use state context.
+func (e *Event) IsValid() bool {
+	tx := e.Transition()
+	if tx == nil {
+		return false
+	}
+
+	return e.TransitionId == tx.ID && !tx.IsCompleted() && tx.Accepted
+}
+
+// AcceptTimeout is like IsValid, but requires the handler to stop executing
+// after receiving [true].
+func (e *Event) AcceptTimeout() bool {
+	panic("Not implemented")
+
+	// TODO notify the handler loop
+	// if !e.isClosed {
+	// 	close(e.done)
+	// }
+}
+
+// Clone clones only the essential data of the Event. Useful for tracing vs GC.
 func (e *Event) Clone() *Event {
 	id := e.MachineId
 	if e.Machine() == nil {

--- a/pkg/machine/misc.go
+++ b/pkg/machine/misc.go
@@ -304,7 +304,7 @@ func (e *Event) IsValid() bool {
 		return false
 	}
 
-	return e.TransitionId == tx.ID && !tx.IsCompleted() && tx.Accepted
+	return e.TransitionId == tx.ID && !tx.IsCompleted() && tx.IsAccepted()
 }
 
 // AcceptTimeout is like IsValid, but requires the handler to stop executing

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -11,6 +11,7 @@ import (
 // Transition represents processing of a single mutation within a machine.
 type Transition struct {
 	// ID is a unique identifier of the transition.
+	// TODO refac to Id()
 	ID string
 	// Steps is a list of steps taken by this transition (so far).
 	Steps []*Step
@@ -55,7 +56,7 @@ func newTransition(m *Machine, item *Mutation) *Transition {
 	defer m.activeStatesLock.RUnlock()
 
 	t := &Transition{
-		ID:         RandId(),
+		ID:         randId(),
 		Mutation:   item,
 		TimeBefore: m.time(nil),
 		Machine:    m,

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -245,9 +245,9 @@ var (
 	ErrQueued = errors.New("transition queued")
 	// ErrInvalidArgs can be used to indicate invalid arguments.
 	ErrInvalidArgs = errors.New("invalid arguments")
-	// ErrHandlerTimeout sindicate a timed out mutation.
+	// ErrHandlerTimeout indicates a timed out mutation.
 	ErrHandlerTimeout = errors.New("handler timeout")
-	// ErrHandlerTimeout sindicate a timed out eval func.
+	// ErrHandlerTimeout indicates a timed out eval func.
 	ErrEvalTimeout = errors.New("eval timeout")
 	// ErrTimeout can be used to indicate a timeout.
 	ErrTimeout = errors.New("timeout")

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -67,6 +67,7 @@ type HandlerDispose func(id string, ctx context.Context)
 // Opts struct is used to configure a new Machine.
 type Opts struct {
 	// Unique ID of this machine. Default: random ID.
+	// TODO refac to Id
 	ID string
 	// Time for a handler to execute. Default: time.Second
 	HandlerTimeout time.Duration
@@ -75,6 +76,7 @@ type Opts struct {
 	// If true, the machine will die on panics.
 	DontPanicToException bool
 	// If true, the machine will NOT prefix its logs with its ID.
+	// TODO refac to DontLogId
 	DontLogID bool
 	// Custom relations resolver. Default: *DefaultRelationsResolver.
 	Resolver RelationsResolver
@@ -88,6 +90,7 @@ type Opts struct {
 	// Overrides ParentID. Default: nil.
 	Parent Api
 	// ParentID is the ID of the parent machine. Default: "".
+	// TODO refac to ParentId
 	ParentID string
 	// Tags is a list of tags for the machine. Default: nil.
 	Tags []string
@@ -133,7 +136,7 @@ type Api interface {
 
 	// ///// LOCAL
 
-	// Checking (local)
+	// Checking (local)o
 
 	IsErr() bool
 	Is(states S) bool
@@ -234,14 +237,18 @@ const (
 var (
 	// ErrStateUnknown indicates that the state is unknown.
 	ErrStateUnknown = errors.New("state unknown")
+	// ErrStateInactive indicates that a neccessary state isn't active.
+	ErrStateInactive = errors.New("state not active")
 	// ErrCanceled can be used to indicate a canceled Transition.
 	ErrCanceled = errors.New("transition canceled")
 	// ErrQueued can be used to indicate a queued Transition.
 	ErrQueued = errors.New("transition queued")
 	// ErrInvalidArgs can be used to indicate invalid arguments.
 	ErrInvalidArgs = errors.New("invalid arguments")
-	// ErrHandlerTimeout can be used to indicate timed out mutation.
+	// ErrHandlerTimeout sindicate a timed out mutation.
 	ErrHandlerTimeout = errors.New("handler timeout")
+	// ErrHandlerTimeout sindicate a timed out eval func.
+	ErrEvalTimeout = errors.New("eval timeout")
 	// ErrTimeout can be used to indicate a timeout.
 	ErrTimeout = errors.New("timeout")
 	// ErrStateMissing is used to indicate missing states.

--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -408,7 +408,7 @@ type handlerCall struct {
 	timeout bool
 }
 
-func RandId() string {
+func randId() string {
 	id := make([]byte, 16)
 	_, err := rand.Read(id)
 	if err != nil {

--- a/pkg/rpc/rpc_worker.go
+++ b/pkg/rpc/rpc_worker.go
@@ -1423,7 +1423,8 @@ func (w *Worker) updateClock(now am.Time) {
 	}
 
 	tx := &am.Transition{
-		Api:      w,
+		Api: w,
+		// TODO IsAccepted()
 		Accepted: true,
 
 		TimeBefore: before,


### PR DESCRIPTION
`Eval` now has a separate timeout, as the way eval funcs execute is completely different than handlers. Additionally
event now exposes `Event.IsValid()`, but changes in the handler loop are needed to properly implement timeouts.

Further work forked to https://github.com/pancsta/asyncmachine-go/issues/220.