### PR TITLE
fix(states): piping ErrFoo will also add Exception

### DIFF
--- a/pkg/states/ss_basic.go
+++ b/pkg/states/ss_basic.go
@@ -38,9 +38,15 @@ type BasicStatesDef struct {
 var BasicSchema = am.Schema{
 	// Errors
 
-	ssB.Exception:         {Multi: true},
-	ssB.ErrNetwork:        {Require: S{Exception}},
-	ssB.ErrHandlerTimeout: {Require: S{Exception}},
+	ssB.Exception: {Multi: true},
+	ssB.ErrNetwork: {
+		Multi:   true,
+		Require: S{Exception},
+	},
+	ssB.ErrHandlerTimeout: {
+		Multi:   true,
+		Require: S{Exception},
+	},
 
 	// Basics
 


### PR DESCRIPTION
All error states (eg `ErrFoo`) should require `Exception`, so piping to custom error states wasn't possible, unless ErrFoo:Add:Exception was in relations. This is now automated by piping methods.