### PR TITLE
feat(integrations): add NATS and JSON types with schemas

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -460,3 +460,7 @@ tasks:
   am-dbg-dashboard:
     desc: Start an example am-dbg dashboard
     cmd: zellij --layout ./config/dashboards/2x1x1.kdl
+
+  gen-jsonschema:
+    desc: Generate JSON schemas for pkg/integrations
+    cmd: go run ./scripts/gen_jsonschema

--- a/docs/jsonschema/getter_req.json
+++ b/docs/jsonschema/getter_req.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/getter-req",
+  "$ref": "#/$defs/GetterReq",
+  "$defs": {
+    "GetterReq": {
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the request."
+        },
+        "time": {
+          "$ref": "#/$defs/S",
+          "description": "Request ticks of the passed states"
+        },
+        "time_sum": {
+          "$ref": "#/$defs/S",
+          "description": "Request the sum of ticks of the passed states"
+        },
+        "clocks": {
+          "$ref": "#/$defs/S",
+          "description": "Request named clocks of the passed states"
+        },
+        "tags": {
+          "type": "boolean",
+          "description": "Request the tags of the state machine"
+        },
+        "export": {
+          "type": "boolean",
+          "description": "Request an importable version of the state machine"
+        },
+        "id": {
+          "type": "boolean",
+          "description": "Request the ID of the state machine"
+        },
+        "parent_id": {
+          "type": "boolean",
+          "description": "Request the ID of the parent state machine"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "description": "GetterReq is a generic request, which results in GetterResp with respective fields filled out."
+    },
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "S": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/docs/jsonschema/getter_resp.json
+++ b/docs/jsonschema/getter_resp.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/getter-resp",
+  "$ref": "#/$defs/GetterResp",
+  "$defs": {
+    "Clock": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "GetterResp": {
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the response."
+        },
+        "mach_id": {
+          "type": "string",
+          "description": "The ID of the state machine."
+        },
+        "time": {
+          "$ref": "#/$defs/Time",
+          "description": "The ticks of the passed states"
+        },
+        "time_sum": {
+          "type": "integer",
+          "description": "The sum of ticks of the passed states"
+        },
+        "clocks": {
+          "$ref": "#/$defs/Clock",
+          "description": "The named clocks of the passed states"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "The tags of the state machine"
+        },
+        "export": {
+          "$ref": "#/$defs/Serialized",
+          "description": "The importable version of the state machine"
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the state machine"
+        },
+        "parent_id": {
+          "type": "string",
+          "description": "The ID of the parent state machine"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "description": "GetterResp is a response to GetterReq."
+    },
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "S": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "Serialized": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/$defs/Time"
+        },
+        "state_names": {
+          "$ref": "#/$defs/S"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "time",
+        "state_names"
+      ]
+    },
+    "Time": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/docs/jsonschema/msg_kind_req.json
+++ b/docs/jsonschema/msg_kind_req.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/msg-kind-req",
+  "$ref": "#/$defs/MsgKindReq",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "MsgKindReq": {
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the request."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "description": "MsgKindReq is a decoding helper."
+    }
+  }
+}

--- a/docs/jsonschema/msg_kind_resp.json
+++ b/docs/jsonschema/msg_kind_resp.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/msg-kind-resp",
+  "$ref": "#/$defs/MsgKindResp",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "MsgKindResp": {
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the response."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "description": "MsgKindResp is a decoding helper."
+    }
+  }
+}

--- a/docs/jsonschema/mutation_req.json
+++ b/docs/jsonschema/mutation_req.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/mutation-req",
+  "$ref": "#/$defs/MutationReq",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "MutationReq": {
+      "oneOf": [
+        {
+          "required": [
+            "add"
+          ],
+          "title": "add"
+        },
+        {
+          "required": [
+            "remove"
+          ],
+          "title": "remove"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the request."
+        },
+        "add": {
+          "$ref": "#/$defs/S",
+          "description": "The states to add to the state machine."
+        },
+        "remove": {
+          "$ref": "#/$defs/S",
+          "description": "The states to remove from the state machine."
+        },
+        "args": {
+          "type": "object",
+          "description": "Arguments passed to transition handlers."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    },
+    "S": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  }
+}

--- a/docs/jsonschema/mutation_resp.json
+++ b/docs/jsonschema/mutation_resp.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/mutation-resp",
+  "$ref": "#/$defs/MutationResp",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "MutationResp": {
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the request."
+        },
+        "result": {
+          "type": "integer",
+          "description": "The result of the mutation request."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind",
+        "result"
+      ]
+    }
+  }
+}

--- a/docs/jsonschema/waiting_req.json
+++ b/docs/jsonschema/waiting_req.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/waiting-req",
+  "$ref": "#/$defs/WaitingReq",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "S": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "Time": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "WaitingReq": {
+      "oneOf": [
+        {
+          "required": [
+            "states"
+          ],
+          "title": "states"
+        },
+        {
+          "required": [
+            "states_not"
+          ],
+          "title": "statesNot"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the request."
+        },
+        "states": {
+          "$ref": "#/$defs/S",
+          "description": "The states to wait for, the default is to all states being active simultaneously (if no time passed)."
+        },
+        "states_not": {
+          "$ref": "#/$defs/S",
+          "description": "The states names to wait for to be inactive. Ignores the Time field."
+        },
+        "time": {
+          "$ref": "#/$defs/Time",
+          "description": "The specific (minimal) time to wait for."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    }
+  }
+}

--- a/docs/jsonschema/waiting_resp.json
+++ b/docs/jsonschema/waiting_resp.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pancsta/asyncmachine-go/pkg/integrations/waiting-resp",
+  "$ref": "#/$defs/WaitingResp",
+  "$defs": {
+    "Kind": {
+      "properties": {
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Value"
+      ]
+    },
+    "S": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "Time": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "WaitingResp": {
+      "oneOf": [
+        {
+          "required": [
+            "states",
+            "states_not"
+          ],
+          "title": "states"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/Kind",
+          "description": "The kind of the response."
+        },
+        "mach_id": {
+          "type": "string",
+          "description": "The ID of the state machine."
+        },
+        "states": {
+          "$ref": "#/$defs/S",
+          "description": "The active states waited for. If time is empty, all these states are active simultaneously."
+        },
+        "states_not": {
+          "$ref": "#/$defs/S",
+          "description": "The inactive states waited for."
+        },
+        "time": {
+          "$ref": "#/$defs/Time",
+          "description": "The requested machine time (the current one may be higher)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind",
+        "mach_id"
+      ]
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -18,18 +18,21 @@ require (
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/hibiken/asynq v0.24.1
 	github.com/ic2hrmk/promtail v0.0.5
+	github.com/invopop/jsonschema v0.12.0
 	github.com/joho/godotenv v1.5.1
 	github.com/libp2p/go-libp2p v0.39.1
 	github.com/libp2p/go-libp2p-pubsub v0.13.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/multiformats/go-multiaddr v0.14.0
+	github.com/nats-io/nats-server/v2 v2.11.3
+	github.com/nats-io/nats.go v1.41.2
 	github.com/nkall/compactnumber v1.1.1
+	github.com/orsinium-labs/enum v1.4.0
 	github.com/pancsta/cview v1.5.14
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.20.5
 	github.com/reeflective/console v0.1.22
 	github.com/reeflective/readline v1.1.2
-	github.com/samber/lo v1.39.0
 	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.8.1
@@ -46,8 +49,8 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.11.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
-	golang.org/x/sync v0.12.0
-	golang.org/x/text v0.23.0
+	golang.org/x/sync v0.13.0
+	golang.org/x/text v0.24.0
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6
 	oss.terrastruct.com/d2 v0.6.9
@@ -60,8 +63,10 @@ require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/hub v1.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -86,6 +91,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-tpm v0.9.3 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20250202011525-fc3143867406 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -102,7 +108,7 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/koron/go-ssdp v0.0.5 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
@@ -114,6 +120,7 @@ require (
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
@@ -121,6 +128,7 @@ require (
 	github.com/miekg/dns v1.1.63 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
+	github.com/minio/highwayhash v1.0.3 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
@@ -133,6 +141,9 @@ require (
 	github.com/multiformats/go-multistream v0.6.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/jwt/v2 v2.7.4 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/onsi/ginkgo/v2 v2.22.2 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
@@ -174,6 +185,7 @@ require (
 	github.com/rsteube/carapace-shlex v0.1.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -184,13 +196,13 @@ require (
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/image v0.20.0 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/term v0.30.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/term v0.31.0 // indirect
+	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/plot v0.14.0 // indirect

--- a/pkg/integrations/integrations.go
+++ b/pkg/integrations/integrations.go
@@ -1,0 +1,302 @@
+// Package integrations provides NATS and other JSON integrations.
+//
+//nolint:lll
+package integrations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/orsinium-labs/enum"
+
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+// Kind enum
+
+type Kind enum.Member[string]
+
+var (
+	KindReqGetter    = Kind{"am_req_getter"}
+	KindReqMutation  = Kind{"am_req_mutation"}
+	KindReqWaiting   = Kind{"am_req_waiting"}
+	KindRespGetter   = Kind{"am_resp_getter"}
+	KindRespMutation = Kind{"am_resp_mutation"}
+	KindRespWaiting  = Kind{"am_resp_waiting"}
+	KindEnum         = enum.New(KindReqGetter, KindReqMutation, KindReqWaiting,
+		KindRespGetter, KindRespMutation, KindRespWaiting)
+)
+
+// flatten to a string in JSON
+
+func (k *Kind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.Value)
+}
+
+func (k *Kind) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	// success
+	k.Value = s
+	return nil
+}
+
+// TODO validate JSON also for Req and Resp structs
+
+// MsgKindReq is a decoding helper.
+type MsgKindReq struct {
+	// The kind of the request.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_req_getter,enum=am_req_mutation,enum=am_req_waiting"`
+}
+
+// MsgKindResp is a decoding helper.
+type MsgKindResp struct {
+	// The kind of the response.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_resp_waiting,enum=am_resp_mutation,enum=am_resp_getter"`
+}
+
+// MUTATION
+
+type MutationReq struct {
+	// The kind of the request.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_req_mutation"`
+	// The states to add to the state machine.
+	Add am.S `json:"add,omitempty" jsonschema:"oneof_required=add"`
+	// The states to remove from the state machine.
+	Remove am.S `json:"remove,omitempty" jsonschema:"oneof_required=remove"`
+	// Arguments passed to transition handlers.
+	Args map[string]any `json:"args,omitempty"`
+
+	// TODO machine filters to narrow down the request on group channels
+}
+
+type MutationResp struct {
+	// The kind of the request.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_req_mutation"`
+	// The result of the mutation request.
+	Result am.Result `json:"result"`
+}
+
+// WAITING
+
+type WaitingReq struct {
+	// The kind of the request.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_req_waiting"`
+	// The states to wait for, the default is to all states being active simultaneously (if no time passed).
+	States am.S `json:"states,omitempty" jsonschema:"oneof_required=states"`
+	// The states names to wait for to be inactive. Ignores the Time field.
+	StatesNot am.S `json:"states_not,omitempty" jsonschema:"oneof_required=statesNot"`
+	// The specific (minimal) time to wait for.
+	Time am.Time `json:"time,omitempty"`
+	// TODO WhenArgs
+}
+
+type WaitingRespUnsafe struct {
+	// The kind of the response.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_resp_waiting"`
+	// The ID of the state machine.
+	MachId string `json:"mach_id"`
+	// The active states waited for. If time is empty, all these states are active simultaneously.
+	States am.S `json:"states,omitempty" jsonschema:"oneof_required=states"`
+	// The inactive states waited for.
+	StatesNot am.S `json:"states_not,omitempty" jsonschema:"oneof_required=states"`
+	// The requested machine time (the current one may be higher).
+	Time am.Time `json:"time,omitempty"`
+}
+
+type WaitingResp struct {
+	WaitingRespUnsafe
+}
+
+func (w *WaitingResp) UnmarshalJSON(b []byte) error {
+	resp := WaitingRespUnsafe{}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return err
+	}
+	if resp.Kind != KindRespWaiting {
+		return errors.New("wrong response kind")
+	}
+	w.WaitingRespUnsafe = resp
+
+	// TODO more validation
+
+	return nil
+}
+
+// GETTER
+
+// GetterReq is a generic request, which results in GetterResp with
+// respective fields filled out.
+type GetterReq struct {
+	// The kind of the request.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_req_getter"`
+	// Request ticks of the passed states
+	Time am.S `json:"time,omitempty"`
+	// Request the sum of ticks of the passed states
+	TimeSum am.S `json:"time_sum,omitempty"`
+	// Request named clocks of the passed states
+	Clocks am.S `json:"clocks,omitempty"`
+	// Request the tags of the state machine
+	Tags bool `json:"tags,omitempty"`
+	// Request an importable version of the state machine
+	Export bool `json:"export,omitempty"`
+	// Request the ID of the state machine
+	Id bool `json:"id,omitempty"`
+	// Request the ID of the parent state machine
+	ParentId bool `json:"parent_id,omitempty"`
+}
+
+// GetterResp is a response to GetterReq.
+type GetterResp struct {
+	// The kind of the response.
+	Kind Kind `json:"kind" jsonschema:"required,enum=am_resp_getter"`
+	// The ID of the state machine.
+	MachId string `json:"mach_id,omitempty"`
+	// The ticks of the passed states
+	Time am.Time `json:"time,omitempty"`
+	// The sum of ticks of the passed states
+	TimeSum int `json:"time_sum,omitempty"`
+	// The named clocks of the passed states
+	Clocks am.Clock `json:"clocks,omitempty"`
+	// The tags of the state machine
+	Tags []string `json:"tags,omitempty"`
+	// The importable version of the state machine
+	Export *am.Serialized `json:"export,omitempty"`
+	// The ID of the state machine
+	Id string `json:"id,omitempty"`
+	// The ID of the parent state machine
+	ParentId string `json:"parent_id,omitempty"`
+}
+
+// UTILS & HANDLERS
+
+// NewGetterReq creates a new getter request.
+func NewGetterReq() *GetterReq {
+	return &GetterReq{
+		Kind: KindReqGetter,
+	}
+}
+
+// NewMutationReq creates a new mutation request.
+// TODO sugar for NewAddReq and NewRemoveReq
+func NewMutationReq() *MutationReq {
+	return &MutationReq{
+		Kind: KindReqMutation,
+	}
+}
+
+// NewWaitingReq creates a new waiting request.
+func NewWaitingReq() *WaitingReq {
+	return &WaitingReq{
+		Kind: KindReqWaiting,
+	}
+}
+
+func HandlerWaiting(
+	ctx context.Context, mach am.Api, req *WaitingReq,
+) (*WaitingResp, error) {
+	resp := &WaitingResp{WaitingRespUnsafe{Kind: KindRespWaiting}}
+
+	// validate
+	lenTime := len(req.Time)
+	lenStates := max(len(req.States), len(req.StatesNot))
+	if lenStates == 0 {
+		return nil, errors.New("waiting states missing")
+	} else if lenTime > 0 && lenTime != len(req.States) {
+		return nil, errors.New("waiting states and time length mismatch")
+	}
+
+	if !mach.Has(req.States) {
+		return nil, fmt.Errorf("%w: (%s) for %s", am.ErrStateMissing, req.States,
+			mach.Id())
+	}
+
+	// subscribe
+	var sub <-chan struct{}
+	if len(req.StatesNot) > 0 {
+		sub = mach.WhenNot(req.StatesNot, ctx)
+		resp.StatesNot = req.StatesNot
+	} else if lenTime > 0 {
+		sub = mach.WhenTime(req.States, req.Time, ctx)
+	} else {
+		sub = mach.When(req.States, ctx)
+		resp.States = req.States
+	}
+
+	// wait
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+		// pass
+	case <-sub:
+	}
+
+	// update the response and return
+	resp.MachId = mach.Id()
+	if lenTime > 0 {
+		resp.Time = mach.Time(req.States)
+	}
+	return resp, nil
+}
+
+func HandlerMutation(
+	ctx context.Context, mach am.Api, req *MutationReq,
+) (*MutationResp, error) {
+	resp := &MutationResp{Kind: KindRespMutation}
+	if len(req.Add) > 0 && len(req.Remove) == 0 {
+
+		if !mach.Has(req.Add) {
+			return nil, fmt.Errorf("%w: (%s) for %s", am.ErrStateMissing, req.Add,
+				mach.Id())
+		}
+		resp.Result = mach.Add(req.Add, req.Args)
+	} else if len(req.Remove) > 0 && len(req.Add) == 0 {
+
+		if !mach.Has(req.Remove) {
+			return nil, fmt.Errorf("%w: (%s) for %s", am.ErrStateMissing, req.Remove,
+				mach.Id())
+		}
+		resp.Result = mach.Remove(req.Remove, req.Args)
+	} else if len(req.Add) > 0 && len(req.Remove) > 0 {
+		return nil, errors.New("mutation can be add or remove, not both")
+	} else {
+		return nil, errors.New("mutation state names missing")
+	}
+
+	return resp, nil
+}
+
+func HandlerGetter(
+	ctx context.Context, mach am.Api, req *GetterReq,
+) (*GetterResp, error) {
+	resp := &GetterResp{Kind: KindRespGetter}
+	if req.Id {
+		resp.Id = mach.Id()
+	}
+	if req.ParentId {
+		resp.ParentId = mach.ParentId()
+	}
+	if req.Tags {
+		resp.Tags = mach.Tags()
+	}
+	if req.Export {
+		resp.Export = mach.Export()
+	}
+	if len(req.Time) > 0 {
+		resp.Time = mach.Time(req.Time)
+	}
+	if len(req.Clocks) > 0 {
+		resp.Clocks = mach.Clock(req.Clocks)
+	}
+	if len(req.TimeSum) > 0 {
+		resp.TimeSum = int(mach.TimeSum(req.TimeSum))
+	}
+
+	return resp, nil
+}

--- a/pkg/integrations/nats/nats.go
+++ b/pkg/integrations/nats/nats.go
@@ -1,0 +1,192 @@
+package nats
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/pancsta/asyncmachine-go/pkg/integrations"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+// ExposeMachine exposes a state machine to NATS for requests of type
+// - GetterReq
+// - MutationReq
+// - WaitingReq
+// with responses of type
+// - GetterResp
+// - MutationResp
+// - WaitingResp
+//
+// Each state machine subscribed to a dedicated subtopic "[topic].[machineID]".
+// Optional [queue] allows to load-balance requests across multiple subscribers.
+// ExposeMachine allocates a goroutine for GC blocked by ctx.
+func ExposeMachine(
+	ctx context.Context, mach am.Api, nc *nats.Conn, topic, queue string,
+) error {
+	var (
+		sub1 *nats.Subscription
+		err  error
+	)
+
+	bind := func(msg *nats.Msg) {
+		dispatcher(ctx, nc, mach, msg)
+	}
+
+	if queue != "" {
+		sub1, err = nc.QueueSubscribe(topic, queue, bind)
+	} else {
+		sub1, err = nc.Subscribe(topic, bind)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// dedicated subtopic for this machine
+	sub2, err := nc.Subscribe(topic+"."+mach.Id(), bind)
+	if err != nil {
+		_ = sub1.Unsubscribe()
+		return err
+	}
+
+	// dispose with ctx
+	go func() {
+		<-ctx.Done()
+		_ = sub1.Unsubscribe()
+		_ = sub2.Unsubscribe()
+	}()
+
+	return err
+}
+
+// Add is a helper to add a list of states to machine machID, exposed
+// under [topic]. It will block until the response or the context expires.
+func Add(
+	ctx context.Context, nc *nats.Conn, topic, machID string, states am.S,
+	args am.A) (am.Result, error) {
+
+	// create the request
+	req := integrations.NewMutationReq()
+	req.Add = states
+	req.Args = args
+	reqJs, err := json.Marshal(req)
+	if err != nil {
+		return am.Canceled, err
+	}
+
+	msg, err := nc.RequestWithContext(ctx, topic+"."+machID, reqJs)
+	if err != nil {
+		return am.Canceled, err
+	}
+
+	var resp integrations.MutationResp
+	err = json.Unmarshal(msg.Data, &resp)
+
+	return resp.Result, err
+}
+
+// Remove is a helper to remove a list of states from machine machID,
+// exposed under [topic]. It will block until the response or the context
+// expires.
+func Remove(
+	ctx context.Context, nc *nats.Conn, machID, topic string, states am.S,
+	args am.A,
+) (am.Result, error) {
+
+	// create the request
+	req := integrations.NewMutationReq()
+	req.Remove = states
+	req.Args = args
+	reqJs, err := json.Marshal(req)
+	if err != nil {
+		return am.Canceled, err
+	}
+
+	msg, err := nc.RequestWithContext(ctx, topic+"."+machID, reqJs)
+	if err != nil {
+		return am.Canceled, err
+	}
+
+	var resp integrations.MutationResp
+	err = json.Unmarshal(msg.Data, &resp)
+
+	return resp.Result, err
+}
+
+// UTILS
+
+func dispatcher(
+	ctx context.Context, nc *nats.Conn, mach am.Api, msg *nats.Msg) {
+	var (
+		j    []byte
+		err0 error
+	)
+
+	// check if this is something for us
+	msgKind := integrations.MsgKindReq{}
+	if err := json.Unmarshal(msg.Data, &msgKind); err != nil ||
+		!integrations.KindEnum.Contains(msgKind.Kind) {
+
+		// no match, exit
+		return
+	}
+
+	get := &integrations.GetterReq{}
+	mut := &integrations.MutationReq{}
+	wait := &integrations.WaitingReq{}
+
+	switch msgKind.Kind {
+	case integrations.KindReqGetter:
+		if err0 = json.Unmarshal(msg.Data, get); err0 == nil {
+			resp, err := integrations.HandlerGetter(ctx, mach, get)
+			if err != nil {
+				err0 = err
+			} else {
+				j, err0 = json.Marshal(resp)
+			}
+		}
+
+	case integrations.KindReqMutation:
+		if err0 = json.Unmarshal(msg.Data, mut); err0 == nil {
+			resp, err := integrations.HandlerMutation(ctx, mach, mut)
+			if err != nil {
+				err0 = err
+			} else {
+				j, err0 = json.Marshal(resp)
+			}
+		}
+
+	case integrations.KindReqWaiting:
+		if err0 = json.Unmarshal(msg.Data, wait); err0 == nil {
+			resp, err := integrations.HandlerWaiting(ctx, mach, wait)
+			if err != nil {
+				err0 = err
+			} else {
+				j, err0 = json.Marshal(resp)
+			}
+		}
+	}
+
+	// internal err
+	if err0 != nil {
+		mach.AddErr(err0, nil)
+		return
+	}
+
+	// opt response
+	if j != nil {
+		// publish for async replies
+		if msgKind.Kind == integrations.KindReqWaiting {
+			err0 = nc.Publish(msg.Subject, j)
+
+			// response to sync request
+		} else {
+			err0 = msg.Respond(j)
+		}
+		if err0 != nil {
+			mach.AddErr(err0, nil)
+		}
+	}
+}

--- a/pkg/integrations/nats/nats_test.go
+++ b/pkg/integrations/nats/nats_test.go
@@ -1,0 +1,228 @@
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+
+	testutils "github.com/pancsta/asyncmachine-go/internal/testing/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	amhelpt "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
+	"github.com/pancsta/asyncmachine-go/pkg/integrations"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+var timeout = 1 * time.Second
+
+// start an embedded local NATS instance on :0
+var natsUrl = ""
+
+// use an existing NATS instance
+// var natsUrl = "nats://localhost:7542"
+
+func init() {
+	_ = godotenv.Load()
+
+	if os.Getenv(am.EnvAmTestDebug) != "" {
+		amhelp.EnableDebugging(true)
+	}
+
+	if amhelp.IsDebug() {
+		timeout = 100 * timeout
+	}
+}
+
+func TestGetter(t *testing.T) {
+	ctx := context.Background()
+	topic := t.Name()
+	nc := initServerConn(ctx, t)
+
+	// init machine
+	mach := testutils.NewRels(t, nil)
+	err := ExposeMachine(ctx, mach, nc, topic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// request ID
+	req := integrations.NewGetterReq()
+	req.Id = true
+	reqJs, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err := nc.Request(topic, reqJs, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp integrations.GetterResp
+	err = json.Unmarshal(msg.Data, &resp)
+
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, mach.Id(), resp.Id)
+}
+
+func TestMutation(t *testing.T) {
+	ctx := context.Background()
+	topic := t.Name()
+	nc := initServerConn(ctx, t)
+
+	// init machine and handlers
+	mach := testutils.NewNoRels(t, nil)
+	err := ExposeMachine(ctx, mach, nc, topic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	okArg1 := false
+	err = mach.BindHandlers(&struct {
+		BEnd am.HandlerFinal
+	}{
+		BEnd: func(event *am.Event) {
+			arg1 := event.Args["arg1"].(string)
+			assert.Equal(t, "test", arg1)
+			okArg1 = true
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// request [add] A B
+	req := integrations.NewMutationReq()
+	req.Add = am.S{"A", "B"}
+	reqJs, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err := nc.Request(topic, reqJs, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp integrations.MutationResp
+	err = json.Unmarshal(msg.Data, &resp)
+
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, am.Executed, resp.Result)
+
+	// request [remove] B
+	req = integrations.NewMutationReq()
+	req.Remove = am.S{"B"}
+	req.Args = map[string]any{
+		"arg1": "test",
+	}
+	reqJs, err = json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, err = nc.Request(topic, reqJs, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = json.Unmarshal(msg.Data, &resp)
+
+	// assert
+	assert.NoError(t, err)
+	assert.True(t, okArg1, "BEnd handler executed")
+	assert.Equal(t, am.Executed, resp.Result)
+}
+
+func TestWaiting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	topic := t.Name()
+	nc := initServerConn(ctx, t)
+
+	// init machine and handlers
+	mach := testutils.NewNoRels(t, nil)
+	amhelpt.MachDebugEnv(t, mach)
+	err := ExposeMachine(ctx, mach, nc, topic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// subscribe to A
+	reqSub := integrations.NewWaitingReq()
+	reqSub.States = am.S{"A"}
+	j, err := json.Marshal(reqSub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = nc.Publish(topic, j)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the subscription result
+	readySub := make(chan struct{})
+	okSub := make(chan struct{})
+	go func() {
+		sub, err := nc.Subscribe(topic, func(msg *nats.Msg) {
+			var resp integrations.WaitingResp
+			err := json.Unmarshal(msg.Data, &resp)
+			assert.NoError(t, err)
+			assert.Len(t, resp.States, 1)
+			close(okSub)
+		})
+		_ = sub.AutoUnsubscribe(2)
+		if err != nil {
+			assert.NoError(t, err)
+		}
+		close(readySub)
+	}()
+	<-readySub
+
+	// mutate
+	res, err := Add(ctx, nc, topic, mach.Id(), am.S{"A"}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, am.Executed, res)
+
+	// wait for the subscription result
+	<-okSub
+}
+
+// UTILS
+
+func initServerConn(ctx context.Context, t *testing.T) *nats.Conn {
+
+	var ns *server.Server
+	var err error
+	if natsUrl == "" || os.Getenv(amhelp.EnvAmTestRunner) != "" {
+		t.Log("Using embedded NATS on :0")
+		// start local nats server
+		ns, err = server.NewServer(&server.Options{
+			Port: -1, // random port
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ns.Start()
+		natsUrl = ns.ClientURL()
+	}
+
+	// connect to nats
+	nc, err := nats.Connect(natsUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Connected to nats at %s", natsUrl)
+
+	go func() {
+		<-ctx.Done()
+		if ns != nil {
+			ns.Shutdown()
+		}
+		nc.Close()
+	}()
+
+	return nc
+}

--- a/scripts/gen_jsonschema/gen_jsonschema.go
+++ b/scripts/gen_jsonschema/gen_jsonschema.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/invopop/jsonschema"
+
+	"github.com/pancsta/asyncmachine-go/pkg/integrations"
+)
+
+func main() {
+	r := new(jsonschema.Reflector)
+	if err := r.AddGoComments("github.com/pancsta/asyncmachine-go",
+		"./pkg/integrations"); err != nil {
+		panic(err)
+	}
+
+	// Create docs/jsonschema directory if it doesn't exist
+	schemaDir := filepath.Join("docs", "jsonschema")
+	if err := os.MkdirAll(schemaDir, 0755); err != nil {
+		panic(err)
+	}
+
+	// List of structs to generate schemas for
+	structs := []struct {
+		name string
+		obj  interface{}
+	}{
+		{"msg_kind_req", &integrations.MsgKindReq{}},
+		{"msg_kind_resp", &integrations.MsgKindResp{}},
+		{"mutation_req", &integrations.MutationReq{}},
+		{"mutation_resp", &integrations.MutationResp{}},
+		{"waiting_req", &integrations.WaitingReq{}},
+		{"waiting_resp", &integrations.WaitingResp{}},
+		{"getter_req", &integrations.GetterReq{}},
+		{"getter_resp", &integrations.GetterResp{}},
+	}
+
+	for _, s := range structs {
+		schema := r.Reflect(s.obj)
+		jsonData, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			panic(fmt.Errorf("failed to marshal schema for %s: %v", s.name, err))
+		}
+
+		filename := filepath.Join(schemaDir, s.name+".json")
+		if err := os.WriteFile(filename, jsonData, 0644); err != nil {
+			panic(fmt.Errorf("failed to write schema for %s: %v", s.name, err))
+		}
+
+		fmt.Printf("Generated /%s\n", filename)
+	}
+}


### PR DESCRIPTION
The first integration has landed and it's [NATS](https://github.com/nats-io/nats-server/) because of how versatile and scalable it its (pubsub, queue, kv). The whole comms is through JSON (with tight schemas) and the plan is to use them for other integrations. Below an example of a subscription:

```json
{
  "kind" : "am_req_waiting",
  "states" : [ "A" ]
}
```

Types:
- MutationReq
- MutationResp
- WaitingReq
- WaitingResp
- GetterReq
- GetterResp

Usage is as simple as `res, err := amnats.Add(ctx, nc, topic, mach.Id(), am.S{"A"}, nil)`.