### PR TITLE
feat(machine): AddErr methods will no-op for nil errors

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -898,9 +898,10 @@ func (m *Machine) AddErr(err error, args A) Result {
 // Like every mutation method, it will resolve relations and trigger handlers.
 // AddErrState produces a stack trace of the error, if LogStackTrace is enabled.
 func (m *Machine) AddErrState(state string, err error, args A) Result {
-	if m.disposed.Load() || m.disposing.Load() {
+	if m.disposed.Load() || m.disposing.Load() || err == nil {
 		return Canceled
 	}
+
 	// TODO test Err()
 	m.err.Store(&err)
 

--- a/pkg/rpc/rpc_worker.go
+++ b/pkg/rpc/rpc_worker.go
@@ -298,7 +298,7 @@ func (w *Worker) AddErr(err error, args am.A) am.Result {
 // Like every mutation method, it will resolve relations and trigger handlers.
 // AddErrState produces a stack trace of the error, if LogStackTrace is enabled.
 func (w *Worker) AddErrState(state string, err error, args am.A) am.Result {
-	if w.c == nil || w.Disposed.Load() {
+	if w.c == nil || w.Disposed.Load() || err == nil {
 		return am.Canceled
 	}
 


### PR DESCRIPTION
Non-actionable errors can be handled by oneliners. The two examples below are equal. All `*AddErr*` mutation methods work this way now.

Before:
```go
err := Op()
if err != nil {
    mach.AddErr(err, nil)
    // no return
}
```

After:
```go
err := Op()
mach.AddErr(err, nil) // does nothing for err == nil
```