### PR TITLE
feat(pubsub): optimize pubsub, add UDS for tests

### DIFF
--- a/pkg/pubsub/README.md
+++ b/pkg/pubsub/README.md
@@ -94,6 +94,7 @@ var ss = states.TopicStates
 // ...
 
 var remotePeerId string
+var ps *ampusub.Topic
 
 // list machines exported by [remotePeerId]
 ch := make(chan []*rpc.Worker, 1)
@@ -105,7 +106,7 @@ args := &A{
 }
 _ = ps.Mach.Add1(ss.ListMachines, Pass(args))
 workers := <-ch
-close(ch)
+close(ch)s
 
 // find a worker tagged "foo", add state "Bar", and wait for state "Baz"
 for _, mach := range workers {
@@ -113,8 +114,10 @@ for _, mach := range workers {
         continue
     }
     mach.Add1("Bar", nil)
-    <-mach.Add1("Baz", nil)
-    println("Baz set on " + mach.Id())
+    println("Bar set on " + mach.Id())
+    
+    <-mach.When1("Baz", nil)
+    println("Baz active on " + mach.Id())
     break
 }
 ```

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -163,13 +163,16 @@ type A struct {
 	MsgReqInfo    *MsgReqInfo
 	MsgReqUpdates *MsgReqUpdates
 	MsgGossip     *MsgGossip
-	// Msgs is a list of received general (non-semantic) PubSub messages.
+	// Msgs is a list of PubSub messages.
 	Msgs []*pubsub.Message
+	// Length is a general length used for logging
+	Length int `log:"length"`
 	// Msg is a raw msg.
 	Msg []byte
 	// PeerId is a peer ID
-	PeerId  string   `log:"peer"`
-	PeerIds []string `log:"peer_ids"`
+	Peer    string `log:"peer"`
+	PeerId  string
+	PeerIds []string
 	// MachId is a state machine ID
 	MachId string `log:"mach_id"`
 	// MTime is machine time

--- a/pkg/pubsub/states/ss_topic.go
+++ b/pkg/pubsub/states/ss_topic.go
@@ -57,6 +57,7 @@ type TopicStatesDef struct {
 	// via chan, as [rpc.Worker].
 	ListMachines string
 	SendMsg      string
+	ProcessMsgs  string
 	SendInfo     string
 
 	// inherit from BasicStatesDef
@@ -168,6 +169,10 @@ var TopicSchema = SchemaMerge(
 			Require: S{ssT.Joined},
 		},
 		ssT.SendMsg: {
+			Multi:   true,
+			Require: S{ssT.Joined},
+		},
+		ssT.ProcessMsgs: {
 			Multi:   true,
 			Require: S{ssT.Joined},
 		},

--- a/pkg/pubsub/uds/uds.go
+++ b/pkg/pubsub/uds/uds.go
@@ -1,0 +1,171 @@
+// Package uds was auto-translated from rust-libp2p.
+// https://github.com/libp2p/rust-libp2p/blob/master/transports/uds/src/lib.rs
+package uds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/transport"
+	ma "github.com/multiformats/go-multiaddr"
+	mafmt "github.com/multiformats/go-multiaddr-fmt"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+const defaultConnectTimeout = 5 * time.Second
+
+var log = logging.Logger("uds-tpt")
+
+// UdsTransport is the Unix Domain Socket transport.
+type UdsTransport struct {
+	upgrader       transport.Upgrader
+	connectTimeout time.Duration
+	rcmgr          network.ResourceManager
+}
+
+var _ transport.Transport = &UdsTransport{}
+var _ transport.DialUpdater = &UdsTransport{}
+
+// NewUDSTransport creates a UDS transport object.
+func NewUDSTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, opts ...func(*UdsTransport) error) (*UdsTransport, error) {
+	if rcmgr == nil {
+		rcmgr = &network.NullResourceManager{}
+	}
+	tr := &UdsTransport{
+		upgrader:       upgrader,
+		connectTimeout: defaultConnectTimeout,
+		rcmgr:          rcmgr,
+	}
+	for _, o := range opts {
+		if err := o(tr); err != nil {
+			return nil, err
+		}
+	}
+	return tr, nil
+}
+
+var udsMatcher = mafmt.Base(ma.P_UNIX)
+
+// CanDial returns true if this transport believes it can dial the given multiaddr.
+func (t *UdsTransport) CanDial(addr ma.Multiaddr) bool {
+	return udsMatcher.Matches(addr)
+}
+
+func multiaddrToPath(addr ma.Multiaddr) (string, error) {
+	for _, p := range addr.Protocols() {
+		if p.Code == ma.P_UNIX {
+			path, err := addr.ValueForProtocol(ma.P_UNIX)
+			if err != nil {
+				return "", err
+			}
+			if !filepath.IsAbs(path) {
+				return "", errors.New("unix socket path must be absolute")
+			}
+			return path, nil
+		}
+	}
+	return "", errors.New("not a unix multiaddr")
+}
+
+func (t *UdsTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (manet.Conn, error) {
+	if t.connectTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, t.connectTimeout)
+		defer cancel()
+	}
+	path, err := multiaddrToPath(raddr)
+	if err != nil {
+		return nil, err
+	}
+	var d net.Dialer
+	nconn, err := d.DialContext(ctx, "unix", path)
+	if err != nil {
+		return nil, err
+	}
+	return manet.WrapNetConn(nconn)
+}
+
+// Dial dials the peer at the remote address.
+func (t *UdsTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
+	return t.DialWithUpdates(ctx, raddr, p, nil)
+}
+
+func (t *UdsTransport) DialWithUpdates(ctx context.Context, raddr ma.Multiaddr, p peer.ID, updateChan chan<- transport.DialUpdate) (transport.CapableConn, error) {
+	connScope, err := t.rcmgr.OpenConnection(network.DirOutbound, true, raddr)
+	if err != nil {
+		log.Debugw("resource manager blocked outgoing connection", "peer", p, "addr", raddr, "error", err)
+		return nil, err
+	}
+
+	c, err := t.dialWithScope(ctx, raddr, p, connScope, updateChan)
+	if err != nil {
+		connScope.Done()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (t *UdsTransport) dialWithScope(ctx context.Context, raddr ma.Multiaddr, p peer.ID, connScope network.ConnManagementScope, updateChan chan<- transport.DialUpdate) (transport.CapableConn, error) {
+	if err := connScope.SetPeer(p); err != nil {
+		log.Debugw("resource manager blocked outgoing connection for peer", "peer", p, "addr", raddr, "error", err)
+		return nil, err
+	}
+	conn, err := t.maDial(ctx, raddr)
+	if err != nil {
+		return nil, err
+	}
+	if updateChan != nil {
+		select {
+		case updateChan <- transport.DialUpdate{Kind: transport.UpdateKindHandshakeProgressed, Addr: raddr}:
+		default:
+		}
+	}
+	direction := network.DirOutbound
+	if ok, isClient, _ := network.GetSimultaneousConnect(ctx); ok && !isClient {
+		direction = network.DirInbound
+	}
+	return t.upgrader.Upgrade(ctx, t, conn, direction, p, connScope)
+}
+
+// Listen listens on the given multiaddr.
+func (t *UdsTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
+	path, err := multiaddrToPath(laddr)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove old unix socket: %w", err)
+	}
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	mln, err := manet.WrapNetListener(ln)
+	if err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return t.upgrader.UpgradeListener(t, mln), nil
+}
+
+// Protocols returns the list of terminal protocols this transport can dial.
+func (t *UdsTransport) Protocols() []int {
+	return []int{ma.P_UNIX}
+}
+
+// Proxy always returns false for the UDS transport.
+func (t *UdsTransport) Proxy() bool {
+	return false
+}
+
+func (t *UdsTransport) String() string {
+	return "UDS"
+}

--- a/pkg/pubsub/uds/uds_test.go
+++ b/pkg/pubsub/uds/uds_test.go
@@ -1,0 +1,261 @@
+// Package uds was auto-translated from rust-libp2p.
+// https://github.com/libp2p/rust-libp2p/blob/master/transports/uds/src/lib.rs
+package uds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
+	mocknetwork "github.com/libp2p/go-libp2p/core/network/mocks"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/sec"
+	"github.com/libp2p/go-libp2p/core/sec/insecure"
+	"github.com/libp2p/go-libp2p/core/transport"
+	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
+	ttransport "github.com/libp2p/go-libp2p/p2p/transport/testsuite"
+
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+var muxers = []tptu.StreamMuxer{} // No muxers for UDS in this test
+
+func randomSocketPath() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("amtest-%d-%d.sock", os.Getpid(), rand.Intn(1e6)))
+}
+
+func TestUdsTransport(t *testing.T) {
+	t.Skip()
+	for i := 0; i < 2; i++ {
+		peerA, ia := makeInsecureMuxer(t)
+		_, ib := makeInsecureMuxer(t)
+
+		ua, err := tptu.New(ia, muxers, nil, nil, nil)
+		require.NoError(t, err)
+		ta, err := NewUDSTransport(ua, nil)
+		require.NoError(t, err)
+		ub, err := tptu.New(ib, muxers, nil, nil, nil)
+		require.NoError(t, err)
+		tb, err := NewUDSTransport(ub, nil)
+		require.NoError(t, err)
+
+		path := randomSocketPath()
+		addr := fmt.Sprintf("/unix/%s", path)
+		ttransport.SubtestTransport(t, ta, tb, addr, peerA)
+	}
+}
+
+func TestUdsTransportWithResourceManager(t *testing.T) {
+	t.Skip()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	peerA, ia := makeInsecureMuxer(t)
+	_, ib := makeInsecureMuxer(t)
+
+	ua, err := tptu.New(ia, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	ta, err := NewUDSTransport(ua, nil)
+	require.NoError(t, err)
+	path := randomSocketPath()
+	ln, err := ta.Listen(ma.StringCast(fmt.Sprintf("/unix/%s", path)))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ub, err := tptu.New(ib, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	rcmgr := mocknetwork.NewMockResourceManager(ctrl)
+	tb, err := NewUDSTransport(ub, rcmgr)
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		scope := mocknetwork.NewMockConnManagementScope(ctrl)
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(scope, nil)
+		scope.EXPECT().SetPeer(peerA)
+		scope.EXPECT().PeerScope().Return(&network.NullScope{}).AnyTimes()
+		conn, err := tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		require.NoError(t, err)
+		scope.EXPECT().Done()
+		defer conn.Close()
+	})
+
+	t.Run("connection denied", func(t *testing.T) {
+		rerr := errors.New("nope")
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(nil, rerr)
+		_, err = tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		require.ErrorIs(t, err, rerr)
+	})
+
+	t.Run("peer denied", func(t *testing.T) {
+		scope := mocknetwork.NewMockConnManagementScope(ctrl)
+		rcmgr.EXPECT().OpenConnection(network.DirOutbound, true, ln.Multiaddr()).Return(scope, nil)
+		rerr := errors.New("nope")
+		scope.EXPECT().SetPeer(peerA).Return(rerr)
+		scope.EXPECT().Done()
+		_, err = tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		require.ErrorIs(t, err, rerr)
+	})
+}
+
+func TestUdsTransportCantDialNonUnix(t *testing.T) {
+	t.Skip()
+	for i := 0; i < 2; i++ {
+		dnsa, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234")
+		require.NoError(t, err)
+
+		var u transport.Upgrader
+		tpt, err := NewUDSTransport(u, nil)
+		require.NoError(t, err)
+
+		if tpt.CanDial(dnsa) {
+			t.Fatal("shouldn't be able to dial non-unix multiaddr")
+		}
+	}
+}
+
+func TestDialWithUpdatesUDS(t *testing.T) {
+	t.Skip()
+	peerA, ia := makeInsecureMuxer(t)
+	_, ib := makeInsecureMuxer(t)
+
+	ua, err := tptu.New(ia, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	ta, err := NewUDSTransport(ua, nil)
+	require.NoError(t, err)
+	path := randomSocketPath()
+	ln, err := ta.Listen(ma.StringCast(fmt.Sprintf("/unix/%s", path)))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ub, err := tptu.New(ib, muxers, nil, nil, nil)
+	require.NoError(t, err)
+	tb, err := NewUDSTransport(ub, nil)
+	require.NoError(t, err)
+
+	updCh := make(chan transport.DialUpdate, 1)
+	conn, err := tb.DialWithUpdates(context.Background(), ln.Multiaddr(), peerA, updCh)
+	upd := <-updCh
+	require.Equal(t, transport.UpdateKindHandshakeProgressed, upd.Kind)
+	require.NotNil(t, conn)
+	require.NoError(t, err)
+
+	acceptAndClose := func() manet.Listener {
+		path := randomSocketPath()
+		li, err := manet.Listen(ma.StringCast(fmt.Sprintf("/unix/%s", path)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			conn, err := li.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}()
+		return li
+	}
+	li := acceptAndClose()
+	defer li.Close()
+	// This dial will fail as acceptAndClose will not upgrade the connection
+	conn, err = tb.DialWithUpdates(context.Background(), li.Multiaddr(), peerA, updCh)
+	upd = <-updCh
+	require.Equal(t, transport.UpdateKindHandshakeProgressed, upd.Kind)
+	require.Nil(t, conn)
+	require.Error(t, err)
+}
+
+func makeInsecureMuxer(t *testing.T) (peer.ID, []sec.SecureTransport) {
+	t.Skip()
+	t.Helper()
+	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 256)
+	require.NoError(t, err)
+	id, err := peer.IDFromPrivateKey(priv)
+	require.NoError(t, err)
+	return id, []sec.SecureTransport{insecure.NewWithIdentity(insecure.ID, id, priv)}
+}
+
+type errDialer struct {
+	err error
+}
+
+func (d errDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return nil, d.err
+}
+
+func TestCustomOverrideUDSDialer(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		peerA, ia := makeInsecureMuxer(t)
+		ua, err := tptu.New(ia, muxers, nil, nil, nil)
+		require.NoError(t, err)
+		ta, err := NewUDSTransport(ua, nil)
+		require.NoError(t, err)
+		path := randomSocketPath()
+		ln, err := ta.Listen(ma.StringCast(fmt.Sprintf("/unix/%s", path)))
+		require.NoError(t, err)
+		defer ln.Close()
+
+		_, ib := makeInsecureMuxer(t)
+		ub, err := tptu.New(ib, muxers, nil, nil, nil)
+		require.NoError(t, err)
+		// called := false
+		// customDialer := func(raddr ma.Multiaddr) (ContextDialer, error) {
+		// 	called = true
+		// 	return &net.Dialer{}, nil
+		// }
+		tb, err := NewUDSTransport(ub, nil /*, WithDialerForAddr(customDialer) */)
+		// TODO: implement WithDialerForAddr for UDS if needed
+		require.NoError(t, err)
+
+		conn, err := tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		// require.True(t, called, "custom dialer should have been called")
+		conn.Close()
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		peerA, ia := makeInsecureMuxer(t)
+		ua, err := tptu.New(ia, muxers, nil, nil, nil)
+		require.NoError(t, err)
+		ta, err := NewUDSTransport(ua, nil)
+		require.NoError(t, err)
+		path := randomSocketPath()
+		ln, err := ta.Listen(ma.StringCast(fmt.Sprintf("/unix/%s", path)))
+		require.NoError(t, err)
+		defer ln.Close()
+
+		for _, test := range []string{"error in factory", "error in custom dialer"} {
+			t.Run(test, func(t *testing.T) {
+				_, ib := makeInsecureMuxer(t)
+				ub, err := tptu.New(ib, muxers, nil, nil, nil)
+				require.NoError(t, err)
+				// customErr := errors.New("custom dialer error")
+				// customDialer := func(raddr ma.Multiaddr) (ContextDialer, error) {
+				// 	if test == "error in factory" {
+				// 		return nil, customErr
+				// 	} else {
+				// 		return errDialer{err: customErr}, nil
+				// 	}
+				// }
+				tb, err := NewUDSTransport(ub, nil /*, WithDialerForAddr(customDialer) */)
+				// TODO: implement WithDialerForAddr for UDS if needed
+				require.NoError(t, err)
+
+				conn, err := tb.Dial(context.Background(), ln.Multiaddr(), peerA)
+				require.Error(t, err)
+				// require.ErrorContains(t, err, customErr.Error())
+				require.Nil(t, conn)
+			})
+		}
+	})
+}


### PR DESCRIPTION
- update libp2p (not pubsub)
- add more rate limiting via a multiplayer
- queue-aware mutations
- evals removed
- use libp2p without prom_client
  - saves 15k goroutines for 100 peers
- load test using Unix Domain Sockets

Load test for 200 peers now passes. It's possible to debug 100 peers with metrics machines, and logging disabled.