### PR TITLE
feat(machine): add LogExternal, LogSteps log levels

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -2172,7 +2172,7 @@ func (m *Machine) Log(msg string, args ...any) {
 	// single lines only
 	msg = strings.ReplaceAll(msg, "\n", " ")
 
-	m.log(LogChanges, prefix+"] "+msg, args...)
+	m.log(LogExternal, prefix+"] "+msg, args...)
 }
 
 // InternalLog adds an internal log entry from the outside. It should be used
@@ -2345,13 +2345,16 @@ func (m *Machine) handle(
 	}
 
 	// negotiation support
-	if !step.IsFinal && res == Canceled {
-		var self string
-		if step.IsSelf {
-			self = ":self"
+	if !isFinal && res == Canceled {
+		if m.LogLevel() >= LogOps {
+			var self string
+			if isSelf {
+				self = ":self"
+			}
+
+			m.log(LogOps, "[cancel%s] (%s) by %s", self,
+				j(targetStates), name)
 		}
-		m.log(LogOps, "[cancel%s] (%s) by %s", self,
-			targetStates, name)
 
 		return Canceled, handlerCalled
 	}

--- a/pkg/machine/misc_mach.go
+++ b/pkg/machine/misc_mach.go
@@ -332,10 +332,14 @@ type LogEntry struct {
 // LogLevel enum
 type LogLevel int
 
-// TODO add LogOpsSubs (30), spread log level 0 - 10 - 20 - 30 - 40
+// TODO spread log level 0 - 10 - 20 - 30 - 40 - 50 - 60
 const (
 	// LogNothing means no logging, including external msgs.
 	LogNothing LogLevel = iota
+	// LogExternal will show ony external user msgs.
+	LogExternal
+	// LogSteps will show external user msgs and also create transition steps.
+	LogSteps
 	// LogChanges means logging state changes and external msgs.
 	LogChanges
 	// LogOps means LogChanges + logging all the operations.
@@ -348,6 +352,10 @@ const (
 
 func (l LogLevel) String() string {
 	switch l {
+	case LogExternal:
+		return "external"
+	case LogSteps:
+		return "steps"
 	case LogChanges:
 		return "changes"
 	case LogOps:

--- a/pkg/machine/misc_mach_test.go
+++ b/pkg/machine/misc_mach_test.go
@@ -75,6 +75,7 @@ func TestLogLevelString(t *testing.T) {
 
 	assert.Equal(t, "nothing", LogNothing.String())
 	assert.Equal(t, "nothing", LogLevel(0).String())
+	assert.Equal(t, "external", LogExternal.String())
 	assert.Equal(t, "changes", LogChanges.String())
 	assert.Equal(t, "ops", LogOps.String())
 	assert.Equal(t, "decisions", LogDecisions.String())


### PR DESCRIPTION
A simple yet effective optimization in v0.13 is disabling the log, while still keeping external msgs. This will also prevent the machine from creating and sending out debugging steps, per each transition. This unfortunately breaks old data dumps a bit, which need to be bumped +2 for the log level.