### PR TITLE
feat(machine): add CanAdd, CanRemove, and EnableCan

### DIFF
--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -361,6 +361,8 @@ type Mutation struct {
 	Auto bool
 	// Source is the source event for this mutation.
 	Source *MutSource
+	// Can* methods
+	IsCheck bool
 
 	// specific context for this mutation (optional)
 	ctx context.Context


### PR DESCRIPTION
The long-delayed "Can methods" have finally landed. These can be used to probe which mutations are possible, or rather **impossible**. Benefits:

- just for checking things out (graph traversal)
- a cleaner debug timeline for negotiation-heavy machines (less canceled transitions)

```go
func (d *Debugger) ExceptionEnter(e *am.Event) bool {
	// ignore eval timeouts, but log them
	a := am.ParseArgs(e.Args)
	if errors.Is(a.Err, am.ErrEvalTimeout) {
		if !e.IsCheck {
			d.Mach.Log(a.Err.Error())
		}

		return false
	}

	return true
}
```