### PR TITLE
feat(dbg): add ttyd docker image

### DIFF
--- a/deploy/web-am-dbg/Dockerfile
+++ b/deploy/web-am-dbg/Dockerfile
@@ -1,0 +1,37 @@
+FROM archlinux:latest
+
+# OS
+
+RUN pacman -Sy --noconfirm go git ca-certificates \
+     ttyd go-task zellij xclip xsel
+RUN mkdir -p /app
+RUN cp /usr/bin/go-task /usr/bin/task
+RUN mkdir -p ~/.config/zellij/
+RUN echo "show_startup_tips false" > ~/.config/zellij/config.kdl
+RUN echo "show_release_notes false" >> ~/.config/zellij/config.kdl
+
+# DEPS
+
+COPY ./cview /app/cview
+COPY ./asyncmachine-go/go.mod /app/asyncmachine-go/
+COPY ./asyncmachine-go/go.sum /app/asyncmachine-go/
+
+# PREBUILD
+
+WORKDIR /app/asyncmachine-go
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
+
+# SOURCE
+
+COPY ./asyncmachine-go /app/asyncmachine-go
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  task build-am-dbg
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  task build-arpc
+
+# START
+
+# ports: am-dbg ttyd
+EXPOSE 6831 7681
+ENTRYPOINT ["go-task", "web-dashboard-repl"]


### PR DESCRIPTION
am-dbg now has a docker image with a web interface and REPL (via a zellij dashboard). This is useful for docker compose deployments.

![ss-2025-06-21-12-45-59](https://github.com/user-attachments/assets/f8db3d67-cf57-4ea7-a6cd-b957748823f7)
