### PR TITLE
feat(dbg): support machine URLs in data imports

### DIFF
--- a/tools/debugger/cli/cli_dbg.go
+++ b/tools/debugger/cli/cli_dbg.go
@@ -93,6 +93,7 @@ type Params struct {
 	Timelines     int
 	Rain          bool
 	TailMode      bool
+	MachUrl       string
 }
 
 type RootFn func(cmd *cobra.Command, args []string, params Params)
@@ -164,8 +165,12 @@ func AddFlags(rootCmd *cobra.Command) {
 	f.Bool(pTail, true, "Start from the last tx")
 }
 
-func ParseParams(cmd *cobra.Command, _ []string) Params {
+func ParseParams(cmd *cobra.Command, args []string) Params {
 	// TODO dont panic
+	url := ""
+	if len(args) > 0 {
+		url = args[0]
+	}
 
 	// params
 	version, err := cmd.Flags().GetBool(pVersion)
@@ -265,6 +270,8 @@ func ParseParams(cmd *cobra.Command, _ []string) Params {
 	}
 
 	return Params{
+		MachUrl: url,
+
 		ListenAddr: serverAddr,
 		DebugAddr:  debugAddr,
 		ImportData: importData,

--- a/tools/debugger/misc_dbg.go
+++ b/tools/debugger/misc_dbg.go
@@ -90,6 +90,7 @@ type MsgTxParsed struct {
 }
 
 type Opts struct {
+	MachUrl         string
 	SelectConnected bool
 	CleanOnConnect  bool
 	EnableMouse     bool
@@ -161,7 +162,15 @@ func (ma *MachAddress) Clone() *MachAddress {
 
 func (a *MachAddress) String() string {
 	if a.TxId != "" {
-		return fmt.Sprintf("mach://%s/%s", a.MachId, a.TxId)
+		u := fmt.Sprintf("mach://%s/%s", a.MachId, a.TxId)
+		if a.Step != 0 {
+			u += fmt.Sprintf("/%d", a.Step)
+		}
+		if a.MachTime != 0 {
+			u += fmt.Sprintf("/t%d", a.MachTime)
+		}
+
+		return u
 	}
 	if a.MachTime != 0 {
 		return fmt.Sprintf("mach://%s/t%d", a.MachId, a.MachTime)


### PR DESCRIPTION
When importing a data dump, it's possible to go to a specific transition step by passing a Machine URL:

`am-dbg mach://cook/f6578eb6cdf79e59f0ecccbe375c26c0/27/t152 --import-data dump.gob`