### PR TITLE
feat(machine): introduce backoff for handler timeouts

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -865,7 +865,7 @@ func TestPartialAutoStatesByStateState(t *testing.T) {
 
 	// trigger auto
 	m.Add1("C", nil)
-	assertStates(t, m, S{"C", "A"}, "only A auto state should be active")
+	assertStates(t, m, S{"C", "A"}, "only C and A auto state should be active")
 }
 
 func TestPartialAutoStatesByEnter(t *testing.T) {
@@ -2663,6 +2663,7 @@ func TestHandlerTimeout(t *testing.T) {
 	// init
 	m := NewNoRels(t, nil)
 	m.HandlerTimeout = 450 * time.Millisecond
+	m.HandlerDeadline = time.Second
 
 	// bind handlers
 	err := m.BindHandlers(&TestHandlerTimeoutHandlers{})
@@ -2672,11 +2673,33 @@ func TestHandlerTimeout(t *testing.T) {
 	res := m.Add1("A", nil)
 
 	// assert TODO assert log
-	assert.Equal(t, Canceled, res, "expeting Canceled")
+	assert.Equal(t, Canceled, res, "expecting Canceled")
 
 	// dispose
 	m.Dispose()
 	<-m.WhenDisposed()
+}
+
+// TestNestedMutation
+type TestHandlerAcceptTimeoutHandlers struct {
+	*ExceptionHandler
+}
+
+func (h *TestHandlerAcceptTimeoutHandlers) AState(e *Event) {
+	// wait longer then the timeout
+	time.Sleep(500 * time.Millisecond)
+
+	// TODO assert pre-err
+
+	if !e.IsValid() {
+		return
+	}
+	panic("should not reach here")
+}
+
+func TestHandlerDeadline(t *testing.T) {
+	t.Skip("TODO")
+	// TODO assert new event loop and backoff
 }
 
 // TestBindTracer

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -78,6 +78,8 @@ type Opts struct {
 	Id string
 	// Time for a handler to execute. Default: time.Second
 	HandlerTimeout time.Duration
+	// TODO docs
+	HandlerDeadline time.Duration
 	// If true, the machine will NOT print all exceptions to stdout.
 	DontLogStackTrace bool
 	// If true, the machine will die on panics.
@@ -108,7 +110,8 @@ type Opts struct {
 	// deadlock. It works in similar way as -race flag in Go and can also be
 	// triggered by setting either env var: AM_DEBUG=1 or AM_DETECT_EVAL=1.
 	// Default: false.
-	DetectEval bool
+	DetectEval     bool
+	HandlerBackoff time.Duration
 }
 
 // Serialized is a machine state serialized to a JSON/YAML/TOML compatible


### PR DESCRIPTION
 - fixes #220
 - add Backoff(), HandlerDeadline, HandlerBackoff

Fault tolerancy now works well under a heavy load with handlers timing out:

- handler is started
- timeout is reached (100ms)
- handle has to return within `HandlerDeadline` (10s)
- as early as `Event.IsValid()` returns true
- transition is canceled anyway
- in case of no return, the machine goes into a backoff state
- all the queue is flushed down the drain
- machine cancels any mutations for the period of `HandlerBackoff` (3s)
- new mutations run on a new event loop

This achieves goroutine cancellation based on probabilities (similar to hash collisions), and can be adjusted on per-machine and per-usecase basis.