### PR TITLE
feat(machine): add Semantic Logger

### DIFF
--- a/pkg/machine/misc_mach_test.go
+++ b/pkg/machine/misc_mach_test.go
@@ -28,7 +28,7 @@ func TestWithOpts(t *testing.T) {
 
 	// OptsWithParentTracers
 	mach := New(context.TODO(), nil, opts)
-	mach.SetLogArgs(NewArgsMapper([]string{"arg"}, 10))
+	mach.SemLogger().SetArgs(NewArgsMapper([]string{"arg"}, 10))
 }
 
 func TestResultString(t *testing.T) {

--- a/pkg/machine/resolver.go
+++ b/pkg/machine/resolver.go
@@ -116,7 +116,7 @@ func (rr *DefaultRelationsResolver) TargetStates(
 		}
 
 		m.log(lvl, "[rel:remove] %s by %s", name, j(blockedBy))
-		if m.LogLevel() >= LogSteps {
+		if t.isLogSteps() {
 			if m.is(S{name}) {
 				t.addSteps(newStep("", name, StepRemove, 0))
 			} else {
@@ -206,13 +206,13 @@ func (rr *DefaultRelationsResolver) SortStates(states S) {
 
 		// forward relations
 		if slices.Contains(state1.After, name2) {
-			if m.LogLevel() >= LogSteps {
+			if t.isLogSteps() {
 				t.addSteps(newStep(name2, name1, StepRelation, RelationAfter))
 			}
 			return false
 
 		} else if slices.Contains(state2.After, name1) {
-			if m.LogLevel() >= LogSteps {
+			if t.isLogSteps() {
 				t.addSteps(newStep(name1, name2, StepRelation, RelationAfter))
 			}
 			return true
@@ -265,7 +265,7 @@ func (rr *DefaultRelationsResolver) parseAdd(states S) S {
 				continue
 			}
 
-			if rr.Machine.LogLevel() >= LogChanges {
+			if rr.Machine.semLogger.IsSteps() {
 				t.addSteps(newSteps(name, addStates, StepRelation,
 					RelationAdd)...)
 				t.addSteps(newSteps("", addStates, StepSet, 0)...)
@@ -294,7 +294,7 @@ func (rr *DefaultRelationsResolver) stateBlockedBy(
 			continue
 		}
 
-		if m.LogLevel() >= LogSteps {
+		if t.isLogSteps() {
 			t.addSteps(newStep(blocking, blocked, StepRelation,
 				RelationRemove))
 		}
@@ -343,11 +343,10 @@ func (rr *DefaultRelationsResolver) getMissingRequires(
 	name string, state State, states S,
 ) S {
 	t := rr.Transition
-	m := t.Machine
 	ret := S{}
 
 	for _, req := range state.Require {
-		if m.LogLevel() >= LogSteps {
+		if t.isLogSteps() {
 			t.addSteps(newStep(name, req, StepRelation,
 				RelationRequire))
 		}
@@ -355,13 +354,13 @@ func (rr *DefaultRelationsResolver) getMissingRequires(
 			continue
 		}
 		ret = append(ret, req)
-		if m.LogLevel() >= LogSteps {
+		if t.isLogSteps() {
 			t.addSteps(newStep(name, "", StepRemoveNotActive, 0))
 		}
 
 		idx := slices.Index(rr.Index, name)
 		if slices.Contains(t.Mutation.Called, idx) {
-			if m.LogLevel() >= LogSteps {
+			if t.isLogSteps() {
 				t.addSteps(newStep("", req,
 					StepCancel, 0))
 			}

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -18,6 +18,18 @@ const (
 	// EnvAmLog sets the log level.
 	// "1" | "2" | "3" | "4" | "" (default)
 	EnvAmLog = "AM_LOG"
+	// EnvAmLogFull enables all the semantuc loggers.
+	// "1" | "2" | "3" | "4" | "5" | "" (default)
+	EnvAmLogFull = "AM_LOG_FULL"
+	// EnvAmLogSteps logs transition steps
+	// "1" | "" (default)
+	EnvAmLogSteps = "AM_LOG_STEPS"
+	// EnvAmLogGraph logs graph structure (mut traces, pipes, etc)
+	// "1" | "" (default)
+	EnvAmLogGraph = "AM_LOG_GRAPH"
+	// EnvAmLogChecks logs Can methods.
+	// "1" | "" (default)
+	EnvAmLogChecks = "AM_LOG_CHECKS"
 	// EnvAmLogFile enables file logging (using machine ID as the name).
 	// "1" | "" (default)
 	EnvAmLogFile = "AM_LOG_FILE"
@@ -202,19 +214,22 @@ type Api interface {
 
 	// Misc (local)
 
-	Log(msg string, args ...any)
+	// Id is [Machine.Id].
 	Id() string
+	// ParentId is [Machine.ParentId].
 	ParentId() string
+	// Tags is [Machine.Tags].
 	Tags() []string
-	SetLogId(val bool)
-	GetLogId() bool
-	SetLogger(logger Logger)
-	SetLogLevel(lvl LogLevel)
-	SetLoggerEmpty(lvl LogLevel)
-	SetLoggerSimple(logf func(format string, args ...any), level LogLevel)
+	// Ctx is [Machine.Ctx].
 	Ctx() context.Context
+	// String is [Machine.String].
 	String() string
+	// StringAll is [Machine.StringAll].
 	StringAll() string
+	// Log is [Machine.Log].
+	Log(msg string, args ...any)
+	// SemLogger is [Machine.SemLogger].
+	SemLogger() SemLogger
 	Inspect(states S) string
 	Index(states S) []int
 	Index1(state string) int


### PR DESCRIPTION
- replacing many log related methods
- `InternalLog` removed

Logging changes from `v0.13` proved not to scale well, and a new semantic logger has been introduced. `LogChanges` is now `2` (was `1` and then `3`), which is final thanks to sem logger methods:

- `EnableGraph` (for pipes and custom connections)
- `EnableSteps`
- `EnableCan`

New logging env vars were added:

- `AM_LOG_FULL`
- `AM_LOG_STEPS`
- `AM_LOG_GRAPH`
- `AM_LOG_CHECKS`