### PR TITLE
feat(am-dbg): add am-dbg v0.12

### DIFF
--- a/tools/cmd/am-dbg-ssh/cmd_dbg_ssh.go
+++ b/tools/cmd/am-dbg-ssh/cmd_dbg_ssh.go
@@ -16,19 +16,19 @@ import (
 	"github.com/gdamore/tcell/v2/terminfo"
 	"github.com/gliderlabs/ssh"
 	"github.com/lithammer/dedent"
-	"github.com/pancsta/asyncmachine-go/internal/utils"
-	"github.com/pancsta/asyncmachine-go/tools/debugger/cli"
 	"github.com/spf13/cobra"
 
+	"github.com/pancsta/asyncmachine-go/internal/utils"
 	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	"github.com/pancsta/asyncmachine-go/tools/debugger"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/cli"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 )
 
 type Params struct {
 	cli.Params
 
-	SSHAddr string
+	SshAddr string
 }
 
 func main() {
@@ -69,7 +69,7 @@ func parseParams(cmd *cobra.Command, p cli.Params) Params {
 	sshAddr := cmd.Flag(cliParamServerAddr).Value.String()
 	return Params{
 		Params:  p,
-		SSHAddr: sshAddr,
+		SshAddr: sshAddr,
 	}
 }
 
@@ -93,8 +93,7 @@ func cliRun(_ *cobra.Command, _ []string, par Params) {
 			return
 		}
 
-		// tview says we don't have to do this
-		// when using SetScreen, but it lies
+		// Init is required for cview, but not for tview
 		if err := screen.Init(); err != nil {
 			_, _ = fmt.Fprintln(sess.Stderr(), "unable to init screen:", err)
 			return
@@ -105,8 +104,7 @@ func cliRun(_ *cobra.Command, _ []string, par Params) {
 			Screen:      screen,
 			DbgLogLevel: par.LogLevel,
 			DbgLogger:   cli.GetLogger(&par.Params),
-			// TODO cache import data and deep copy for new connections
-			ImportData: par.ImportData,
+			ImportData:  par.ImportData,
 			// ServerAddr is disabled
 			ServerAddr:  par.ListenAddr,
 			EnableMouse: par.EnableMouse,
@@ -159,8 +157,8 @@ func cliRun(_ *cobra.Command, _ []string, par Params) {
 			return nil
 		}
 
-		fmt.Printf("SSH: listening on %s\n", par.SSHAddr)
-		err := ssh.ListenAndServe(par.SSHAddr, nil, optSrv)
+		fmt.Printf("SSH: listening on %s\n", par.SshAddr)
+		err := ssh.ListenAndServe(par.SshAddr, nil, optSrv)
 		if err != nil {
 			log.Printf("ssh.ListenAndServe: %v", err)
 			close(srvCh)
@@ -178,7 +176,9 @@ func cliRun(_ *cobra.Command, _ []string, par Params) {
 }
 
 // ///// ///// /////
+
 // ///// SSH
+
 // ///// ///// /////
 
 func NewSessionScreen(s ssh.Session) (tcell.Screen, error) {

--- a/tools/cmd/am-dbg/cmd_dbg.go
+++ b/tools/cmd/am-dbg/cmd_dbg.go
@@ -54,6 +54,7 @@ func cliRun(_ *cobra.Command, _ []string, p cli.Params) {
 		OutputDir:       p.OutputDir,
 		ServerAddr:      p.ListenAddr,
 		EnableMouse:     p.EnableMouse,
+		MachUrl:         p.MachUrl,
 		SelectConnected: p.SelectConnected,
 		ShowReader:      p.Reader,
 		CleanOnConnect:  p.CleanOnConnect,

--- a/tools/debugger/cli/cli_dbg.go
+++ b/tools/debugger/cli/cli_dbg.go
@@ -53,6 +53,8 @@ const (
 	pDir            = "dir"
 	pOutputDirShort = "d"
 	pOutputClients  = "output-clients"
+	pOutputTx       = "output-tx"
+	pDiagrams       = "output-diagrams"
 
 	// UI
 
@@ -60,7 +62,6 @@ const (
 	pViewShort  = "v"
 	pViewNarrow = "view-narrow"
 	pReader     = "view-reader"
-	pDiagrams   = "diagrams"
 	pTimelines  = "view-timelines"
 	pRain       = "view-rain"
 )
@@ -93,6 +94,7 @@ type Params struct {
 	Timelines     int
 	Rain          bool
 	TailMode      bool
+	OutputTx      bool
 	MachUrl       string
 }
 
@@ -148,7 +150,7 @@ func AddFlags(rootCmd *cobra.Command) {
 	// MISC
 
 	f.String(pProfSrv, "", "Start pprof server")
-	f.Int(pMaxMem, 100, "Max memory usage (in MB) to flush old transitions")
+	f.Int(pMaxMem, 1000, "Max memory usage (in MB) to flush old transitions")
 	f.String(pLog2Ttl, "24h", "Max time to live for logs level 2")
 	f.Bool(pVersion, false, "Print version and exit")
 
@@ -157,9 +159,12 @@ func AddFlags(rootCmd *cobra.Command) {
 	f.StringP(pDir, pOutputDirShort, ".",
 		"Output directory for generated files")
 	f.Bool(pOutputClients, false,
-		"Write a detailed client list into in am-dbg-clients.txt inside --dir")
+		"Write a detailed client list into am-dbg-clients.txt inside --dir")
+	f.Bool(pOutputTx, false,
+		"Write the current transition with steps into am-dbg-tx.md inside --dir")
 	f.Int(pDiagrams, 0,
-		"Level of details for diagrams (svg, d2, mermaid) in --dir (0-3)")
+		"Level of details for diagrams (svg, d2, mermaid) in "+
+			"--dir (0 off, 1-3 on). EXPERIMENTAL")
 	f.Int(pTimelines, 2, "Number of timelines to show (0-2)")
 	f.Bool(pRain, false, "Show the rain view")
 	f.Bool(pTail, true, "Start from the last tx")
@@ -205,6 +210,7 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 	timelines = min(2, timelines)
 
 	outputClients, err := cmd.Flags().GetBool(pOutputClients)
+	outputTx, err := cmd.Flags().GetBool(pOutputTx)
 	if err != nil {
 		panic(err)
 	}
@@ -296,6 +302,7 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 		// output
 
 		OutputClients: outputClients,
+		OutputTx:      outputTx,
 		OutputDir:     outputDir,
 		Graph:         graph,
 		Timelines:     timelines,

--- a/tools/debugger/client_list.go
+++ b/tools/debugger/client_list.go
@@ -40,6 +40,8 @@ func (d *Debugger) buildClientList(selectedIndex int) {
 }
 
 func (d *Debugger) doBuildClientList(selectedIndex int) {
+	defer d.buildCLScheduled.Store(false)
+	
 	if d.Mach.Not1(ss.ClientListVisible) {
 		return
 	}
@@ -99,7 +101,6 @@ func (d *Debugger) doBuildClientList(selectedIndex int) {
 	d.clientList.SetTitle(d.P.Sprintf(
 		" Machines:%d T:%v ", len(d.Clients), totalSum))
 
-	d.buildCLScheduled.Store(false)
 	// sort TODO rewrite
 	d.doUpdateClientList(true)
 }

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -85,6 +85,7 @@ var States = am.Schema{
 	FilterCanceledTx:  {},
 	FilterEmptyTx:     {},
 	FilterSummaries:   {},
+	FilterTraces:      {},
 	FilterHealthcheck: {},
 
 	// ///// Actions
@@ -313,6 +314,7 @@ const (
 	// run any self handler either
 	FilterEmptyTx   = "FilterEmptyTx"
 	FilterSummaries = "FilterSummaries"
+	FilterTraces    = "FilterTraces"
 	ToggleTool      = "ToggleTool"
 	// SwitchingClientTx switches to the given client and scrolls to the given
 	// transaction (1-based tx index). Accepts Client.id and Client.cursorTx.
@@ -334,6 +336,7 @@ const (
 
 // Names is an ordered list of all the state names.
 var Names = S{
+	am.Exception,
 
 	// /// Input events
 
@@ -386,6 +389,7 @@ var Names = S{
 	FilterCanceledTx,
 	FilterEmptyTx,
 	FilterSummaries,
+	FilterTraces,
 	FilterHealthcheck,
 	ToggleTool,
 	SwitchingClientTx,
@@ -419,8 +423,6 @@ var Names = S{
 	GraphsScheduled,
 
 	InitClient,
-
-	am.Exception,
 }
 
 // #endregion

--- a/tools/debugger/test/integration_test.go
+++ b/tools/debugger/test/integration_test.go
@@ -155,7 +155,7 @@ func TestTailModeFLAKY(t *testing.T) {
 
 	// assert.NotEqual(t, res, am.Canceled)
 	assert.Equal(t, 4, len(worker.C.MsgTxs), "tx count")
-	assert.Equal(t, 4, worker.C.CursorTx1, "cursorTx")
+	assert.Equal(t, len(worker.C.MsgTxsFiltered), worker.C.CursorTx1, "cursorTx")
 	// TODO assert tree clocks
 	// TODO assert log highlight
 }


### PR DESCRIPTION
- feat(dbg): add `--output-tx` to dir/am-dbg-tx.txt
- fix(dbg): show client list when started in narrow view
- fix(dbg): fix help button
- feat(dbg): click on log line selects the 1st state
- feat(dbg): add hiding stack traces
- feat(dbg): add forked txs in the reader
- feat(dbg): add support for schema changes
- feat(dbg): remember tree expansions in reader view
- feat(dbg): add detailed step descriptions in statusbar
- feat(dbg): add keybindings for steps
- feat(dbg): add sibling mutations to reader view
- fix(dbg): fix received txs not filtered for canceled and auto 
- feat(dbg): add multi state indicators to schema tree
- feat(dbg): add tags support to schema tree
- fix(dbg): empty filter wont remove canceled txs
- fix(dbg): fix tree steps color issues #167
- feat(dbg): de-noise stack traces
- fix(dbg): send disconnects with --fwd-data 
- fix(dbg): fix visualizer panic when parent mach missing

This release is full a tiny features and fixes aiming at daily usage, as well as adding support for dynamic schemas.

![ss-2025-06-21-12-51-20](https://github.com/user-attachments/assets/f0e9d0fc-5aaf-4728-8fdb-6317ef43c5a7)
