### PR TITLE
feat(rpc): inherit Subscriptions from pkg/machine

### DIFF
--- a/pkg/pubsub/topic.go
+++ b/pkg/pubsub/topic.go
@@ -802,7 +802,7 @@ func (t *Topic) MsgInfoState(e *am.Event) {
 			if w, ok := t.workers[peerId][machIdx]; ok {
 				// update to the newest clock
 				if info.MTime.Sum() > w.TimeSum(nil) {
-					w.InternalUpdateClock(info.MTime, true)
+					w.InternalUpdateClock(info.MTime, 0, true)
 				}
 				// TODO check schema?
 				continue
@@ -836,7 +836,7 @@ func (t *Topic) MsgInfoState(e *am.Event) {
 			// check for ahead-of-time MsgUpdates
 			// add ctx to go-s
 			if mtime, ok := t.pendingMachUpdates[peerId][machIdx]; ok {
-				worker.InternalUpdateClock(mtime, true)
+				worker.InternalUpdateClock(mtime, 0, true)
 				// GC
 				delete(t.pendingMachUpdates[peerId], machIdx)
 				if len(t.pendingMachUpdates[peerId]) == 0 {
@@ -845,7 +845,7 @@ func (t *Topic) MsgInfoState(e *am.Event) {
 				t.Mach.EvRemove1(e, ss.MissPeersByUpdates, nil)
 
 			} else {
-				worker.InternalUpdateClock(info.MTime, true)
+				worker.InternalUpdateClock(info.MTime, 0, true)
 			}
 
 			t.workers[peerId][machIdx] = worker
@@ -1176,7 +1176,7 @@ func (t *Topic) MsgUpdatesState(e *am.Event) {
 
 			// skip old updates
 			if mtime.Sum() > w.TimeSum(nil) {
-				w.InternalUpdateClock(mtime, true)
+				w.InternalUpdateClock(mtime, 0, true)
 			}
 
 			// clean up

--- a/pkg/rpc/README.md
+++ b/pkg/rpc/README.md
@@ -333,8 +333,8 @@ type Api interface {
     Remove(states S, args A) Result
     AddErr(err error, args A) Result
     AddErrState(state string, err error, args A) Result
-	Toggle(states S, args A) Result
-	Toggle1(state string, args A) Result
+    Toggle(states S, args A) Result
+    Toggle1(state string, args A) Result
     Set(states S, args A) Result
 
     // Traced mutations (remote)
@@ -345,8 +345,8 @@ type Api interface {
     EvRemove(event *Event, states S, args A) Result
     EvAddErr(event *Event, err error, args A) Result
     EvAddErrState(event *Event, state string, err error, args A) Result
-	EvToggle(event *Event, states S, args A) Result
-	EvToggle1(event *Event, state string, args A) Result
+    EvToggle(event *Event, states S, args A) Result
+    EvToggle1(event *Event, state string, args A) Result
 
     // Waiting (remote)
 
@@ -427,7 +427,7 @@ type Api interface {
     Tracers() []Tracer
     DetachTracer(tracer Tracer) error
     BindTracer(tracer Tracer) error
-	AddBreakpoint1(added string, removed string, strict bool)
+    AddBreakpoint1(added string, removed string, strict bool)
     AddBreakpoint(added S, removed S, strict bool)
     Dispose()
     WhenDisposed() <-chan struct{}

--- a/pkg/rpc/rpc_server.go
+++ b/pkg/rpc/rpc_server.go
@@ -509,9 +509,7 @@ func (s *Server) genClockUpdate(skipTimeCheck bool) *ClockMsg {
 	for _, v := range mTime {
 		tSum += v
 	}
-	// update only on state change, ignoring queue ticks (for canceled and empty)
-	// TODO support queuetick-only updates (always 1 off)
-	// if tSum == s.lastClockSum.Load() && qTick == s.lastQueueTick {
+	// update on a state change and queue tick change
 	if tSum == s.lastClockSum.Load() && qTick == s.lastQueueTick {
 		s.log("genClockUpdate: no change t%d q%d", tSum, qTick)
 		return nil
@@ -538,7 +536,6 @@ func (s *Server) genClockUpdate(skipTimeCheck bool) *ClockMsg {
 func (s *Server) RemoteHello(
 	client *rpc2.Client, req *ArgsHello, resp *RespHandshake,
 ) error {
-
 	if s.Mach.Not1(ssS.Start) {
 		return am.ErrCanceled
 	}


### PR DESCRIPTION
RPC worker now directly inherits `Subscriptions` from `pkg/machine` which reduces redundant code. More methods should follow this path, if possible.
