### PR TITLE
feat(mach): recover state from timeouts in final handlers

### DIFF
--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -634,6 +634,14 @@ func (t *Transition) emitEvents() Result {
 			// FooEnd
 			result = t.emitFinalEvents()
 		}
+
+		// handle timeouts in final handlers the same as a panic
+		// TODO test
+		if result == Canceled {
+			m.recoverFinalPhase()
+		}
+
+		// TODO safe to continue?
 		hasStateChanged = !m.IsTime(t.TimeBefore, nil)
 	} else {
 		// gather new clock values, overwrite fake TimeAfter


### PR DESCRIPTION
Timed-out transitions now recover the final state the same way [panics do](/docs/manual.md#panic-in-a-final-handler). Manual data recovery (if any) is still necessary via catching the correct Exception.