### PR TITLE
feat(am-dbg): add log pane hiding

### DIFF
--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -96,7 +96,7 @@ type Debugger struct {
 	exportDialog       *cview.Modal
 	contentPanels      *cview.Panels
 	toolbars           [3]*cview.Table
-	treeLogGrid        *cview.Grid
+	schemaLogGrid      *cview.Grid
 	treeMatrixGrid     *cview.Grid
 	lastSelectedState  string
 	// TODO should be after a redraw, not before

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -622,11 +622,12 @@ func (d *Debugger) initLayout() {
 	d.nextTxBar.AddItem(d.nextTxBarRight, 0, 1, false)
 
 	// content grid
-	d.treeLogGrid = cview.NewGrid()
-	d.treeLogGrid.SetRows(-1)
-	d.treeLogGrid.SetColumns( /*tree*/ -1, -1 /*log*/, -1, -1, -1, -1)
-	d.treeLogGrid.AddItem(d.tree, 0, 0, 1, 2, 0, 0, false)
-	d.treeLogGrid.AddItem(d.log, 0, 2, 1, 4, 0, 0, false)
+	d.schemaLogGrid = cview.NewGrid()
+	d.schemaLogGrid.SetRows(-1)
+	// TODO use hUpdateSchemaLogGrid()
+	d.schemaLogGrid.SetColumns( /*tree*/ -1, -1 /*log*/, -1, -1, -1, -1)
+	d.schemaLogGrid.AddItem(d.treeLayout, 0, 0, 1, 2, 0, 0, false)
+	d.schemaLogGrid.AddItem(d.log, 0, 2, 1, 4, 0, 0, false)
 
 	d.treeMatrixGrid = cview.NewGrid()
 	d.treeMatrixGrid.SetRows(-1)
@@ -779,9 +780,47 @@ func (d *Debugger) checkNarrow() {
 	}
 }
 
-func (d *Debugger) expandStructPane() {
-	// keep in sync with initLayout()
-	d.treeLogGrid.UpdateItem(d.tree, 0, 0, 1, 3, 0, 0, false)
+func (d *Debugger) hUpdateSchemaLogGrid() {
+	lvl := d.Opts.Filters.LogLevel
+
+	d.schemaLogGrid.RemoveItem(d.log)
+	d.schemaLogGrid.RemoveItem(d.logReader)
+	d.schemaLogGrid.RemoveItem(d.matrix)
+	d.schemaLogGrid.SetColumns( /*tree*/ -1, -1 /*log*/, -1, -1, -1, -1)
+
+	showLog := lvl > am.LogNothing
+	showReader := d.Mach.Is1(ss.LogReaderVisible)
+	stepping := d.Mach.Any1(ss.TimelineStepsScrolled, ss.TimelineStepsFocused)
+	showMatrix := d.Mach.Is1(ss.TreeMatrixView)
+
+	// TODO flexbox...
+	switch {
+
+	// log
+
+	case showLog && showReader && stepping:
+		d.schemaLogGrid.UpdateItem(d.treeLayout, 0, 0, 1, 3, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.log, 0, 3, 1, 2, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.logReader, 0, 5, 1, 1, 0, 0, false)
+
+	case showLog && showReader:
+		d.schemaLogGrid.UpdateItem(d.treeLayout, 0, 0, 1, 2, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.log, 0, 2, 1, 2, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.logReader, 0, 4, 1, 2, 0, 0, false)
+
+	case showLog && !showReader:
+		d.schemaLogGrid.UpdateItem(d.treeLayout, 0, 0, 1, 2, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.log, 0, 2, 1, 4, 0, 0, false)
+
+	case !showLog && showReader:
+		d.schemaLogGrid.UpdateItem(d.treeLayout, 0, 0, 1, 3, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.logReader, 0, 3, 1, 3, 0, 0, false)
+
+	// matrix
+
+	case showMatrix && stepping:
+		d.schemaLogGrid.UpdateItem(d.treeLayout, 0, 0, 1, 3, 0, 0, false)
+		d.schemaLogGrid.AddItem(d.matrix, 0, 3, 1, 3, 0, 0, false)
 
 	if d.Mach.Is1(ss.LogReaderVisible) {
 		d.treeLogGrid.UpdateItem(d.log, 0, 3, 1, 2, 0, 0, false)


### PR DESCRIPTION
The log view is now fully optional, which makes the debugger fit into a sidebar. The reader pane can be opened without the log (although it still relies on `LogOps` to be send over telemetry). 

All the views below show the same transition:

<img width="787" height="1063" alt="ss-2025-08-17-14-32-36" src="https://github.com/user-attachments/assets/27100d59-fa80-4b02-81ef-6830ca0a75db" />
<img width="776" height="1048" alt="ss-2025-08-17-14-32-24" src="https://github.com/user-attachments/assets/0440c4b5-df2e-4f57-a2b3-3c88f704762c" />
<img width="1159" height="1022" alt="ss-2025-08-17-14-32-07" src="https://github.com/user-attachments/assets/703e9e18-ebae-4add-bd7a-a87f66807787" />
<img width="1146" height="999" alt="ss-2025-08-17-14-31-52" src="https://github.com/user-attachments/assets/a5e28f75-754f-4b21-8970-2e1adf0ff559" />
<img width="1127" height="995" alt="ss-2025-08-17-14-31-23" src="https://github.com/user-attachments/assets/8500a8c2-33ef-4d5b-8f1e-2bd36862297b" />
