### PR TITLE
feat(machine): optimize ctx-based GC

### DIFF
--- a/pkg/helpers/help.go
+++ b/pkg/helpers/help.go
@@ -122,7 +122,7 @@ func Add1Block(
 // but at the moment it is not compatible with RPC. This method checks
 // expiration ctx and returns as [am.Canceled].
 func Add1Sync(
-	ctx context.Context, mach *am.Machine, state string, args am.A,
+	ctx context.Context, mach am.Api, state string, args am.A,
 ) am.Result {
 	res := mach.Add1(state, args)
 	switch res {
@@ -161,7 +161,6 @@ func Add1Async(
 	ctxWhen, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// TODO use WhenQueue
 	when := mach.WhenTicks(waitState, ticks, ctxWhen)
 	res := mach.Add1(addState, args)
 	if res == am.Canceled {

--- a/pkg/machine/misc_mach.go
+++ b/pkg/machine/misc_mach.go
@@ -687,6 +687,7 @@ type Tracer interface {
 }
 
 // NoOpTracer is a no-op implementation of Tracer, used for embedding.
+// TODO rename to TracerNoOp
 type NoOpTracer struct{}
 
 func (t *NoOpTracer) TransitionInit(transition *Transition)          {}
@@ -855,13 +856,13 @@ type WhenBinding struct {
 
 type WhenTimeBinding struct {
 	Ch chan struct{}
-	// map of completed to their index positions
+	// map of matched to their index positions
 	// TODO optimize indexes
 	Index map[string]int
-	// number of matches so far
+	// number of matches so far TODO len(Index) ?
 	Matched int
 	// number of total matches needed
-	Total int
+	Total int // TODO len(Times) ?
 	// optional Time to match for completed from Index
 	Times     Time
 	Completed StateIsActive
@@ -869,9 +870,10 @@ type WhenTimeBinding struct {
 }
 
 type WhenArgsBinding struct {
-	ch   chan struct{}
-	args A
-	ctx  context.Context
+	ch      chan struct{}
+	handler string
+	args    A
+	ctx     context.Context
 }
 
 type whenQueueEndsBinding struct {
@@ -884,7 +886,7 @@ type whenQueueBinding struct {
 	tick Result
 }
 
-// TODO optimize indexes
+// TODO optimize with indexes
 type StateIsActive map[string]bool
 
 // handler represents a single event consumer, synchronized by channels.
@@ -1047,4 +1049,10 @@ func (t *LastTxTracer) String() string {
 	}
 
 	return tx.String()
+}
+
+func newClosedChan() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }

--- a/pkg/machine/relations.go
+++ b/pkg/machine/relations.go
@@ -9,6 +9,7 @@ import (
 // RelationsResolver is an interface for parsing relations between states.
 // Not thread-safe.
 // TODO support custom relation types and additional state properties.
+// TODO refac Relations
 type RelationsResolver interface {
 	// TargetStates returns the target states after parsing the relations.
 	TargetStates(t *Transition, calledStates, index S) S
@@ -34,6 +35,7 @@ type RelationsResolver interface {
 // DefaultRelationsResolver is the default implementation of the
 // RelationsResolver with Add, Remove, Require and After. It can be overridden
 // using Opts.Resolver.
+// TODO refac RelationsDefault
 type DefaultRelationsResolver struct {
 	Machine      *Machine
 	Transition   *Transition

--- a/pkg/machine/subscriptions.go
+++ b/pkg/machine/subscriptions.go
@@ -1,0 +1,780 @@
+package machine
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+)
+
+type (
+	InternalLogFunc   func(level LogLevel, msg string, args ...any)
+	InternalCheckFunc func(states S) bool
+)
+
+// Subscriptions is an embed responsible for binding subscriptions,
+// managing their indexes, processing triggers, and garbage collection.
+type Subscriptions struct {
+	// Mx locks the subscription manager. TODO optimize?
+	Mx sync.Mutex
+
+	mach  Api
+	clock Clock
+	is    InternalCheckFunc
+	not   InternalCheckFunc
+	log   InternalLogFunc
+
+	stateCtx      IndexStateCtx
+	when          IndexWhen
+	whenCtx       map[context.Context][]*WhenBinding
+	whenTime      IndexWhenTime
+	whenTimeCtx   map[context.Context][]*WhenTimeBinding
+	whenArgs      IndexWhenArgs
+	whenArgsCtx   map[context.Context][]*WhenArgsBinding
+	whenQueueEnds []*whenQueueEndsBinding
+	whenQueue     []*whenQueueBinding
+}
+
+func NewSubscriptionManager(
+	mach Api, clock Clock, is, not InternalCheckFunc, log InternalLogFunc,
+) *Subscriptions {
+	return &Subscriptions{
+		mach:  mach,
+		clock: clock,
+		is:    is,
+		not:   not,
+		log:   log,
+
+		when:        IndexWhen{},
+		whenTime:    IndexWhenTime{},
+		whenArgs:    IndexWhenArgs{},
+		stateCtx:    IndexStateCtx{},
+		whenCtx:     map[context.Context][]*WhenBinding{},
+		whenTimeCtx: map[context.Context][]*WhenTimeBinding{},
+		whenArgsCtx: map[context.Context][]*WhenArgsBinding{},
+	}
+}
+
+// ///// ///// /////
+
+// ///// PROCESSING
+
+// ///// ///// /////
+
+// ProcessStateCtx collects all deactivated state contexts, and returns theirs
+// cancel funcs. Uses transition caches.
+func (sm *Subscriptions) ProcessStateCtx(deactivated S) []context.CancelFunc {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	var toCancel []context.CancelFunc
+	for _, s := range deactivated {
+		if _, ok := sm.stateCtx[s]; !ok {
+			continue
+		}
+
+		toCancel = append(toCancel, sm.stateCtx[s].Cancel)
+		sm.log(LogOps, "[ctx:match] %s", s)
+		delete(sm.stateCtx, s)
+	}
+
+	return toCancel
+}
+
+// ProcessWhen collects all the matched active state subscriptions, and
+// returns theirs channels.
+func (sm *Subscriptions) ProcessWhen(activated, deactivated S) []chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// collect ctx expirations
+	// TODO optimize by skipping
+	ret := sm.processWhenCtx()
+
+	// collect matched bindings
+	all := slices.Concat(activated, deactivated)
+	for _, s := range all {
+		for _, binding := range sm.when[s] {
+
+			if slices.Contains(activated, s) {
+
+				// state activated, check the index
+				if !binding.Negation {
+					// match for When(
+					if !binding.States[s] {
+						binding.Matched++
+					}
+				} else {
+					// match for WhenNot(
+					if !binding.States[s] {
+						binding.Matched--
+					}
+				}
+
+				// update index: mark as active
+				binding.States[s] = true
+			} else {
+
+				// state deactivated
+				if !binding.Negation {
+					// match for When(
+					if binding.States[s] {
+						binding.Matched--
+					}
+				} else {
+					// match for WhenNot(
+					if binding.States[s] {
+						binding.Matched++
+					}
+				}
+
+				// update index: mark as inactive
+				binding.States[s] = false
+			}
+
+			// if not all matched, ignore for now
+			expired := binding.Ctx != nil && binding.Ctx.Err() != nil
+			if binding.Matched < binding.Total && !expired {
+				continue
+			}
+
+			// completed - rm binding and collect ch
+			sm.gcWhenBinding(binding, true)
+			ret = append(ret, binding.Ch)
+		}
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) processWhenCtx() []chan struct{} {
+	var ret []chan struct{}
+
+	// find expired ctxs
+	for ctx, bindings := range sm.whenCtx {
+		if ctx.Err() == nil {
+			continue
+		}
+
+		// delete the ctx and all the bindings
+		delete(sm.whenCtx, ctx)
+		for _, binding := range bindings {
+			sm.gcWhenBinding(binding, false)
+		}
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) gcWhenBinding(binding *WhenBinding, gcCtx bool) {
+	// completed - close and delete indexes for all involved states
+	var names []string
+	for state := range binding.States {
+		// remove GC ctx
+		if binding.Ctx != nil && gcCtx {
+			sm.whenCtx[binding.Ctx] = slicesWithout(
+				sm.whenCtx[binding.Ctx], binding)
+
+			if len(sm.whenCtx[binding.Ctx]) == 0 {
+				delete(sm.whenCtx, binding.Ctx)
+			}
+		}
+
+		// delete state index
+		names = append(names, state)
+		if len(sm.when[state]) == 1 {
+			delete(sm.when, state)
+			continue
+		}
+
+		// delete with a lookup TODO optimize, GC later
+		sm.when[state] = slicesWithout(sm.when[state], binding)
+	}
+
+	// log TODO sem logger
+	if binding.Negation {
+		sm.log(LogOps, "[whenNot:match] %s", j(names))
+	} else {
+		sm.log(LogOps, "[when:match] %s", j(names))
+	}
+}
+
+// ProcessWhenTime collects all the time-based subscriptions, and
+// returns theirs channels.
+func (sm *Subscriptions) ProcessWhenTime(before Clock) []chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// collect ctx expirations
+	// TODO optimize by skipping
+	ret := sm.processWhenTimeCtx()
+
+	// collect all the ticked states
+	// TODO optimize?
+	allTicked := S{}
+	for state, t := range before {
+		// if changed, collect to check
+		if sm.clock[state] != t {
+			allTicked = append(allTicked, state)
+		}
+	}
+
+	// check all the bindings for all the ticked states
+	for _, s := range allTicked {
+		for _, binding := range sm.whenTime[s] {
+
+			// check if the requested time has passed
+			if !binding.Completed[s] &&
+				sm.clock[s] >= binding.Times[binding.Index[s]] {
+				binding.Matched++
+				// mark in the index as completed
+				binding.Completed[s] = true
+			}
+
+			// if not all matched, ignore for now
+			expired := binding.Ctx != nil && binding.Ctx.Err() != nil
+			if binding.Matched < binding.Total && !expired {
+				continue
+			}
+
+			// completed - rm binding and collect ch
+			sm.gcWhenTimeBinding(binding, true)
+			ret = append(ret, binding.Ch)
+		}
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) processWhenTimeCtx() []chan struct{} {
+	var ret []chan struct{}
+
+	// find expired ctxs
+	for ctx, bindings := range sm.whenTimeCtx {
+		if ctx.Err() == nil {
+			continue
+		}
+
+		// delete the ctx and all the bindings
+		delete(sm.whenTimeCtx, ctx)
+		for _, binding := range bindings {
+			sm.gcWhenTimeBinding(binding, false)
+		}
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) gcWhenTimeBinding(
+	binding *WhenTimeBinding, gcCtx bool,
+) {
+	// completed - close and delete indexes for all involved states
+	var names []string
+	for state := range binding.Index {
+		// remove GC ctx
+		if binding.Ctx != nil && gcCtx {
+			sm.whenTimeCtx[binding.Ctx] = slicesWithout(
+				sm.whenTimeCtx[binding.Ctx], binding)
+
+			if len(sm.whenTimeCtx[binding.Ctx]) == 0 {
+				delete(sm.whenTimeCtx, binding.Ctx)
+			}
+		}
+
+		// remove state index
+		names = append(names, state)
+		if len(sm.whenTime[state]) == 1 {
+			delete(sm.whenTime, state)
+			continue
+		}
+
+		// delete with a lookup
+		sm.whenTime[state] = slicesWithout(sm.whenTime[state], binding)
+	}
+
+	// log TODO sem logger
+	sm.log(LogOps, "[whenTime:match] %s %d", j(names), binding.Times)
+}
+
+// ProcessWhenArgs collects all the args-matching subscriptions, and
+// returns theirs channels.
+func (sm *Subscriptions) ProcessWhenArgs(e *Event) []chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// collect ctx expirations
+	// TODO optimize by skipping
+	ret := sm.processWhenArgsCtx()
+
+	// collect arg matches
+	for _, binding := range sm.whenArgs[e.Name] {
+		expired := binding.ctx != nil && binding.ctx.Err() != nil
+		// TODO better comparison
+		if !compareArgs(e.Args, binding.args) && !expired {
+			continue
+		}
+
+		// completed - rm binding and collect ch
+		sm.gcWhenArgsBinding(binding, true)
+		ret = append(ret, binding.ch)
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) processWhenArgsCtx() []chan struct{} {
+	var ret []chan struct{}
+
+	// find expired ctxs
+	for ctx, bindings := range sm.whenArgsCtx {
+		if ctx.Err() == nil {
+			continue
+		}
+
+		// delete the ctx and all the bindings
+		delete(sm.whenArgsCtx, ctx)
+		for _, binding := range bindings {
+			sm.gcWhenArgsBinding(binding, false)
+		}
+	}
+
+	return ret
+}
+
+func (sm *Subscriptions) gcWhenArgsBinding(
+	binding *WhenArgsBinding, gcCtx bool,
+) {
+	// remove GC ctx
+	if binding.ctx != nil && gcCtx {
+		sm.whenArgsCtx[binding.ctx] = slicesWithout(
+			sm.whenArgsCtx[binding.ctx], binding)
+
+		if len(sm.whenArgsCtx[binding.ctx]) == 0 {
+			delete(sm.whenArgsCtx, binding.ctx)
+		}
+	}
+
+	// GC
+	if len(sm.whenArgs[binding.handler]) == 1 {
+		delete(sm.whenArgs, binding.handler)
+	} else {
+		sm.whenArgs[binding.handler] = slicesWithout(
+			sm.whenArgs[binding.handler], binding)
+	}
+
+	// log TODO sem logger
+	argNames := jw(slices.Collect(maps.Keys(binding.args)), ",")
+	// FooState -> Foo
+	name, _ := strings.CutSuffix(binding.handler, SuffixState)
+	sm.log(LogOps, "[whenArgs:match] %s (%s)", name, argNames)
+}
+
+// ProcessWhenQueueEnds collects all queue-end subscriptions, and
+// returns theirs channels.
+func (sm *Subscriptions) ProcessWhenQueueEnds() []chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// collect chans
+	ret := make([]chan struct{}, len(sm.whenQueueEnds))
+	for i, binding := range sm.whenQueueEnds {
+		ret[i] = binding.ch
+	}
+
+	// clean up
+	sm.whenQueueEnds = nil
+
+	return ret
+}
+
+func (sm *Subscriptions) ProcessWhenQueue(queueTick uint64) []chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// collect
+	var toClose []chan struct{}
+	var toCloseIdx []int
+	for i, binding := range sm.whenQueue {
+		if uint64(binding.tick) > queueTick {
+			continue
+		}
+
+		// TODO sem logger
+		sm.log(LogOps, "[whenQueue:match] %d", binding.tick)
+		toClose = append(toClose, binding.ch)
+		toCloseIdx = append(toCloseIdx, i)
+	}
+
+	// GC
+	for _, idx := range toCloseIdx {
+		sm.whenQueue = slices.Delete(sm.whenQueue, idx, idx+1)
+	}
+
+	// close and execute waits
+	return toClose
+}
+
+// ///// ///// /////
+
+// ///// BINDING
+
+// ///// ///// /////
+
+// NewStateCtx returns a new sub-context, bound to the current clock's tick of
+// the passed state.
+//
+// Context cancels when the state has been deactivated, or right away,
+// if it isn't currently active.
+//
+// State contexts are used to check state expirations and should be checked
+// often inside goroutines.
+func (sm *Subscriptions) NewStateCtx(state string) context.Context {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	if _, ok := sm.stateCtx[state]; ok {
+		return sm.stateCtx[state].Ctx
+	}
+
+	// store a fingerprint
+	v := CtxValue{
+		Id:    sm.mach.Id(),
+		State: state,
+		Tick:  sm.clock[state],
+	}
+	stateCtx, cancel := context.WithCancel(context.WithValue(sm.mach.Ctx(),
+		CtxKey, v))
+
+	// cancel early
+	if !sm.is(S{state}) {
+		// TODO decision msg
+		cancel()
+		return stateCtx
+	}
+
+	binding := &CtxBinding{
+		Ctx:    stateCtx,
+		Cancel: cancel,
+	}
+
+	// add an index
+	sm.stateCtx[state] = binding
+	sm.log(LogOps, "[ctx:new] %s", state)
+
+	return stateCtx
+}
+
+func (sm *Subscriptions) When(states S, ctx context.Context) <-chan struct{} {
+	// TODO re-use channels with the same state set and context
+
+	// if all active, close early
+	if sm.is(states) {
+		return newClosedChan()
+	}
+
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	ch := make(chan struct{})
+
+	setMap := StateIsActive{}
+	matched := 0
+	for _, s := range states {
+		setMap[s] = sm.is(S{s})
+		if setMap[s] {
+			matched++
+		}
+	}
+
+	// add the binding to an index of each state
+	binding := &WhenBinding{
+		Ch:       ch,
+		Negation: false,
+		States:   setMap,
+		Total:    len(states),
+		Matched:  matched,
+		Ctx:      ctx,
+	}
+	sm.log(LogOps, "[when:new] %s", j(states))
+
+	// insert the binding
+	for _, s := range states {
+		sm.when[s] = append(sm.when[s], binding)
+
+		if ctx != nil {
+			sm.whenCtx[ctx] = append(sm.whenCtx[ctx], binding)
+		}
+	}
+
+	return ch
+}
+
+// WhenNot returns a channel that will be closed when all the passed states
+// become inactive or the machine gets disposed.
+//
+// ctx: optional context that will close the channel early.
+func (sm *Subscriptions) WhenNot(
+	states S, ctx context.Context,
+) <-chan struct{} {
+	// if all inactive, close early
+	if sm.not(states) {
+		return newClosedChan()
+	}
+
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	ch := make(chan struct{})
+	setMap := StateIsActive{}
+	matched := 0
+	for _, s := range states {
+		setMap[s] = sm.is(S{s})
+		if !setMap[s] {
+			matched++
+		}
+	}
+
+	// add the binding to an index of each state
+	binding := &WhenBinding{
+		Ch:       ch,
+		Negation: true,
+		States:   setMap,
+		Total:    len(states),
+		Matched:  matched,
+		Ctx:      ctx,
+	}
+	sm.log(LogOps, "[whenNot:new] %s", j(states))
+
+	// insert the binding
+	for _, s := range states {
+		if _, ok := sm.when[s]; !ok {
+			sm.when[s] = []*WhenBinding{binding}
+		} else {
+			sm.when[s] = append(sm.when[s], binding)
+		}
+	}
+	if ctx != nil {
+		sm.whenCtx[ctx] = append(sm.whenCtx[ctx], binding)
+	}
+
+	return ch
+}
+
+// WhenArgs returns a channel that will be closed when the passed state
+// becomes active with all the passed args. Args are compared using the native
+// '=='. It's meant to be used with async Multi states, to filter out
+// a specific call.
+//
+// ctx: optional context that will close the channel when handler loop ends.
+func (sm *Subscriptions) WhenArgs(
+	state string, args A, ctx context.Context,
+) <-chan struct{} {
+	// TODO better val comparisons
+	//  support regexp for strings
+	// TODO support typed args
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	ch := make(chan struct{})
+	handler := state + SuffixState
+
+	// log TODO pass through logArgs?
+	argNames := jw(slices.Collect(maps.Keys(args)), ",")
+	sm.log(LogOps, "[whenArgs:new] %s (%s)", state, argNames)
+
+	// try to reuse an existing channel
+	for _, binding := range sm.whenArgs[handler] {
+		if compareArgs(binding.args, args) {
+			return binding.ch
+		}
+	}
+
+	binding := &WhenArgsBinding{
+		ch:      ch,
+		handler: handler,
+		args:    args,
+		ctx:     ctx,
+	}
+
+	// insert the binding
+	sm.whenArgs[handler] = append(sm.whenArgs[handler], binding)
+
+	if ctx != nil {
+		sm.whenArgsCtx[ctx] = append(sm.whenArgsCtx[ctx], binding)
+	}
+
+	return ch
+}
+
+// WhenTime returns a channel that will be closed when all the passed states
+// have passed the specified time. The time is a logical clock of the state.
+// Machine time can be sourced from [Machine.Time](), or [Machine.Clock]().
+//
+// ctx: optional context that will close the channel early.
+func (sm *Subscriptions) WhenTime(
+	states S, times Time, ctx context.Context,
+) <-chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	ch := make(chan struct{})
+	indexWhenTime := sm.whenTime
+
+	// if all times passed, close early
+	passed := true
+	for i, s := range states {
+		if sm.clock[s] < times[i] {
+			passed = false
+			break
+		}
+	}
+	if passed {
+		// TODO decision msg
+		close(ch)
+		return ch
+	}
+
+	completed := StateIsActive{}
+	matched := 0
+	index := map[string]int{}
+	for i, s := range states {
+		completed[s] = sm.clock[s] >= times[i]
+		if completed[s] {
+			matched++
+		}
+		index[s] = i
+	}
+
+	// add the binding to an index of each state
+	binding := &WhenTimeBinding{
+		Ch:        ch,
+		Index:     index,
+		Completed: completed,
+		Total:     len(states),
+		Matched:   matched,
+		Times:     times,
+		Ctx:       ctx,
+	}
+	sm.log(LogOps, "[whenTime:new] %s %s", jw(states, ","), times)
+
+	// insert the binding
+	for _, s := range states {
+		indexWhenTime[s] = append(indexWhenTime[s], binding)
+	}
+	if ctx != nil {
+		sm.whenTimeCtx[ctx] = append(sm.whenTimeCtx[ctx], binding)
+	}
+
+	return ch
+}
+
+// WhenQueueEnds closes every time the queue ends, or the optional ctx expires.
+// This function assumes the queue is running, and wont close early.
+//
+// ctx: optional context that will close the channel early.
+func (sm *Subscriptions) WhenQueueEnds(
+	ctx context.Context, mx *sync.RWMutex,
+) <-chan struct{} {
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// add the binding to an index of each state
+	ch := make(chan struct{})
+	binding := &whenQueueEndsBinding{
+		ch:  ch,
+		ctx: ctx,
+	}
+
+	// insert the binding
+	sm.whenQueueEnds = append(sm.whenQueueEnds, binding)
+
+	if ctx != nil {
+		// fork in this special case
+		go func() {
+			<-ctx.Done()
+			mx.Lock()
+			defer mx.Unlock()
+			sm.whenQueueEnds = slicesWithout(sm.whenQueueEnds, binding)
+			close(ch)
+		}()
+	}
+
+	return ch
+}
+
+// WhenQueue waits until the passed queueTick gets processed.
+func (sm *Subscriptions) WhenQueue(tick Result) <-chan struct{} {
+	// TODO add gc ctx? use cases?
+	// locks
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	// add the binding to an index of each state
+	ch := make(chan struct{})
+	binding := &whenQueueBinding{
+		ch:   ch,
+		tick: tick,
+	}
+	sm.log(LogOps, "[whenQueue:new] %d", tick)
+
+	// insert the binding
+	sm.whenQueue = append(sm.whenQueue, binding)
+
+	return ch
+}
+
+// ///// ///// /////
+
+// ///// MISC
+
+// ///// ///// /////
+
+func (sm *Subscriptions) HasWhenArgs() bool {
+	sm.Mx.Lock()
+	defer sm.Mx.Unlock()
+
+	return len(sm.whenArgs) > 0
+}
+
+func (sm *Subscriptions) dispose() {
+	// cancel ctx
+	for _, binding := range sm.stateCtx {
+		binding.Cancel()
+	}
+
+	// close channels
+	for state := range sm.when {
+		for _, binding := range sm.when[state] {
+			closeSafe(binding.Ch)
+		}
+	}
+	for state := range sm.whenTime {
+		for _, binding := range sm.whenTime[state] {
+			closeSafe(binding.Ch)
+		}
+	}
+	for state := range sm.whenArgs {
+		for _, binding := range sm.whenArgs[state] {
+			closeSafe(binding.ch)
+		}
+	}
+	for _, bind := range sm.whenQueueEnds {
+		closeSafe(bind.ch)
+	}
+	for _, bind := range sm.whenQueue {
+		closeSafe(bind.ch)
+	}
+}

--- a/pkg/machine/utils.go
+++ b/pkg/machine/utils.go
@@ -216,9 +216,10 @@ func SchemaMerge(schemas ...Schema) Schema {
 	// TODO test
 	// defaults
 	l := len(schemas)
-	if l == 0 {
+	switch l {
+	case 0:
 		return Schema{}
-	} else if l == 1 {
+	case 1:
 		return schemas[0]
 	}
 

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -34,7 +34,6 @@ import (
 	"golang.org/x/text/message"
 
 	"github.com/pancsta/asyncmachine-go/internal/utils"
-	"github.com/pancsta/asyncmachine-go/pkg/graph"
 	amgraph "github.com/pancsta/asyncmachine-go/pkg/graph"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
@@ -95,7 +94,7 @@ type Debugger struct {
 	// repaintPending indicates a skipped repaint
 	repaintPending atomic.Bool
 	genGraphsLast  time.Time
-	graph          *graph.Graph
+	graph          *amgraph.Graph
 	// update client list scheduled
 	updateCLScheduled atomic.Bool
 	buildCLScheduled  atomic.Bool
@@ -218,7 +217,7 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 		"err", "_am_err",
 	}, 20))
 
-	d.graph, err = graph.New(d.Mach)
+	d.graph, err = amgraph.New(d.Mach)
 	if err != nil {
 		mach.AddErr(fmt.Errorf("graph init: %w", err), nil)
 	}
@@ -668,7 +667,7 @@ func (d *Debugger) hImportData(filename string) {
 	var res []*Exportable
 	err = decoder.Decode(&res)
 	if err != nil {
-		d.Mach.AddErr(fmt.Errorf("Error: import failed %w", err), nil)
+		d.Mach.AddErr(fmt.Errorf("import failed %w", err), nil)
 		return
 	}
 
@@ -686,7 +685,7 @@ func (d *Debugger) hImportData(filename string) {
 		if d.graph != nil {
 			err := d.graph.AddClient(data.MsgStruct)
 			if err != nil {
-				d.Mach.AddErr(fmt.Errorf("Error: import failed %w", err), nil)
+				d.Mach.AddErr(fmt.Errorf("import failed %w", err), nil)
 				return
 			}
 		}
@@ -712,9 +711,10 @@ func (d *Debugger) hUpdateToolbar() {
 	// tx filters
 	for i, row := range d.toolbarItems {
 		focused := d.Mach.Is1(ss.Toolbar1Focused)
-		if i == 1 {
+		switch i {
+		case 1:
 			focused = d.Mach.Is1(ss.Toolbar2Focused)
-		} else if i == 2 {
+		case 2:
 			focused = d.Mach.Is1(ss.Toolbar3Focused)
 		}
 
@@ -1808,7 +1808,7 @@ func (d *Debugger) hGetParentTags(c *Client, tags []string) []string {
 }
 
 func (d *Debugger) initGraphGen(
-	snapshot *graph.Graph, id string, detailsLvl, numClients int, outDir,
+	snapshot *amgraph.Graph, id string, detailsLvl, numClients int, outDir,
 	svgName string, statesAllowlist S,
 ) []*amvis.Visualizer {
 	var vizs []*amvis.Visualizer

--- a/tools/debugger/handlers.go
+++ b/tools/debugger/handlers.go
@@ -569,7 +569,7 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 		if existing.connId != "" && existing.connId == connId {
 			d.Mach.Log("schema changed for %s", msg.ID)
 			// TODO use MsgStructPatch
-			existing.Exportable.MsgStruct = msg
+			existing.MsgStruct = msg
 			c = existing
 			c.parseSchema()
 
@@ -1564,7 +1564,7 @@ func (d *Debugger) GcMsgsState(e *am.Event) {
 			break
 		}
 		if round > 100 {
-			d.Mach.AddErr(errors.New("Too many GC rounds"), nil)
+			d.Mach.AddErr(errors.New("too many GC rounds"), nil)
 			break
 		}
 		d.Mach.Log("GC tx round %d", round)
@@ -1841,12 +1841,12 @@ func (d *Debugger) UpdateFocusState(e *am.Event) {
 	var box *cview.Box
 	// change focus (or not) when changing view types
 	switch d.Mach.Switch(ss.GroupFocused) {
-	case ss.AddressFocused:
-		focused = d.addressBar
-		box = d.addressBar.Box
 	default:
 		focused = d.clientList
 		box = d.clientList.Box
+	case ss.AddressFocused:
+		focused = d.addressBar
+		box = d.addressBar.Box
 	case ss.TreeFocused:
 		focused = d.tree
 		box = d.tree.Box

--- a/tools/debugger/log.go
+++ b/tools/debugger/log.go
@@ -1281,9 +1281,10 @@ func (d *Debugger) hUpdateLogReader(e *am.Event) {
 			if past.MutQueueTick > 0 {
 				after = after + " " + d.P.Sprintf("[gray]q%v", past.MutQueueTick)
 			}
-			if before == "+" {
+			switch before {
+			case "+":
 				before = " +"
-			} else if before == "-" {
+			case "-":
 				before = "- "
 			}
 			mutNode := cview.NewTreeNode("[::b]" + before + "[::-]" + after)

--- a/tools/repl/cli_repl.go
+++ b/tools/repl/cli_repl.go
@@ -299,8 +299,7 @@ func addrsFromDir(dirpath string) ([]string, error) {
 			if !d.IsDir() && strings.HasSuffix(path, ".addr") {
 				content, err := os.ReadFile(path)
 				if err != nil {
-					return fmt.Errorf(
-						"%s: %w\n", path, err)
+					return fmt.Errorf("%s: %w\n", path, err)
 				}
 				addrs = append(addrs, strings.TrimSpace(string(content)))
 			}


### PR DESCRIPTION
Closes https://github.com/pancsta/asyncmachine-go/issues/160.

- extract `Subscriptions`
- no goroutine per listener
- close channels on `Machine.Dispose()`

The only places where the machine was working a waiting goroutine were ctx-bound subscriptions. These are now are GCed during processing of the queue. This may cause some delays but won't flood the VM with goroutines.