### PR TITLE
refac(machine): limit queue len to `uint16`

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -26,7 +26,7 @@ var _ Api = &Machine{}
 // mutations to execute.
 type Machine struct {
 	// Maximum number of mutations that can be queued. Default: 1000.
-	QueueLimit int
+	QueueLimit uint16
 	// HandlerTimeout defined the time for a handler to execute before it causes
 	// StateException. Default: 1s. See also Opts.HandlerTimeout.
 	// Using HandlerTimeout can cause race conditions, see Event.IsValid().
@@ -101,8 +101,9 @@ type Machine struct {
 	queueToken        atomic.Uint64
 	queueMx           sync.RWMutex
 	queueProcessing   atomic.Bool
-	// total len of the queue (ticking and prepended0
-	queueLen atomic.Int32
+	// total len of the queue, both appended (with queue ticks) and prepended.
+	// TODO should be uint16
+	queueLen atomic.Uint32
 	// length of the ticking mutations
 	// Relation resolver, used to produce target schema of a transition.
 	// Default: *DefaultRelationsResolver.
@@ -747,7 +748,7 @@ func (m *Machine) PrependMut(mut *Mutation) Result {
 	}
 	m.queue = append([]*Mutation{mut}, m.queue...)
 	lenQ := len(m.queue)
-	m.queueLen.Store(int32(lenQ))
+	m.queueLen.Store(uint32(lenQ))
 	if !isEval {
 		mut.QueueLen = int32(lenQ)
 		mut.QueueToken = m.queueToken.Add(1)
@@ -778,7 +779,7 @@ func (m *Machine) Add(states S, args A) Result {
 	}
 
 	// let Exception in even with a full queue, but only once
-	if int(m.queueLen.Load()) >= m.QueueLimit {
+	if uint16(m.queueLen.Load()) >= m.QueueLimit {
 		if !slices.Contains(states, StateException) || m.IsErr() {
 			return Canceled
 		}
@@ -995,7 +996,7 @@ func (m *Machine) Remove(states S, args A) Result {
 	}
 
 	// let Exception in even with a full queue, but only once
-	if int(m.queueLen.Load()) >= m.QueueLimit {
+	if uint16(m.queueLen.Load()) >= m.QueueLimit {
 		if !slices.Contains(states, StateException) || !m.IsErr() {
 			return Canceled
 		}
@@ -1041,7 +1042,7 @@ func (m *Machine) Remove1(state string, args A) Result {
 // the transition (Executed, Queued, Canceled).
 // Like every mutation method, it will resolve relations and trigger handlers.
 func (m *Machine) Set(states S, args A) Result {
-	if m.disposed.Load() || int(m.queueLen.Load()) >= m.QueueLimit {
+	if m.disposed.Load() || uint16(m.queueLen.Load()) >= m.QueueLimit {
 		return Canceled
 	}
 	queueTick := m.queueMutation(MutationSet, states, args, nil)
@@ -2423,7 +2424,7 @@ func (m *Machine) Tick(state string) uint64 {
 }
 
 // IsQueued checks if a particular mutation has been queued. Returns
-// an index of the match or -1 if not found.
+// an index (idx, true), or (0, false), if not found.
 //
 // mutType: add, remove, set
 //
@@ -2440,22 +2441,22 @@ func (m *Machine) Tick(state string) uint64 {
 //
 // position: position in the queue, after applying the [startIndex]
 func (m *Machine) IsQueued(mutType MutationType, states S,
-	withoutArgsOnly bool, statesStrictEqual bool, startIndex int16, isCheck bool,
+	withoutArgsOnly bool, statesStrictEqual bool, startIndex uint16, isCheck bool,
 	position Position,
-) int16 {
+) (uint16, bool) {
 	// TODO add QueueQuery with all the params
 	// TODO test case
 
 	if m.disposed.Load() {
-		return -1
+		return 0, false
 	}
 	m.queueMx.RLock()
 	defer m.queueMx.RUnlock()
 
 	// start index
-	qLen := int16(m.queueLen.Load())
+	qLen := uint16(m.queueLen.Load())
 	if qLen == 0 || qLen-startIndex < 1 {
-		return -1
+		return 0, false
 	}
 	iter := m.queue[startIndex:]
 
@@ -2480,16 +2481,16 @@ func (m *Machine) IsQueued(mutType MutationType, states S,
 			// and all the checked ones have to be included in the target ones
 			slicesEvery(mut.Called, m.Index(states)) {
 
-			return int16(i)
+			return uint16(i), true
 		}
 	}
 
-	return -1
+	return 0, false
 }
 
 // IsQueuedAbove allows for rate-limiting of mutations for a specific state.
 func (m *Machine) IsQueuedAbove(threshold int, mutationType MutationType,
-	states S, withoutArgsOnly bool, statesStrictEqual bool, startIndex int,
+	states S, withoutArgsOnly bool, statesStrictEqual bool, startIndex uint16,
 ) bool {
 	if m.disposed.Load() {
 		return false
@@ -2501,7 +2502,7 @@ func (m *Machine) IsQueuedAbove(threshold int, mutationType MutationType,
 	c := 0
 
 	for i, item := range m.queue {
-		if i >= startIndex &&
+		if uint16(i) >= startIndex &&
 			item.Type == mutationType &&
 			((withoutArgsOnly && len(item.Args) == 0) || !withoutArgsOnly) &&
 			// target states have to be at least as long as the checked ones
@@ -2523,8 +2524,8 @@ func (m *Machine) IsQueuedAbove(threshold int, mutationType MutationType,
 	return false
 }
 
-func (m *Machine) QueueLen() int {
-	return int(m.queueLen.Load())
+func (m *Machine) QueueLen() uint16 {
+	return uint16(m.queueLen.Load())
 }
 
 // WillBe returns true if the passed states are scheduled to be activated.
@@ -2538,14 +2539,15 @@ func (m *Machine) WillBe(states S, position ...Position) bool {
 	if len(position) == 0 {
 		position = []Position{PositionAny}
 	}
-	idx := m.IsQueued(MutationAdd, states, false, false, 0, false, position[0])
+	idx, found := m.IsQueued(MutationAdd, states, false, false, 0, false,
+		position[0])
 
 	switch {
-	case idx == -1:
+	case !found:
 		return false
 	case idx == 0 && position[0] == PositionFirst:
 		return true
-	case int32(idx) == m.queueLen.Load()-1 && position[0] == PositionLast:
+	case idx == uint16(m.queueLen.Load())-1 && position[0] == PositionLast:
 		return true
 	default:
 		return true
@@ -2570,14 +2572,15 @@ func (m *Machine) WillBeRemoved(states S, position ...Position) bool {
 	if len(position) == 0 {
 		position = []Position{PositionAny}
 	}
-	idx := m.IsQueued(MutationRemove, states, false, false, 0, false, position[0])
+	idx, found := m.IsQueued(MutationRemove, states, false, false, 0, false,
+		position[0])
 
 	switch {
-	case idx == -1:
+	case !found:
 		return false
 	case idx == 0 && position[0] == PositionFirst:
 		return true
-	case int32(idx) == m.queueLen.Load()-1 && position[0] == PositionLast:
+	case idx == uint16(m.queueLen.Load())-1 && position[0] == PositionLast:
 		return true
 	default:
 		return true

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -1799,15 +1799,16 @@ func (h *TestQueueCheckableHandlers) AState(e *Event) {
 	assert.Len(t, m.queue, 3, "queue should have 3 mutations scheduled")
 	h.assertsCount++
 
-	assert.Equal(t, int16(1),
-		m.IsQueued(MutationAdd, S{"C"}, false, false, 0, false, PositionAny),
-		"C should be queued")
+	idx, found := m.IsQueued(MutationAdd, S{"C"}, false, false, 0, false,
+		PositionAny)
+	assert.Equal(t, uint16(1), idx, "C should be queued")
+	assert.True(t, found, "C should be queued")
 	assert.True(t, m.WillBe1("C"), "A should NOT be queued")
 	h.assertsCount++
 
-	assert.Equal(t, int16(-1),
-		m.IsQueued(MutationAdd, S{"A"}, false, false, 0, false, PositionAny),
-		"A should NOT be queued")
+	_, found = m.IsQueued(MutationAdd, S{"A"}, false, false, 0, false,
+		PositionAny)
+	assert.False(t, found, "A should NOT be queued")
 	assert.False(t, m.WillBe1("A"), "A should NOT be queued")
 	h.assertsCount++
 
@@ -2969,7 +2970,7 @@ func TestOpts(t *testing.T) {
 	assert.Equal(t, m.Id(), m2.ParentId())
 	assert.Equal(t, false, m2.LogStackTrace)
 	assert.Equal(t, tags, m2.Tags())
-	assert.Equal(t, 10, m2.QueueLimit)
+	assert.Equal(t, uint16(10), m2.QueueLimit)
 	assert.Equal(t, LogChanges, m2.SemLogger().Level())
 
 	tags2 := []string{"c"}


### PR DESCRIPTION
Lowering the limit to save space.