### PR TITLE
feat(am-dbg): add support for schema groups and Can methods

### DIFF
--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -95,6 +95,8 @@ var States = am.Schema{
 	FilterSummaries:   {},
 	FilterTraces:      {},
 	FilterHealthcheck: {},
+	FilterChecks:      {},
+	FilterOutGroup:    {},
 
 	// ///// Actions
 
@@ -320,6 +322,9 @@ const (
 	FilterCanceledTx  = "FilterCanceledTx"
 	FilterAutoTx      = "FilterAutoTx"
 	FilterHealthcheck = "FilterHealthcheck"
+	FilterChecks      = "FilterChecks"
+	// FilterOutGroup filters out txs for states outside the selected group.
+	FilterOutGroup = "FilterOutGroup"
 	// FilterEmptyTx is a filter for txes which didn't change state and didn't
 	// run any self handler either
 	FilterEmptyTx   = "FilterEmptyTx"
@@ -403,6 +408,8 @@ var Names = S{
 	FilterSummaries,
 	FilterTraces,
 	FilterHealthcheck,
+	FilterChecks,
+	FilterOutGroup,
 	ToggleTool,
 	SwitchingClientTx,
 	SwitchedClientTx,

--- a/tools/debugger/tree.go
+++ b/tools/debugger/tree.go
@@ -702,8 +702,16 @@ func (d *Debugger) handleExpanded(
 func (d *Debugger) buildStatesTree() {
 	msg := d.C.MsgStruct
 	d.treeRoot.ClearChildren()
-	// var bl bool
-	for _, name := range msg.StatesIndex {
+
+	// pick states
+	states := msg.StatesIndex
+	if c.SelectedGroup != "" {
+		states = c.msgSchemaParsed.Groups[c.SelectedGroup]
+	}
+	d.schemaTreeStates = states
+
+	// build
+	for _, name := range states {
 		// if !bl {
 		// 	// TODO enable breaklines
 		// 	bl = d.addBreakLine(name, i)

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -35,6 +35,14 @@ func (d *Debugger) initUiComponents() {
 	d.tree.SetTitle(" Schema ")
 	d.tree.SetBorder(true)
 
+	// groups dropdown
+	d.treeGroups = cview.NewDropDown()
+	d.treeGroups.SetLabel(" Group ")
+	d.treeGroups.SetFieldBackgroundColor(colorHighlight)
+	d.treeGroups.SetDropDownBackgroundColor(colorHighlight)
+	d.treeGroups.SetDropDownSelectedTextColor(colorDefault)
+	d.treeGroups.SetDropDownTextColor(colorDefault)
+
 	// sidebar
 	// TODO refac to a tree component
 	d.clientList = cview.NewList()
@@ -370,6 +378,12 @@ func (d *Debugger) initToolbar() {
 			{id: toolFilterHealthcheck, label: "health tx", active: func() bool {
 				return d.Mach.Not1(ss.FilterHealthcheck)
 			}},
+			{id: toolFilterOutGroup, label: "group", active: func() bool {
+				return d.Mach.Is1(ss.FilterOutGroup)
+			}},
+			{id: toolFilterChecks, label: "checks", active: func() bool {
+				return d.Mach.Not1(ss.FilterChecks)
+			}},
 			{id: ToolFilterSummaries, label: "times", active: func() bool {
 				return d.Mach.Not1(ss.FilterSummaries)
 			}},
@@ -398,9 +412,9 @@ func (d *Debugger) initToolbar() {
 			{
 				id:    toolExpand,
 				label: "expand", active: func() bool {
-					ch := d.treeRoot.GetChildren()
-					return len(ch) > 0 && ch[0].IsExpanded()
-				},
+				ch := d.treeRoot.GetChildren()
+				return len(ch) > 0 && ch[0].IsExpanded()
+			},
 			},
 			{id: toolTimelines, label: "timelines", active: func() bool {
 				return d.Opts.Timelines > 0
@@ -611,7 +625,13 @@ func (d *Debugger) updateHelpDialog() {
 		strconv.Itoa(mem)+"mb"))
 }
 
-func (d *Debugger) initLayout() {
+func (d *Debugger) hInitLayout() {
+	// tree schema
+	d.treeLayout = cview.NewFlex()
+	d.treeLayout.SetDirection(cview.FlexRow)
+	d.treeLayout.AddItem(d.treeGroups, 1, 1, false)
+	d.treeLayout.AddItem(d.tree, 0, 1, false)
+
 	// transition rows
 	d.currTxBar = cview.NewFlex()
 	d.currTxBar.AddItem(d.currTxBarLeft, 0, 1, false)


### PR DESCRIPTION
The new "Can methods" have their dedicated filter in the debugger.

State groups are now first-class citizens in the debugger, making working with large schemas WAY easier. Support has been added across the whole app:

- schema tree
- timeline
- log
- diagrams
- rain
- matrix
<img width="360" height="397" alt="ss-2025-08-17-14-32-54" src="https://github.com/user-attachments/assets/7fcf1ef7-e752-4552-8ccb-b3e8fabda182" />
