### PR TITLE
feat(machine): add strict breakpoints

### DIFF
--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -314,6 +314,12 @@ type Api interface {
 	IsDisposed() bool
 }
 
+type breakpoint struct {
+	Added   S
+	Removed S
+	Strict  bool
+}
+
 // ///// ///// /////
 
 // ///// ENUMS


### PR DESCRIPTION
Breakpoints now support the queue and empty transitions with the `strict` param.