### PR TITLE
feat(helpers): add slog and loop guards

### DIFF
--- a/pkg/helpers/help_test.go
+++ b/pkg/helpers/help_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type A struct {
+type Args struct {
 	Local struct{}
 	Log   string `log:"log1"`
 	Plain string
@@ -18,7 +18,7 @@ type ARpc struct {
 }
 
 func TestArgsRpc(t *testing.T) {
-	a := &A{
+	a := &Args{
 		Local: struct{}{},
 		Log:   "log",
 		Plain: "plain",
@@ -36,7 +36,7 @@ func TestArgsRpc(t *testing.T) {
 }
 
 func TestArgsToLogMap(t *testing.T) {
-	a := &A{
+	a := &Args{
 		Local: struct{}{},
 		Log:   "log",
 		Plain: "plain",
@@ -46,7 +46,7 @@ func TestArgsToLogMap(t *testing.T) {
 		"log1": "log",
 	}
 
-	logMap := ArgsToLogMap(a)
+	logMap := ArgsToLogMap(a, 0)
 
 	assert.Equal(t, expected["log1"], logMap["log1"])
 	assert.Len(t, logMap, 1)

--- a/pkg/x/helpers/x_helpers.go
+++ b/pkg/x/helpers/x_helpers.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"slices"
+	"strconv"
+	"strings"
 
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 )
@@ -117,7 +120,7 @@ func RelationsMatrix(mach *am.Machine) ([][]int, error) {
 
 		for j, s2 := range names {
 
-			rels, err := mach.Resolver().GetRelationsBetween(s1, s2)
+			rels, err := mach.Resolver().RelationsBetween(s1, s2)
 			if err != nil {
 				return nil, err
 			}
@@ -216,4 +219,144 @@ func TransitionMatrix(tx, prevTx *am.Transition, index am.S) ([][]int, error) {
 	}
 
 	return matrix, nil
+}
+
+type FanFn func(num int, state, stateDone string)
+
+type FanHandlers struct {
+	Concurrency int
+	AnyState    am.HandlerFinal
+	GroupTasks  am.S
+	GroupDone   am.S
+}
+
+// FanOutIn creates [total] number of state pairs of "Name1" and "Name1Done", as
+// well as init and merge states ("Name", "NameDone"). [name] is treated as a
+// namespace and can't have other states within. Retry can be achieved by adding
+// the init state repetively. FanOutIn can be chained, but it should be called
+// before any mutations or telemetry (as it changes the state struct). The
+// returned handlers struct can be used to adjust the concurrency level.
+func FanOutIn(
+	mach *am.Machine, name string, total, concurrency int,
+	fn FanFn,
+) (any, error) {
+	// TODO version with worker as states, instead of tasks as states
+	//  main state tries to push a list of tasks through the "worker states",
+	//  which results in a Done state.
+	states := mach.Schema()
+	suffixDone := "Done"
+
+	if !mach.Has(am.S{name, name + suffixDone}) {
+		return nil, fmt.Errorf("%w: %s", am.ErrStateMissing, name)
+	}
+	base := states[name]
+
+	// create task states
+	groupTasks := make(am.S, total)
+	groupDone := make(am.S, total)
+	for i := range total {
+		num := strconv.Itoa(i)
+		groupTasks[i] = name + num
+		groupDone[i] = name + num + suffixDone
+	}
+	for i := range total {
+		num := strconv.Itoa(i)
+		// task state
+		states[name+num] = base
+		// task completed state, removes task state
+		states[name+num+suffixDone] = am.State{Remove: am.S{name + num}}
+	}
+
+	// inject into a fan-in state
+	done := am.StateAdd(states[name+suffixDone], am.State{
+		Require: groupDone,
+		Remove:  am.S{name},
+	})
+	done.Auto = true
+	states[name+suffixDone] = done
+
+	names := slices.Concat(mach.StateNames(), groupTasks, groupDone)
+	err := mach.SetSchema(states, names)
+	if err != nil {
+		return nil, err
+	}
+
+	// handlers
+	h := FanHandlers{
+		Concurrency: concurrency,
+		GroupTasks:  groupTasks,
+		GroupDone:   groupDone,
+	}
+
+	// simulate fanout states and the init state
+	// Task(e)
+	// Task1(e)
+	// Task2(e)
+	h.AnyState = func(e *am.Event) {
+		// get tx info
+		called := e.Transition().CalledStates()
+		if len(called) < 1 {
+			return
+		}
+
+		for _, state := range called {
+
+			// fan-out state handler, eg Task1
+			// TODO extract to IsFanOutHandler(called am.S, false) bool
+			if strings.HasPrefix(state, name) && len(state) > len(name) &&
+				!strings.HasSuffix(state, suffixDone) {
+
+				iStr, _ := strings.CutPrefix(state, name)
+				num, err := strconv.Atoi(iStr)
+				if err != nil {
+					// TODO
+					panic(err)
+				}
+
+				// call the function and mark as done
+				fn(num, state, state+suffixDone)
+			}
+
+			// fan-out done handler, eg Task1Done
+			// TODO extract to IsFanOutHandler(called am.S, true) bool
+			if strings.HasPrefix(state, name) && len(state) > len(name) &&
+				strings.HasSuffix(state, suffixDone) {
+
+				// call the init state
+				mach.Add1(name, nil)
+			}
+
+			// fan-out init handler, eg Task
+			if state == name {
+
+				// gather remaining ones
+				var remaining am.S
+				for _, name := range groupTasks {
+					// check if done or in progress
+					if mach.Any1(name+suffixDone, name) {
+						continue
+					}
+					remaining = append(remaining, name)
+				}
+
+				// start N threads
+				running := mach.CountActive(groupTasks)
+				// TODO check against running via mach.CountActive
+				for i := running; i < h.Concurrency && len(remaining) > 0; i++ {
+
+					// add a random one
+					idx := rand.Intn(len(remaining))
+					mach.Add1(remaining[idx], nil)
+					remaining = slices.Delete(remaining, idx, idx+1)
+				}
+			}
+		}
+	}
+
+	err = mach.BindHandlers(&h)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }

--- a/pkg/x/helpers/x_helpers_test.go
+++ b/pkg/x/helpers/x_helpers_test.go
@@ -18,7 +18,8 @@ func TestTimeMatrix(t *testing.T) {
 	m1 := NewNoRels(t, nil)
 	statesStruct := m1.Schema()
 	statesStruct["B"] = am.State{Multi: true}
-	err := m1.SetSchema(statesStruct, S{"A", "B", "C", "D", am.Exception})
+	statesStruct["Bump1"] = am.State{}
+	err := m1.SetSchema(statesStruct, S{"A", "B", "C", "D", "Bump1", am.Exception})
 	assert.NoError(t, err)
 
 	// mutate & assert
@@ -31,7 +32,8 @@ func TestTimeMatrix(t *testing.T) {
 	m2 := NewNoRels(t, nil)
 	statesStruct = m1.Schema()
 	statesStruct["B"] = am.State{Multi: true}
-	err = m2.SetSchema(statesStruct, S{"A", "B", "C", "D", am.Exception})
+	statesStruct["Bump1"] = am.State{}
+	err = m2.SetSchema(statesStruct, S{"A", "B", "C", "D", "Bump1", am.Exception})
 	assert.NoError(t, err)
 
 	// mutate & assert
@@ -44,8 +46,8 @@ func TestTimeMatrix(t *testing.T) {
 
 	matrix, err := TimeMatrix([]*am.Machine{m1, m2})
 	assert.NoError(t, err)
-	assert.Equal(t, T{1, 3, 0, 0, 0}, matrix[0])
-	assert.Equal(t, T{2, 6, 2, 1, 0}, matrix[1])
+	assert.Equal(t, T{1, 3, 0, 0, 0, 0}, matrix[0])
+	assert.Equal(t, T{2, 6, 2, 1, 0, 0}, matrix[1])
 }
 
 // /// helpers


### PR DESCRIPTION
- feat(helpers): add NewStateLoop(...) for state loop guards
- feat(helpers): add slog to mach log converter
- feat(helpers): log args for slices
- feat(helpers): add Cond for complex state relations

NewStateLoop helper creates a state loop guard bound to a specific state (eg Heartbeat), preventing infinite loops. It monitors context, off states, ticks of related "context states", and an optional check function.

-----

```go
type A {
  buttons []string `log:"buttons"`
}
```
![ss-2025-06-20-17-40-07](https://github.com/user-attachments/assets/d6e75519-bfdf-44a1-afc8-61ec7445151b)

-----

It's now possible to use a machine as an `slog` sink.