### PR TITLE
feat(machine): add QueueTick, WhenQueue

### DIFF
--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -102,6 +102,12 @@ func IsActiveTick(tick uint64) bool {
 	return tick%2 == 1
 }
 
+// IsQueued returns true if the mutation has been queued, and the result
+// represents the queue time it will be processed.
+func IsQueued(result Result) bool {
+	return result > Canceled
+}
+
 // SAdd concatenates multiple state lists into one, removing duplicates.
 // Useful for merging lists of states, eg a state group with other states
 // involved in a relation.


### PR DESCRIPTION
The highlight of `v0.15` - counted queue ticks for most of the transitions, which allow for waiting until the execution happens, independently of the negotiation. Waiting is efficient as queue ticks are `uint64` and do not create a channel nor a goroutine.

Queue ticks "extend" the `Result` type and are returned by all the mutation methods, except for `PrependMut`.

```go
res := mach.Add1(state, args)
<-mach.WhenQueue(res):
if mach.Is1(state) {
    // executed
} else {
    // canceled
}
```