### PR TITLE
feat(repl): support watching for address changes

### DIFF
--- a/tools/cmd/arpc/cmd_arpc.go
+++ b/tools/cmd/arpc/cmd_arpc.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
 	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
@@ -17,7 +17,6 @@ var ss = states.ReplStates
 var randomId = false
 
 func init() {
-	_ = godotenv.Load()
 	// amhelp.EnableDebugging(false)
 	// amhelp.EnableDebugging(true)
 }
@@ -35,7 +34,7 @@ func main() {
 	for i, v := range osArgs {
 		if v == "--" && len(os.Args) > i+1 {
 			cliArgs = os.Args[i+2:]
-			connArgs = os.Args[1:i+1]
+			connArgs = os.Args[1 : i+1]
 			break
 		}
 	}
@@ -64,9 +63,15 @@ func main() {
 		}
 	}
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+
 	// waits
 	select {
 
+	// signal
+	case <-sigCh:
+		r.Mach.Add1(ss.Disposing, nil)
 	// CLI
 	case <-r.Mach.WhenNot1(ss.ReplMode, nil):
 	// exit

--- a/tools/repl/misc_repl.go
+++ b/tools/repl/misc_repl.go
@@ -148,7 +148,7 @@ func LogArgs(args am.A) map[string]string {
 		return nil
 	}
 
-	return am.AMerge(amhelp.ArgsToLogMap(a1), amhelp.ArgsToLogMap(a2))
+	return am.AMerge(amhelp.ArgsToLogMap(a1, 0), amhelp.ArgsToLogMap(a2, 0))
 }
 
 func completionsNarrowDown(

--- a/tools/repl/states/ss_repl.go
+++ b/tools/repl/states/ss_repl.go
@@ -14,14 +14,6 @@ type ReplStatesDef struct {
 
 	ErrSyntax string
 
-	// CONNECTION
-
-	Disconnected   string
-	Connecting     string
-	Connected      string
-	ConnectedFully string
-	Disconnecting  string
-
 	// PIPES
 
 	RpcConn    string
@@ -47,6 +39,8 @@ type ReplStatesDef struct {
 	ReplMode string
 	// List fully connected machines, with filters.
 	ListMachines string
+	// Watch mode detected a change in address files
+	AddrChanged string
 
 	// inherit from BasicStatesDef
 	*ss.BasicStatesDef
@@ -73,7 +67,16 @@ var ReplSchema = SchemaMerge(
 	ss.DisposedSchema,
 	am.Schema{
 
-		ssC.ErrSyntax: {},
+		ssC.ErrSyntax: {
+			Multi:   true,
+			Require: S{Exception},
+		},
+
+		ssC.ErrNetwork: {
+			Multi:   true,
+			Require: S{Exception},
+			Remove:  S{ssC.ConnectedFully},
+		},
 
 		// PIPES
 
@@ -129,11 +132,16 @@ var ReplSchema = SchemaMerge(
 
 		// STATUS
 
-		ssC.ReplMode: {Require: S{ssC.Start}},
+		ssC.ReplMode: {},
 
 		// ACTIONS
 
 		ssC.ListMachines: {
+			Multi:   true,
+			Require: S{ssC.Start},
+		},
+
+		ssC.AddrChanged: {
 			Multi:   true,
 			Require: S{ssC.Start},
 		},


### PR DESCRIPTION
An experimental implementation of `--watch` is here for both dirs and files. It's brute-forced but seems to work well.