### PR TITLE
feat(machine): add CheckDone to Can methods

### DIFF
--- a/pkg/helpers/help.go
+++ b/pkg/helpers/help.go
@@ -1477,9 +1477,23 @@ func EvalGetter[T any](
 
 // TODO ChanGetter
 
-// CantAdd will confirm that the mutation is impossible.
+// ///// ///// /////
+
+// ///// CAN
+
+// ///// ///// /////
+
+// CantAdd will confirm that the mutation is impossible. Blocks.
 func CantAdd(mach am.Api, states am.S, args am.A) bool {
-	return mach.CanAdd(states, args) == am.Canceled
+	done := &am.CheckDone{
+		Ch: make(chan struct{}),
+	}
+	mach.CanAdd(states, am.PassMerge(args, &am.AT{
+		CheckDone: done,
+	}))
+	<-done.Ch
+
+	return !done.Canceled
 }
 
 // CantAdd1 is a single-state version of [CantAdd].
@@ -1487,9 +1501,17 @@ func CantAdd1(mach am.Api, state string, args am.A) bool {
 	return mach.CanAdd(am.S{state}, args) == am.Canceled
 }
 
-// CantRemove will confirm that the mutation is impossible.
+// CantRemove will confirm that the mutation is impossible. Blocks.
 func CantRemove(mach am.Api, states am.S, args am.A) bool {
-	return mach.CanRemove(states, args) == am.Canceled
+	done := &am.CheckDone{
+		Ch: make(chan struct{}),
+	}
+	mach.CanRemove(states, am.PassMerge(args, &am.AT{
+		CheckDone: done,
+	}))
+	<-done.Ch
+
+	return done.Canceled
 }
 
 // CantRemove1 is a single-state version of [CantRemove].
@@ -1499,15 +1521,15 @@ func CantRemove1(mach am.Api, state string, args am.A) bool {
 
 // AskAdd will first check if a mutation isn't impossible and only then try
 // to mutate the state machine. Causes the negotiation phase to execute twice.
-// Useful to avoid canceled transitions.
+// AskAdd BLOCKS. Useful to avoid canceled transitions.
 //
 // See also [am.Machine.CanAdd] and [CantAdd].
 func AskAdd(mach am.Api, states am.S, args am.A) am.Result {
-	return EvAskAdd(nil, mach, states, args)
+	return AskEvAdd(nil, mach, states, args)
 }
 
-// EvAskAdd is a traced version of [AskAdd].
-func EvAskAdd(e *am.Event, mach am.Api, states am.S, args am.A) am.Result {
+// AskEvAdd is a traced version of [AskAdd].
+func AskEvAdd(e *am.Event, mach am.Api, states am.S, args am.A) am.Result {
 	// only if not impossible
 	if !CantAdd(mach, states, args) {
 		return mach.EvAdd(e, states, args)
@@ -1521,22 +1543,22 @@ func AskAdd1(mach am.Api, state string, args am.A) am.Result {
 	return AskAdd(mach, S{state}, args)
 }
 
-// EvAskAdd1 is a traced version of [AskAdd] for a single state.
-func EvAskAdd1(e *am.Event, mach am.Api, state string, args am.A) am.Result {
-	return EvAskAdd(e, mach, S{state}, args)
+// AskEvAdd1 is a traced version of [AskAdd] for a single state.
+func AskEvAdd1(e *am.Event, mach am.Api, state string, args am.A) am.Result {
+	return AskEvAdd(e, mach, S{state}, args)
 }
 
 // AskRemove will first check if a mutation isn't impossible and only then try
 // to mutate the state machine. Causes the negotiation phase to execute twice.
-// Useful to avoid canceled transitions.
+// AskRemove BLOCKS. Useful to avoid canceled transitions.
 //
 // See also [am.Machine.CanRemove] and [CantRemove].
 func AskRemove(mach am.Api, states am.S, args am.A) am.Result {
-	return EvAskRemove(nil, mach, states, args)
+	return AskEvRemove(nil, mach, states, args)
 }
 
-// EvAskRemove is a traced version of [AskRemove].
-func EvAskRemove(e *am.Event, mach am.Api, states am.S, args am.A) am.Result {
+// AskEvRemove is a traced version of [AskRemove].
+func AskEvRemove(e *am.Event, mach am.Api, states am.S, args am.A) am.Result {
 	// only if not impossible
 	if !CantRemove(mach, states, args) {
 		return mach.EvRemove(e, states, args)
@@ -1550,7 +1572,7 @@ func AskRemove1(mach am.Api, state string, args am.A) am.Result {
 	return AskRemove(mach, S{state}, args)
 }
 
-// EvAskRemove1 is a traced version of [AskRemove] for a single state.
-func EvAskRemove1(e *am.Event, mach am.Api, state string, args am.A) am.Result {
-	return EvAskRemove(e, mach, S{state}, args)
+// AskEvRemove1 is a traced version of [AskRemove] for a single state.
+func AskEvRemove1(e *am.Event, mach am.Api, state string, args am.A) am.Result {
+	return AskEvRemove(e, mach, S{state}, args)
 }

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -410,6 +410,8 @@ func (m *Machine) doDispose(force bool) {
 		closeSafe(m.handlerStart)
 	}()
 
+	// TODO close all the When chans
+
 	if m.handlerTimer != nil {
 		m.handlerTimer.Stop()
 		// m.handlerTimer = nil
@@ -420,6 +422,8 @@ func (m *Machine) doDispose(force bool) {
 		m.unlockDisposed.Store(false)
 		m.queueProcessing.Store(false)
 	}
+
+	// TODO close all the CheckDone chans in the queue
 
 	// run doDispose handlers
 	// TODO timeouts?
@@ -1945,8 +1949,15 @@ func (m *Machine) processQueue() Result {
 		ret = append(ret, t.emitEvents())
 		m.timeLast.Store(&t.TimeAfter)
 
-		if t.IsAccepted.Load() && !t.Mutation.IsCheck {
-			// process flow methods
+		// parse wait chans
+		if t.Mutation.IsCheck {
+			// TODO test case
+			if done, ok := mut.Args[argCheckDone].(*CheckDone); ok {
+				done.Canceled = t.IsAccepted.Load()
+				close(done.Ch)
+			}
+
+		} else if t.IsAccepted.Load() && !t.Mutation.IsCheck {
 			m.processWhenBindings(t)
 			m.processWhenTimeBindings(t)
 			m.processStateCtxBindings(t)


### PR DESCRIPTION
`Can*` methods now return over a channel, which makes them compatible with the queue.

```go
done := &am.CheckDone{
    Ch: make(chan struct{}),
}
mach.CanAdd(states,  &am.AT{
    CheckDone: done,
})
<-done.Ch
```