### PR TITLE
feat(machine): add new Time methods

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -699,33 +699,6 @@ func (m *Machine) time(states S) Time {
 	return ret
 }
 
-// TimeSum returns the sum of machine's time (ticks per state).
-// Returned value includes the specified states, or all the states if nil.
-// It's a very inaccurate, yet simple way to measure the machine's
-// time.
-func (m *Machine) TimeSum(states S) uint64 {
-	// TODO handle overflow
-
-	if m.disposed.Load() {
-		return 0
-	}
-	m.activeStatesMx.RLock()
-	defer m.activeStatesMx.RUnlock()
-	m.schemaLock.RLock()
-	defer m.schemaLock.RUnlock()
-
-	if states == nil {
-		states = m.stateNames
-	}
-
-	ret := uint64(0)
-	for _, s := range states {
-		ret += m.clock[s]
-	}
-
-	return ret
-}
-
 // PrependMut prepends the mutation to the front of the queue. This is a special
 // cases only method and should be used with caution, as it can create an
 // infinite loop. It's useful for postponing mutations inside a negotiation
@@ -1232,7 +1205,7 @@ func (m *Machine) queueMutation(
 			TxId:   event.TransitionId,
 		}
 		if tx != nil {
-			source.MachTime = tx.TimeBefore.Sum()
+			source.MachTime = tx.TimeBefore.Sum(nil)
 		}
 	}
 	mut := &Mutation{
@@ -3074,7 +3047,7 @@ func (m *Machine) Export() *Serialized {
 	}
 
 	t := m.time(nil)
-	m.log(LogOps, "[import] exported at %d ticks", t.Sum())
+	m.log(LogOps, "[import] exported at %d ticks", t.Sum(nil))
 
 	return &Serialized{
 		ID:         m.id,

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -1915,9 +1915,9 @@ func TestTime(t *testing.T) {
 	// assert
 	assertStates(t, m, S{"A", "B", "D", "C"})
 	assertTime(t, m, S{"A", "B", "C", "D"}, Time{3, 7, 5, 1})
-	assert.True(t, IsTimeAfter(now, before))
-	assert.False(t, IsTimeAfter(before, now))
-	assert.Equal(t, 16, int(m.TimeSum(nil)))
+	assert.True(t, now.After(true, before))
+	assert.False(t, before.After(true, now))
+	assert.Equal(t, 16, int(m.Time(nil).Sum(nil)))
 
 	// dispose
 	m.Dispose()
@@ -3016,8 +3016,8 @@ func TestDisposedNoOp(t *testing.T) {
 	assert.Equal(t, Canceled, res)
 
 	// others
-	assert.Equal(t, int16(-1), m.IsQueued(MutationAdd, s, false, false, 0, false,
-		PositionAny))
+	_, found := m.IsQueued(MutationAdd, s, false, false, 0, false, PositionAny)
+	assert.False(t, found)
 	assert.Equal(t, -1, m.Index1("A"))
 	assert.Empty(t, m.Has1("A"))
 	assert.Empty(t, m.IsClock(Clock{}))
@@ -3025,7 +3025,7 @@ func TestDisposedNoOp(t *testing.T) {
 	assert.Empty(t, m.String())
 	assert.Empty(t, m.Time(nil))
 	assert.Empty(t, m.time(nil))
-	assert.Empty(t, m.TimeSum(nil))
+	assert.Empty(t, m.Time(nil).Sum(nil))
 	assert.Empty(t, m.Tick("A"))
 	assert.Empty(t, m.StringAll())
 	assert.Empty(t, m.Inspect(nil))


### PR DESCRIPTION
- `Time.After`, `Time.Before`, `Time.Equal`
- `Time.NonZeroStates`, `Time.ToIndex`
- `Time.ActiveStates`, `Time.Filter`

Time APIs (`Time` and `TimeIndex`) have been streamlined and are now more composable.

```go
mach.Time(nil).Sum(S{"Foo", "Bar"})
mach.Time(nil).ToIndex(mach.Index(nil).ActiveStates(S{"Foo", "Bar"})
```