### PR TITLE
feat(am-dbg): cache SVG diagrams based on schema hashes

### DIFF
--- a/tools/cmd/am-dbg/cmd_dbg.go
+++ b/tools/cmd/am-dbg/cmd_dbg.go
@@ -44,12 +44,12 @@ func cliRun(_ *cobra.Command, _ []string, p cli.Params) {
 
 	// init the debugger
 	dbg, err := debugger.New(ctx, debugger.Opts{
-		DbgLogLevel:   p.LogLevel,
-		DbgLogger:     logger,
-		ImportData:    p.ImportData,
-		OutputClients: p.OutputClients,
-		Diagrams:      p.Graph,
-		Timelines:     p.Timelines,
+		DbgLogLevel:    p.LogLevel,
+		DbgLogger:      logger,
+		ImportData:     p.ImportData,
+		OutputClients:  p.OutputClients,
+		OutputDiagrams: p.Graph,
+		Timelines:      p.Timelines,
 		// ...:           p.FilterLogLevel,
 		OutputDir:       p.OutputDir,
 		ServerAddr:      p.ListenAddr,

--- a/tools/debugger/cli/cli_dbg.go
+++ b/tools/debugger/cli/cli_dbg.go
@@ -20,7 +20,6 @@ import (
 // TODO enum
 // TODO cobra groups
 const (
-	// TODO remove
 	pLogLevel        = "log-level"
 	pServerAddr      = "listen-on"
 	pServerAddrShort = "l"
@@ -41,7 +40,7 @@ const (
 	// TODO AM_DBG_PROF
 	pProfSrv      = "prof-srv"
 	pMaxMem       = "max-mem"
-	pLog2Ttl      = "log-2-ttl"
+	pLogOpsTtl    = "log-ops-ttl"
 	pReaderShort  = "r"
 	pFwdData      = "fwd-data"
 	pFwdDataShort = "f"
@@ -119,7 +118,8 @@ func RootCmd(fn RootFn) *cobra.Command {
 func AddFlags(rootCmd *cobra.Command) {
 
 	f := rootCmd.Flags()
-	f.Int(pLogLevel, 0, "Log level, 0-5 (silent-everything)")
+	f.Int(pLogLevel, 0,
+		"Log level produced by this instance, 0-6 (silent-everything)")
 	f.StringP(pServerAddr, pServerAddrShort, telemetry.DbgAddr,
 		"Host and port for the debugger to listen on")
 	f.String(pAmDbgAddr, "", "Debug this instance of am-dbg with another one")
@@ -151,7 +151,7 @@ func AddFlags(rootCmd *cobra.Command) {
 
 	f.String(pProfSrv, "", "Start pprof server")
 	f.Int(pMaxMem, 1000, "Max memory usage (in MB) to flush old transitions")
-	f.String(pLog2Ttl, "24h", "Max time to live for logs level 2")
+	f.String(pLogOpsTtl, "24h", "Max time to live for logs level LogOps")
 	f.Bool(pVersion, false, "Print version and exit")
 
 	// OUTPUT
@@ -229,7 +229,7 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 	if err != nil {
 		panic(err)
 	}
-	log2Ttl, err := time.ParseDuration(cmd.Flag(pLog2Ttl).Value.String())
+	log2Ttl, err := time.ParseDuration(cmd.Flag(pLogOpsTtl).Value.String())
 	if err != nil {
 		panic(err)
 	}
@@ -368,6 +368,7 @@ func StartCpuProfile(logger *log.Logger, p *Params) func() {
 	if err := pprof.StartCPUProfile(f); err != nil {
 		logger.Fatal("could not start CPU profile: ", err)
 	}
+	
 	return func() {
 		pprof.StopCPUProfile()
 		f.Close()

--- a/tools/debugger/misc_dbg.go
+++ b/tools/debugger/misc_dbg.go
@@ -20,7 +20,7 @@ import (
 const (
 	// TODO light mode
 	colorActive     = tcell.ColorOlive
-	colorActive2    = tcell.ColorOliveDrab
+	colorActive2    = tcell.ColorGreenYellow
 	colorInactive   = tcell.ColorLimeGreen
 	colorHighlight  = tcell.ColorDarkSlateGray
 	colorHighlight2 = tcell.ColorDimGray
@@ -52,11 +52,12 @@ const (
 	toolFilterAutoTx      ToolName = "skip-auto"
 	toolFilterEmptyTx     ToolName = "skip-empty"
 	toolFilterHealthcheck ToolName = "skip-healthcheck"
-	ToolFilterSummaries   ToolName = "hide-summaries"
-	ToolFilterTraces      ToolName = "hide-traces"
-	toolLog               ToolName = "log"
-	toolDiagrams          ToolName = "diagrams"
-	toolTimelines         ToolName = "timelines"
+	// TODO rename to timestamps
+	ToolFilterSummaries ToolName = "hide-summaries"
+	ToolFilterTraces    ToolName = "hide-traces"
+	toolLog             ToolName = "log"
+	toolDiagrams        ToolName = "diagrams"
+	toolTimelines       ToolName = "timelines"
 	// toolLog0              ToolName = "log-0"
 	// toolLog1              ToolName = "log-1"
 	// toolLog2              ToolName = "log-2"
@@ -116,9 +117,9 @@ type Opts struct {
 	OutputClients bool
 	// Root dir for output files
 	OutputDir string
-	// Diagrams is the level of details of the current machine's graph 0-3
+	// OutputDiagrams is the details level of the current machine's diagram (0-3).
 	// 0 - off, 3 - most detailed
-	Diagrams int
+	OutputDiagrams int
 	// Screen overload for tests & ssh
 	Screen tcell.Screen
 	// Debugger's ID
@@ -202,11 +203,12 @@ type Client struct {
 	SelectedReaderEntry *logReaderEntryPtr
 	ReaderCollapsed     bool
 
-	txCache   map[string]int
-	txCacheMx sync.Mutex
-	id        string
-	connId    string
-	connected atomic.Bool
+	txCache    map[string]int
+	txCacheMx  sync.Mutex
+	id         string
+	connId     string
+	schemaHash string
+	connected  atomic.Bool
 	// processed
 	msgTxsParsed []*MsgTxParsed
 	// processed list of filtered tx indexes

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -8,6 +8,14 @@ import (
 // States map defines relations and properties of states.
 var States = am.Schema{
 
+	// Errors
+
+	ErrDiagrams: {
+		Multi:   true,
+		Require: S{Exception},
+		Remove:  S{DiagramsScheduled, DiagramsRendering},
+	},
+
 	// ///// Input events
 
 	ClientMsg:       {Multi: true},
@@ -194,13 +202,15 @@ var States = am.Schema{
 		Multi:   true,
 		Require: S{Ready},
 	},
-	GraphsScheduled: {
+	DiagramsScheduled: {
 		Multi:   true,
 		Require: S{Ready},
 	},
-	GraphsRendering: {
+	DiagramsRendering: {
 		Require: S{Ready},
+		Remove:  S{DiagramsReady},
 	},
+	DiagramsReady: {Remove: S{DiagramsRendering}},
 
 	InitClient: {Multi: true},
 }
@@ -324,12 +334,14 @@ const (
 	// ScrollToMutTx scrolls to a transition which mutated or called the
 	// passed state,
 	// If fwd is true, it scrolls forward, otherwise backwards.
-	ScrollToMutTx   = "ScrollToMutTx"
-	MatrixRain      = "MatrixRain"
-	SetCursor       = "SetCursor"
-	GraphsRendering = "GraphsRendering"
-	GraphsScheduled = "GraphsScheduled"
-	InitClient      = "InitClient"
+	ScrollToMutTx     = "ScrollToMutTx"
+	MatrixRain        = "MatrixRain"
+	SetCursor         = "SetCursor"
+	DiagramsScheduled = "DiagramsScheduled"
+	DiagramsRendering = "DiagramsRendering"
+	DiagramsReady     = "DiagramsReady"
+	ErrDiagrams       = "ErrDiagrams"
+	InitClient        = "InitClient"
 )
 
 // Names of all the states (pkg enum).
@@ -419,8 +431,10 @@ var Names = S{
 	RemoveClient,
 
 	SetCursor,
-	GraphsRendering,
-	GraphsScheduled,
+	DiagramsScheduled,
+	DiagramsRendering,
+	DiagramsReady,
+	ErrDiagrams,
 
 	InitClient,
 }

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -410,10 +410,10 @@ func (d *Debugger) initToolbar() {
 			}},
 			// TODO make it an anchor for file://...svg
 			{id: toolDiagrams, label: "diagrams", active: func() bool {
-				return d.Opts.Diagrams > 0
+				return d.Opts.OutputDiagrams > 0
 			}, activeLabel: func() string {
 				// TODO make Opts threadsafe
-				return strconv.Itoa(d.Opts.Diagrams)
+				return strconv.Itoa(d.Opts.OutputDiagrams)
 			}},
 			{id: toolRain, label: "rain", active: func() bool {
 				return d.Mach.Is1(ss.MatrixRain)
@@ -473,6 +473,7 @@ func (d *Debugger) initHelpDialog() *cview.Flex {
 		[::b]### [::u]tree legend[::-]
 		[%s::b]state[-]        active state
 		[%s::b]state[-]        inactive state
+		[%s::b]state[-]        active multi state
 		[red::b]state[-]        active error state
 		[::b]M|[::-]           multi state
 		[::b]|5[::-]           tick value
@@ -508,7 +509,7 @@ func (d *Debugger) initHelpDialog() *cview.Flex {
 		[::b]### [::u]dashboard keystrokes[::-]
 		[::b]alt arrow[::-]    navigate to tiles
 		[::b]alt -+[::-]       change size of a tile
-	`, "\n ")), colorActive, colorInactive))
+	`, "\n ")), colorActive, colorActive2, colorInactive))
 
 	// render the right side separately
 	d.updateHelpDialog()

--- a/tools/visualizer/visualizer_test.go
+++ b/tools/visualizer/visualizer_test.go
@@ -1,0 +1,27 @@
+package visualizer
+
+// func TestUpdates(t *testing.T) {
+// 	sel := &Selection{
+// 		MachId: "cook",
+// 		States: am.S{"Exception", "StoryCookingStarted", "StoryJoke", "Ready", "Requesting", "StoryStartAgain", "Start", "BaseDBStarting", "CheckStories"},
+// 		// Active: am.S{"StoryJoke"},
+// 		Active: am.S{"Ready", "StoryStartAgain", "Start", "CheckStories"},
+// 	}
+//
+// 	path := "testdata/sample.svg"
+// 	file, err := os.Open(path)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	defer file.Close()
+//
+// 	dom, err := goquery.NewDocumentFromReader(file)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+//
+// 	err = UpdateCache(context.Background(), path, dom, sel)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }


### PR DESCRIPTION
Diagrams are now usable for observing active states, as they dont re-render on each transition change. Re-rendering
completely changes the layout, so schemas are hashed and SVGs reused. Another SVG DOM cache is kept for the current machine, making results almost instantaneous.