### PR TITLE
feat(telemetry): improve Otel integration

### DIFF
--- a/examples/mach_template/mach_template.go
+++ b/examples/mach_template/mach_template.go
@@ -117,7 +117,7 @@ func NewTemplate(ctx context.Context, num int) (*am.Machine, error) {
 		}
 
 		// open telemetry traces
-		err = amtele.MachBindOtelEnv(mach, false)
+		err = amtele.MachBindOtelEnv(mach)
 		if err != nil {
 			mach.AddErr(err, nil)
 		}

--- a/internal/testing/states/ss_rel.go
+++ b/internal/testing/states/ss_rel.go
@@ -2,12 +2,17 @@
 
 package states
 
-import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+import (
+	"context"
+
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
 
 // S is a type alias for a list of state names.
 type S = am.S
 
 // States map defines relations and properties of states.
+// TODO rename to rel
 var States = am.Struct{
 	A: {
 		Auto:    true,
@@ -52,3 +57,7 @@ var Names = S{
 }
 
 // #endregion
+
+func NewRel(ctx context.Context) *am.Machine {
+	return am.New(ctx, States, nil)
+}

--- a/internal/testing/utils/test_utils.go
+++ b/internal/testing/utils/test_utils.go
@@ -39,7 +39,7 @@ func RandPort(min, max int) string {
 }
 
 // RandListener creates a new listener on an open port between 40000 and 50000.
-// It allows to avoid conflicts with other tests, using predefined addresses,
+// It allows avoiding conflicts with other tests, using predefined addresses,
 // unlike using port 0.
 func RandListener(host string) net.Listener {
 
@@ -74,13 +74,14 @@ func NewRels(t *testing.T, initialState am.S) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
 	if initialState != nil {
 		mach.Set(initialState, nil)
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }
@@ -93,7 +94,7 @@ func NewRelsRpcWorker(t *testing.T, initialState am.S) *am.Machine {
 
 	// TODO define these in /states using v2 as RelWorkerStruct and
 	//  RelWorkerStates, inheriting frm RelStructDef etc
-	ssStruct := am.StructMerge(ssrpc.WorkerStruct, ss.States)
+	ssStruct := am.SchemaMerge(ssrpc.WorkerStruct, ss.States)
 	ssNames := am.SAdd(ss.Names, ssrpc.WorkerStates.Names())
 
 	// machine init
@@ -104,8 +105,8 @@ func NewRelsRpcWorker(t *testing.T, initialState am.S) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
 	if initialState != nil {
@@ -118,7 +119,7 @@ func NewRelsRpcWorker(t *testing.T, initialState am.S) *am.Machine {
 // inherit from RPC worker
 
 var (
-	RelsNodeWorkerStruct = am.StructMerge(ssnode.WorkerStruct, ss.States)
+	RelsNodeWorkerStruct = am.SchemaMerge(ssnode.WorkerStruct, ss.States)
 	RelsNodeWorkerStates = am.SAdd(ss.Names, ssnode.WorkerStates.Names())
 )
 
@@ -134,13 +135,14 @@ func NewRelsNodeWorker(t *testing.T, initialState am.S) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
 	if initialState != nil {
 		mach.Set(initialState, nil)
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }
@@ -159,13 +161,14 @@ func NewNoRels(t *testing.T, initialState am.S) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
 	if initialState != nil {
 		mach.Set(initialState, nil)
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }
@@ -174,8 +177,7 @@ func NewNoRels(t *testing.T, initialState am.S) *am.Machine {
 func NewNoRelsRpcWorker(t *testing.T, initialState am.S) *am.Machine {
 
 	// inherit from RPC worker
-
-	ssStruct := am.StructMerge(ssrpc.WorkerStruct, am.Struct{
+	ssStruct := am.SchemaMerge(ssrpc.WorkerStruct, am.Struct{
 		ss.A: {},
 		ss.B: {},
 		ss.C: {},
@@ -190,13 +192,14 @@ func NewNoRelsRpcWorker(t *testing.T, initialState am.S) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
 	if initialState != nil {
 		mach.Set(initialState, nil)
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }
@@ -210,10 +213,11 @@ func NewCustom(t *testing.T, states am.Struct) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }
@@ -223,7 +227,7 @@ func NewCustomRpcWorker(t *testing.T, states am.Struct) *am.Machine {
 
 	// inherit from RPC worker
 
-	ssStruct := am.StructMerge(ssrpc.WorkerStruct, states)
+	ssStruct := am.SchemaMerge(ssrpc.WorkerStruct, states)
 	ssNames := am.SAdd(maps.Keys(states), ssrpc.WorkerStates.Names())
 
 	mach := am.New(context.Background(), ssStruct, &am.Opts{
@@ -233,10 +237,11 @@ func NewCustomRpcWorker(t *testing.T, states am.Struct) *am.Machine {
 		t.Fatal(err)
 	}
 
+	mach.SetLogLevel(am.EnvLogLevel(os.Getenv(am.EnvAmLog)))
 	if os.Getenv(am.EnvAmDebug) != "" && os.Getenv(EnvAmTestRunner) == "" {
-		mach.SetLogLevel(am.LogEverything)
 		mach.HandlerTimeout = 2 * time.Minute
 	}
+	mach.SetLogArgs(am.NewArgsMapper(am.LogArgs, 50))
 
 	return mach
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -119,6 +119,6 @@ func Sp(txt string, args ...any) string {
 	return fmt.Sprintf(dedent.Dedent(strings.Trim(txt, "\n")), args...)
 }
 
-func P(txt string, args ...any) (int, error) {
-	return fmt.Printf(dedent.Dedent(strings.Trim(txt, "\n")), args...)
+func P(txt string, args ...any) {
+	fmt.Printf(dedent.Dedent(strings.Trim(txt, "\n")), args...)
 }

--- a/pkg/helpers/help.go
+++ b/pkg/helpers/help.go
@@ -163,7 +163,7 @@ func IndexesToStates(allStates am.S, indexes []int) am.S {
 }
 
 // MachDebug sets up a machine for debugging, based on the AM_DEBUG env var,
-// passed am-dbg address, log level and stdout flag.
+// passed am-dbg address, log level, and stdout flag.
 func MachDebug(
 	mach am.Api, amDbgAddr string, logLvl am.LogLevel, stdout bool,
 ) {

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -936,7 +936,8 @@ func (h *TestHandlerStateInfoHandlers) DEnter(e *Event) {
 		"provide the target states of the transition")
 	assert.True(t, e.Mutation().StateWasCalled("D"),
 		"provide the called states of the transition")
-	txStrExp := "D (requested)\nD (set)\nA (remove)\nA (handler)"
+	txStrExp := "A -> D (requested)\nA -> D (set)\n" +
+		"A -> A (remove)\nA -> A (handler)"
 	txStr := e.Transition().String()
 	assert.Equal(t, txStrExp, txStr,
 		"provide a string version of the transition")

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -251,23 +251,9 @@ func (t *Transition) LogArgs() string {
 
 // String representation of the transition and the steps taken so far.
 func (t *Transition) String() string {
-	// TODO infer handler names
 	var lines []string
 	for _, step := range t.Steps {
-
-		var line string
-		if step.FromState != "" && step.ToState != "" {
-			line += step.FromState + " -> " + step.ToState
-		} else {
-			name := step.FromState
-			if name == "" {
-				name = step.ToState
-			}
-			line = name
-		}
-
-		line += " (" + step.Type.String() + ")"
-		lines = append(lines, line)
+		lines = append(lines, step.StringFromIdx(t.Machine.StateNames()))
 	}
 
 	return strings.Join(lines, "\n")

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -142,7 +142,7 @@ type Api interface {
 
 	// ///// LOCAL
 
-	// Checking (local)o
+	// Checking (local)
 
 	IsErr() bool
 	Is(states S) bool
@@ -338,6 +338,10 @@ func (m Mutation) StateWasCalled(state string) bool {
 	return slices.Contains(m.CalledStates, state)
 }
 
+func (m Mutation) String() string {
+	return "[" + m.Type.String() + "] " + j(m.CalledStates)
+}
+
 // StepType enum
 type StepType int8
 
@@ -402,6 +406,9 @@ type Step struct {
 // GetToState().
 func (s *Step) GetFromState(index S) string {
 	// TODO rename to FromState
+	if s.FromState != "" {
+		return s.FromState
+	}
 	if s.FromStateIdx == -1 {
 		return ""
 	}
@@ -416,6 +423,9 @@ func (s *Step) GetFromState(index S) string {
 // GetFromState().
 func (s *Step) GetToState(index S) string {
 	// TODO rename to ToState
+	if s.ToState != "" {
+		return s.ToState
+	}
 	if s.ToStateIdx == -1 {
 		return ""
 	}
@@ -424,6 +434,24 @@ func (s *Step) GetToState(index S) string {
 	}
 
 	return ""
+}
+
+func (s *Step) StringFromIdx(idx S) string {
+	var line string
+	from := s.GetFromState(idx)
+	to := s.GetToState(idx)
+
+	if from != "" && to != "" {
+		line += from + " -> " + to
+	} else {
+		line = from
+		if line == "" {
+			line = to
+		}
+	}
+
+	// TODO infer handler names
+	return line + " (" + s.Type.String() + ")"
 }
 
 func newStep(from string, to string, stepType StepType,

--- a/tools/generator/grafana.go
+++ b/tools/generator/grafana.go
@@ -39,6 +39,17 @@ func GenDashboard(p cli.GrafanaParams) (*dashboard.Builder, error) {
 					prometheus.Legend("Number of transitions"),
 				),
 			),
+
+			row.WithHeatmap(
+				"Transition errors",
+				heatmap.Span(12),
+				heatmap.Height("150px"),
+				heatmap.DataSource("Prometheus"),
+				heatmap.WithPrometheusTarget(
+					`am_exceptions_`+pId+`{job="`+source+`"}`,
+					prometheus.Legend("Exception"),
+				),
+			),
 		), dashboard.Row(
 			"Details: "+id,
 			row.Collapse(),
@@ -123,17 +134,6 @@ func GenDashboard(p cli.GrafanaParams) (*dashboard.Builder, error) {
 				heatmap.WithPrometheusTarget(
 					`am_tx_time_`+pId+`{job="`+source+`"}`,
 					prometheus.Legend("Human time (μs)"),
-				),
-			),
-
-			row.WithHeatmap(
-				"Transition errors",
-				heatmap.Span(12),
-				heatmap.Height("150px"),
-				heatmap.DataSource("Prometheus"),
-				heatmap.WithPrometheusTarget(
-					`am_exceptions_`+pId+`{job="`+source+`"}`,
-					prometheus.Legend("Exception"),
 				),
 			),
 		), dashboard.Row(


### PR DESCRIPTION
Changes:
- extend tracing config (add health, handlers, auto)
- link states and transitions
- group handlers as events
- group multi-states as event
- show mutations as events of states
- fix canceled txs
- link transitions to their source transitions (eg from EvAdd)
- env based loki logger
- remove dep on samber/lo
- move Grafana error panel to 2nd position

Some people seems to really like Otel traces, so this iteration covers all the postponed features like linking and noise reduction. This should be enough to handle tracing of larger datasets. Skipping canceled and empty is still pending, as it requires writing a custom processor.

![otel-jaeger dark](https://github.com/user-attachments/assets/a81098d4-dbc9-4753-bca4-d810919df889)
