### PR TITLE
feat(am-dbg): add `--client-list file.txt` for a live detailed dump

### DIFF
--- a/tools/cmd/am-dbg/cmd_dbg.go
+++ b/tools/cmd/am-dbg/cmd_dbg.go
@@ -47,6 +47,7 @@ func cliRun(_ *cobra.Command, _ []string, p cli.Params) {
 		DbgLogLevel:     p.LogLevel,
 		DbgLogger:       logger,
 		ImportData:      p.ImportData,
+		ClientList:      p.ClientList,
 		ServerAddr:      p.ServerAddr,
 		EnableMouse:     p.EnableMouse,
 		SelectConnected: p.SelectConnected,

--- a/tools/debugger/cli/cli.go
+++ b/tools/debugger/cli/cli.go
@@ -31,6 +31,7 @@ const (
 	pCleanOnConnect   = "clean-on-connect"
 	pVersion          = "version"
 	pImport           = "import-data"
+	pClientList       = "client-list"
 	pImportShort      = "i"
 	pSelectConn       = "select-connected"
 	pSelectConnShort  = "c"
@@ -60,6 +61,7 @@ type Params struct {
 	ServerAddr      string
 	DebugAddr       string
 	ImportData      string
+	ClientList      string
 	StartupMachine  string
 	StartupView     string
 	StartupTx       int
@@ -107,6 +109,8 @@ func AddFlags(rootCmd *cobra.Command) {
 	f.StringP(pStartupMach,
 		pStartupMachShort, "",
 		"Select a machine by (partial) ID on startup (requires --"+pImport+")")
+	f.String(pClientList, "", "Keep this file up-to-date with connected"+
+		` clients (eg. "am-dbg.txt")`)
 
 	// TODO parse copy-paste commas, eg 1,001
 	f.IntP(pStartupTx, pStartupTxShort, 0,
@@ -151,6 +155,7 @@ func ParseParams(cmd *cobra.Command, _ []string) Params {
 	serverAddr := cmd.Flag(pServerAddr).Value.String()
 	debugAddr := cmd.Flag(pAmDbgAddr).Value.String()
 	importData := cmd.Flag(pImport).Value.String()
+	clientList := cmd.Flag(pClientList).Value.String()
 	fwdDataRaw := cmd.Flag(pFwdData).Value.String()
 	profSrv := cmd.Flag(pProfSrv).Value.String()
 	startupMachine := cmd.Flag(pStartupMach).Value.String()
@@ -201,6 +206,7 @@ func ParseParams(cmd *cobra.Command, _ []string) Params {
 		ServerAddr:      serverAddr,
 		DebugAddr:       debugAddr,
 		ImportData:      importData,
+		ClientList:      clientList,
 		StartupMachine:  startupMachine,
 		StartupView:     startupView,
 		StartupTx:       startupTx,
@@ -278,7 +284,7 @@ func StartCpuProfileSrv(ctx context.Context, logger *log.Logger, p *Params) {
 		return
 	}
 	go func() {
-		logger.Println("Starting pprof server on "+p.ProfSrv)
+		logger.Println("Starting pprof server on " + p.ProfSrv)
 		// TODO support ctx cancel
 		if err := http.ListenAndServe(p.ProfSrv, nil); err != nil {
 			logger.Fatalf("could not start pprof server: %v", err)

--- a/tools/debugger/client_list.go
+++ b/tools/debugger/client_list.go
@@ -148,6 +148,8 @@ func (d *Debugger) doUpdateClientList(immediate bool) {
 			longestName = maxLen
 		}
 
+		txtFile := ""
+
 		// update
 		for i, item := range d.clientList.GetItems() {
 			ref := item.GetReference().(*sidebarRef)
@@ -174,6 +176,18 @@ func (d *Debugger) doUpdateClientList(immediate bool) {
 				strings.Repeat(" ", spaceCount) + spacePost
 			label := d.getClientListLabel(namePad, c, i)
 			item.SetMainText(label)
+
+			// txt file
+			if d.Opts.ClientList != "" {
+				if !hasParent {
+					txtFile += "\n"
+				}
+				txtFile += string(cview.StripTags([]byte(label), true, false)) + "\n"
+				for _, tag := range c.MsgStruct.Tags {
+					txtFile += strings.Repeat(" ", ref.lvl) + spacePre +
+						"  #" + tag + "\n"
+				}
+			}
 		}
 
 		if len(d.Clients) > 0 {
@@ -191,6 +205,13 @@ func (d *Debugger) doUpdateClientList(immediate bool) {
 		// render if delayed
 		if !immediate {
 			d.draw(d.clientList)
+		}
+
+		// save to a file
+		if d.Opts.ClientList != "" {
+			_, _ = d.clientListFile.Seek(0, 0)
+			_ = d.clientListFile.Truncate(0)
+			_, _ = d.clientListFile.Write([]byte(txtFile))
 		}
 	}
 

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -286,6 +286,8 @@ type Opts struct {
 	Filters *OptsFilters
 	// File path to import (brotli)
 	ImportData string
+	// File to dump client list into.
+	ClientList string
 	// Screen overload for tests & ssh
 	Screen tcell.Screen
 	// Debugger's ID
@@ -398,6 +400,7 @@ type Debugger struct {
 	clip            clipper.Clipboard
 	// toolbarItems is a list of row of toolbars items
 	toolbarItems     [][]toolbarItem
+	clientListFile   *os.File
 	msgsDelayed      []*telemetry.DbgMsgTx
 	msgsDelayedConns []string
 }
@@ -470,6 +473,15 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 		mach.AddErr(fmt.Errorf("clipboard init: %w", err), nil)
 	}
 	d.clip = clip
+
+	// client list file
+	if d.Opts.ClientList != "" {
+		clientListFile, err := os.Create(d.Opts.ClientList)
+		if err != nil {
+			mach.AddErr(fmt.Errorf("client list file open: %w", err), nil)
+		}
+		d.clientListFile = clientListFile
+	}
 
 	return d, nil
 }


### PR DESCRIPTION
With a large list of clients, especially tagged ones, it's way easier to browser it in a plain text file. It refreshes
automatically to match the current one in the TUI. Useful for searching for peer IDs and addresses within tags.

Using `--client-list am-dbg.txt` will create `am-dbg.txt` in CWD.

```bash
ps-TestExposingMany-p0-root   R|85+
  #pubsub:TestExposingMany
  #peer:12D3KooWKBTjhWff2Vd1xbW41duMp5hJmZsBnfGrcNz4vL7XNpuy
- ps-rand-p1-0-065a            |0
    #pubsub-worker
    #src-id:rand-p1-0
- ps-rand-p1-1-41b0            |0
    #pubsub-worker
    #src-id:rand-p1-1
- ps-rand-p1-2-ab80            |0
    #pubsub-worker
    #src-id:rand-p1-2
- ps-rand-p3-0-7408            |0
    #pubsub-worker
    #src-id:rand-p3-0
- ps-rand-p3-1-8476            |0
    #pubsub-worker
    #src-id:rand-p3-1
- ps-rand-p3-2-2787            |0
    #pubsub-worker
    #src-id:rand-p3-2
- ps-rand-p4-0-1f7e            |0
    #pubsub-worker
    #src-id:rand-p4-0
- ps-rand-p4-1-5590            |0
    #pubsub-worker
    #src-id:rand-p4-1
- ps-rand-p4-2-74d8            |0
    #pubsub-worker
    #src-id:rand-p4-2
- ps-rand-p5-0-3728            |1
    #pubsub-worker
    #src-id:rand-p5-0
- ps-rand-p5-1-e61a            |1
    #pubsub-worker
    #src-id:rand-p5-1
- ps-rand-p5-2-fc37            |1
    #pubsub-worker
    #src-id:rand-p5-2

ps-TestExposingMany-p1        S|102+
  #pubsub:TestExposingMany
  #peer:12D3KooWJ6a95r7XZrHXJ8YonNH3xnwWgfdEpcPDTTmEv2Ypdh9Z
- ps-rand-p3-0-831a            |0
    #pubsub-worker
    #src-id:rand-p3-0
- ps-rand-p3-1-c081            |0
    #pubsub-worker
    #src-id:rand-p3-1
- ps-rand-p3-2-1248            |0
    #pubsub-worker
    #src-id:rand-p3-2
- ps-rand-p4-0-370b            |0
    #pubsub-worker
    #src-id:rand-p4-0
- ps-rand-p4-1-4909            |0
    #pubsub-worker
    #src-id:rand-p4-1
- ps-rand-p4-2-069f            |0
    #pubsub-worker
    #src-id:rand-p4-2
- ps-rand-p5-0-783d            |1
    #pubsub-worker
    #src-id:rand-p5-0
- ps-rand-p5-1-a73f            |1
    #pubsub-worker
    #src-id:rand-p5-1
- ps-rand-p5-2-9d04            |1
    #pubsub-worker
    #src-id:rand-p5-2
```
