### PR TITLE
feat: add WhenQuery for time queries

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -573,6 +573,28 @@ func (m *Machine) WhenTicks(
 	return m.WhenTime(S{state}, Time{uint64(ticks) + m.Tick(state)}, ctx)
 }
 
+// WhenQuery returns a channel that will be closed when the passed [clockCheck]
+// function returns true. [clockCheck] should be a pure function and
+// non-blocking.`
+//
+// ctx: optional context that will close the channel early.
+func (m *Machine) WhenQuery(
+	clockCheck func(clock Clock) bool, ctx context.Context,
+) <-chan struct{} {
+	// TODO test case
+	// TODO add to Api
+
+	if m.disposed.Load() {
+		return newClosedChan()
+	}
+
+	// locks
+	m.activeStatesMx.Lock()
+	defer m.activeStatesMx.Unlock()
+
+	return m.subs.WhenQuery(clockCheck, ctx)
+}
+
 // WhenQueueEnds closes every time the queue ends, or the optional ctx expires.
 //
 // ctx: optional context that will close the channel early.
@@ -1961,6 +1983,7 @@ func (m *Machine) processSubscriptions(t *Transition) {
 		m.subs.ProcessWhen(t.cacheActivated, t.cacheDeactivated),
 		m.subs.ProcessWhenTime(t.ClockBefore()),
 		m.subs.ProcessWhenQueue(m.queueTick),
+		m.subs.ProcessWhenQuery(),
 	)
 
 	// unlock

--- a/pkg/rpc/rpc_worker.go
+++ b/pkg/rpc/rpc_worker.go
@@ -756,7 +756,21 @@ func (w *Worker) WhenTicks(
 	return w.WhenTime(am.S{state}, am.Time{uint64(ticks) + w.Tick(state)}, ctx)
 }
 
-// WhenQueue waits until the passed queueTick gets processed.
+// WhenQuery returns a channel that will be closed when the passed [clockCheck]
+// function returns true. [clockCheck] should be a pure function and
+// non-blocking.`
+//
+// ctx: optional context that will close the channel early.
+func (w *Worker) WhenQuery(
+	clockCheck func(clock am.Clock) bool, ctx context.Context,
+) <-chan struct{} {
+	// locks
+	w.clockMx.Lock()
+	defer w.clockMx.Unlock()
+
+	return w.subs.WhenQuery(clockCheck, ctx)
+}
+
 func (w *Worker) WhenQueue(tick am.Result) <-chan struct{} {
 	// locks
 	w.clockMx.Lock()


### PR DESCRIPTION
Time queries assert the current machine time matches a simple function, useful for eg state proportions. The RPC compat is also implemented.

```go
mach.WhenQuery(func(c am.Clock) bool {
    return c["A"] / 2 > c["B"]
}, nil)
```