### PR TITLE
feat(pkg/states): add global import, BindStart, ConnPool

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,8 +5,7 @@ on: [push]
 jobs:
   build:
 
-    # TODO disable until fixed on GH
-    if: false  # Disable this job
+#    if: false  # Disable this job
 
     runs-on: ubuntu-latest
     strategy:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -270,7 +270,7 @@ tasks:
 
   lint-go:
     cmds:
-      - $(go env GOPATH)/bin/golangci-lint run --fix
+      - $(go env GOPATH)/bin/golangci-lint run --fix --timeout 5m
 
   lint-md:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -295,7 +295,7 @@ tasks:
   install-deps:
     cmds:
       - go mod tidy
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
       - go install mvdan.cc/gofumpt@latest
       - go install golang.org/x/tools/cmd/goimports@latest
       - go install github.com/mattn/goreman@latest

--- a/pkg/states/global/states_utils.go
+++ b/pkg/states/global/states_utils.go
@@ -1,0 +1,33 @@
+// Package global should be imported into the package's global scope with:
+//
+//	import _ "github.com/pancsta/asyncmachine-go/pkg/states/global"
+//
+// This removes the need for manual updates, with the cost of an implicit
+// import.
+package global
+
+// TODO import in local pkgs, as global namespace
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// State is a type alias for a state definition. See [am.State].
+type State = am.State
+
+// SAdd is a func alias for merging lists of states.
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition.
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition.
+var StateSet = am.StateSet
+
+// SchemaMerge is a func alias for extending an existing state schema.
+var SchemaMerge = am.StructMerge
+
+// Exception is a type alias for the exception state.
+var Exception = am.Exception

--- a/pkg/states/pipes/pipes.go
+++ b/pkg/states/pipes/pipes.go
@@ -116,6 +116,30 @@ func BindErr(source, target *am.Machine, targetErr string) error {
 	return source.BindHandlers(h)
 }
 
+// BindStart binds Start to custom states using Add/Remove. Empty state
+// defaults to Start.
+func BindStart(
+	source, target *am.Machine, activeState, inactiveState string,
+) error {
+
+	if activeState == "" {
+		activeState = ss.BasicStates.Start
+	}
+	if inactiveState == "" {
+		inactiveState = ss.BasicStates.Start
+	}
+
+	h := &struct {
+		StartState am.HandlerFinal
+		StartEnd   am.HandlerFinal
+	}{
+		StartState: Add(source, target, ss.BasicStates.Start, activeState),
+		StartEnd:   Remove(source, target, ss.BasicStates.Start, inactiveState),
+	}
+
+	return source.BindHandlers(h)
+}
+
 // BindReady binds Ready to custom states using Add/Remove. Empty state
 // defaults to Ready.
 func BindReady(
@@ -139,6 +163,35 @@ func BindReady(
 
 	return source.BindHandlers(h)
 }
+
+// // Bind binds an arbitrary state to custom states using Add and Remove.
+// // Empty [activeState] and [inactiveState] defaults to [source].
+// // TODO
+// func Bind(
+// 	state string, source, target *am.Machine, activeState, inactiveState string
+// ) error {
+//
+// 	if state == "" {
+// 		return am.ErrStateMissing
+// 	}
+// 	if activeState == "" {
+// 		activeState = state
+// 	}
+// 	if inactiveState == "" {
+// 		inactiveState = state
+// 	}
+//
+// 	// TODO dynamic struct init, see pkg/rpc
+// 	h := &struct {
+// 		StartState am.HandlerFinal
+// 		StartEnd   am.HandlerFinal
+// 	}{
+// 		StartState: Add(source, target, ss.BasicStates.Start, activeState),
+// 		StartEnd:   Remove(source, target, ss.BasicStates.Start, inactiveState),
+// 	}
+//
+// 	return source.BindHandlers(h)
+// }
 
 func gcHandler(mach *am.Machine) am.HandlerDispose {
 	return func(id string, ctx context.Context) {

--- a/pkg/states/ss_connected.go
+++ b/pkg/states/ss_connected.go
@@ -1,5 +1,8 @@
 package states
 
+// TODO rename to Schem
+// TODO rename to Schema
+
 import (
 	"errors"
 	"fmt"
@@ -7,61 +10,72 @@ import (
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 )
 
+// ///// ///// /////
+
+// ///// CONECTED
+
+// TODO document both
+// ///// ///// /////
+
+type ConnectedState = string
+
 // ConnectedStatesDef contains states for a connection status.
 // Required states:
 // - Start
 type ConnectedStatesDef struct {
 	// ErrConnecting is a detailed connection error, eg no access.
-	ErrConnecting string
+	ErrConnecting ConnectedState
 
-	Connecting    string
-	Connected     string
-	Disconnecting string
-	Disconnected  string
+	Connecting    ConnectedState
+	Connected     ConnectedState
+	Disconnecting ConnectedState
+	Disconnected  ConnectedState
 
 	*am.StatesBase
 }
 
-// ConnectedGroupsDef contains all the state groups of the Connected state set.
+// ConnectedGroupsDef contains all the state groups of the Connected state
+// schema.
 type ConnectedGroupsDef struct {
 	Connected S
 }
 
 // ConnectedStruct represents all relations and properties of ConnectedStates.
-var ConnectedStruct = am.Struct{
-	cs.ErrConnecting: {Require: S{Exception}},
+var ConnectedStruct = am.Schema{
+	ssC.ErrConnecting: {Require: S{Exception}},
 
-	cs.Connecting: {
+	ssC.Connecting: {
 		Require: S{ssB.Start},
-		Remove:  cg.Connected,
+		Remove:  sgC.Connected,
 	},
-	cs.Connected: {
+	ssC.Connected: {
 		Require: S{ssB.Start},
-		Remove:  cg.Connected,
+		Remove:  sgC.Connected,
 	},
-	cs.Disconnecting: {Remove: cg.Connected},
-	cs.Disconnected: {
+	ssC.Disconnecting: {Remove: sgC.Connected},
+	ssC.Disconnected: {
 		Auto:   true,
-		Remove: cg.Connected,
+		Remove: sgC.Connected,
 	},
 }
 
 // EXPORTS AND GROUPS
 
 var (
-	cs = am.NewStates(ConnectedStatesDef{})
-	cg = am.NewStateGroups(ConnectedGroupsDef{
+	ssC = am.NewStates(ConnectedStatesDef{})
+	sgC = am.NewStateGroups(ConnectedGroupsDef{
 		Connected: S{
-			cs.Connecting, cs.Connected, cs.Disconnecting,
-			cs.Disconnected,
+			ssC.Connecting, ssC.Connected, ssC.Disconnecting,
+			ssC.Disconnected,
 		},
 	})
 
-	// ConnectedStates contains all the states for the Connected state set.
-	ConnectedStates = cs
+	// ConnectedStates contains all the states for the Connected state schema.
+	ConnectedStates = ssC
 
-	// ConnectedGroups contains all the state groups for the Connected state set.
-	ConnectedGroups = cg
+	// ConnectedGroups contains all the state groups for the Connected state
+	// schema.
+	ConnectedGroups = sgC
 )
 
 // ERRORS
@@ -78,7 +92,76 @@ func AddErrConnecting(
 	event *am.Event, mach *am.Machine, err error, args am.A,
 ) error {
 	err = fmt.Errorf("%w: %w", ErrConnecting, err)
-	mach.EvAddErrState(event, cs.ErrConnecting, err, args)
+	mach.EvAddErrState(event, ssC.ErrConnecting, err, args)
 
 	return err
 }
+
+// ///// ///// /////
+
+// ///// CONNECTION POOL
+
+// Connection to multiple hosts, states aggregating a pool of connections.
+// ///// ///// /////
+
+type ConnPoolState = string
+
+// ConnPoolStatesDef contains states for a connection status.
+// Required states:
+// - Start
+type ConnPoolStatesDef struct {
+	// ErrConnecting is a detailed connection error, eg no access.
+	ErrConnecting ConnPoolState
+
+	Connecting     ConnPoolState
+	Connected      ConnPoolState
+	ConnectedFully ConnPoolState
+	Disconnecting  ConnPoolState
+	Disconnected   ConnPoolState
+
+	*am.StatesBase
+}
+
+// ConnPoolGroupsDef contains all the state groups of the ConnPool state schema.
+type ConnPoolGroupsDef struct {
+	Connected S
+}
+
+// ConnPoolSchema represents all relations and properties of ConnPoolStates.
+var ConnPoolSchema = am.Schema{
+	ssPc.ErrConnecting: {Require: S{Exception}},
+
+	ssPc.Disconnected: {
+		Remove: S{ssPc.Connecting, ssPc.ConnectedFully, ssPc.Disconnecting},
+	},
+	ssPc.Connecting: {
+		Require: S{ssB.Start},
+		Remove:  S{ssPc.Disconnecting},
+	},
+	ssPc.Connected: {
+		Require: S{ssB.Start},
+		Remove:  S{ssPc.Disconnected},
+	},
+	ssPc.ConnectedFully: {
+		Require: S{ssPc.Connected},
+		Remove:  S{ssPc.Disconnected},
+	},
+	ssPc.Disconnecting: {
+		Remove: S{ssPc.ConnectedFully, ssPc.Connected, ssPc.Connecting},
+	},
+}
+
+// EXPORTS AND GROUPS
+
+var (
+	ssPc = am.NewStates(ConnPoolStatesDef{})
+	sgCp = am.NewStateGroups(ConnPoolGroupsDef{
+		Connected: S{ssPc.Connected, ssPc.Disconnected},
+	})
+
+	// ConnPoolStates contains all the states for the ConnPool state schema.
+	ConnPoolStates = ssPc
+
+	// ConnPoolGroups contains all the state groups for the ConnPool state schema.
+	ConnPoolGroups = sgCp
+)

--- a/pkg/states/ss_disposed.go
+++ b/pkg/states/ss_disposed.go
@@ -27,7 +27,7 @@ type DisposedGroupsDef struct {
 
 // DisposedStruct represents all relations and properties of DisposedStates.
 var DisposedStruct = am.Struct{
-	ssD.RegisterDisposal: {},
+	ssD.RegisterDisposal: {Multi: true},
 	ssD.Disposing:        {Remove: sgD.Disposed},
 	ssD.Disposed:         {Remove: SAdd(sgD.Disposed, S{ssB.Start})},
 }
@@ -61,8 +61,6 @@ func (h *DisposedHandlers) RegisterDisposalEnter(e *am.Event) bool {
 }
 
 func (h *DisposedHandlers) RegisterDisposalState(e *am.Event) {
-	e.Machine().Remove1(ssD.RegisterDisposal, nil)
-
 	fn := e.Args[DisposedArgHandler].(am.HandlerDispose)
 	h.DisposedHandlers = append(h.DisposedHandlers, fn)
 }

--- a/tools/generator/states_file.go
+++ b/tools/generator/states_file.go
@@ -2,6 +2,7 @@
 //  - repeated cli params
 //  - AST
 //  - embed pkg/states/states_utils.go
+//  	- optional with pkg/states/global
 
 package generator
 


### PR DESCRIPTION
We can skip the states_utils.go file now by importing the namespace into the global scope.

```go
import _ "github.com/pancsta/asyncmachine-go/pkg/states/global"
```

`ConnPool` extends `Connected` schema and adda a new `ConnectedFully` state.

```go
// ConnPoolSchema represents all relations and properties of ConnPoolStates.
var ConnPoolSchema = am.Schema{
	ssPc.ErrConnecting: {Require: S{Exception}},

	ssPc.Disconnected: {
		Remove: S{ssPc.Connecting, ssPc.ConnectedFully, ssPc.Disconnecting},
	},
	ssPc.Connecting: {
		Require: S{ssB.Start},
		Remove:  S{ssPc.Disconnecting},
	},
	ssPc.Connected: {
		Require: S{ssB.Start},
		Remove:  S{ssPc.Disconnected},
	},
	ssPc.ConnectedFully: {
		Require: S{ssPc.Connected},
		Remove:  S{ssPc.Disconnected},
	},
	ssPc.Disconnecting: {
		Remove: S{ssPc.ConnectedFully, ssPc.Connected, ssPc.Connecting},
	},
}
```