### PR TITLE
feat(am-relay): add dbg protocol rotation server

### DIFF
--- a/tools/cmd/am-vis/cmd_vis.go
+++ b/tools/cmd/am-vis/cmd_vis.go
@@ -1,0 +1,228 @@
+// Package am-vis generates diagrams of a filtered graph.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/alexflint/go-arg"
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amgraph "github.com/pancsta/asyncmachine-go/pkg/graph"
+	dbgtypes "github.com/pancsta/asyncmachine-go/tools/debugger/types"
+	"github.com/pancsta/asyncmachine-go/tools/visualizer"
+	"github.com/pancsta/asyncmachine-go/tools/visualizer/states"
+	"github.com/pancsta/asyncmachine-go/tools/visualizer/types"
+)
+
+// const CmdDbgServer = "dbg-server"
+
+// nolint:lll
+type Args struct {
+	RenderDump *RenderDumpCmd `arg:"subcommand:render-dump" help:"Render from a debugger dump file"`
+	// DbgServer     *DbgServerCmd     `arg:"subcommand:dbg-server" help:"Render from live connections"`
+
+	// TODO RenderAllowlist
+
+	// preset single render defaults
+
+	RenderDistance int `arg:"-d,--render-distance" default:"0"`
+	RenderDepth    int `arg:"--render-depth" default:"0"`
+
+	RenderStart     bool `arg:"--render-start" default:"false"`
+	RenderReady     bool `arg:"--render-ready" default:"false"`
+	RenderException bool `arg:"--render-exception" default:"false"`
+
+	RenderStates          bool `arg:"--render-states" default:"true"`
+	RenderInherited       bool `arg:"--render-inherited" default:"true"`
+	RenderPipes           bool `arg:"--render-pipes" default:"false"`
+	RenderDetailedPipes   bool `arg:"--render-detailed-pipes" default:"true"`
+	RenderRelations       bool `arg:"--render-relations" default:"true"`
+	RenderConns           bool `arg:"--render-conns" default:"true"`
+	RenderParentRel       bool `arg:"--render-parent-rel" default:"true"`
+	RenderHalfConns       bool `arg:"--render-half-conns" default:"true"`
+	RenderHalfPipes       bool `arg:"--render-half-pipes" default:"true"`
+	RenderNestSubmachines bool `arg:"--render-nest-submachines" default:"false"`
+	RenderTags            bool `arg:"--render-tags" default:"false"`
+
+	// presets
+
+	Bird bool `arg:"-b,--bird" help:"Use the bird's view preset"`
+	Map  bool `arg:"-b,--map" help:"Use the map view preset"`
+
+	// output
+
+	OutputElk      bool   `arg:"--output-elk" default:"true" help:"Use ELK layout"`
+	OutputFilename string `arg:"-o,--output-filename" default:"am-vis"`
+}
+
+func (Args) Description() string {
+	return utils.Sp(`
+		Render diagrams of interconnected state machines.
+	
+		Examples:
+	
+		# single machine
+		am-vis render-dump mymach.gob.br mach://MyMach1/t234
+	
+		# bird's view with distance of 2 from MyMach1
+		am-vis --bird -d 2 \
+			render-dump mymach.gob.br mach://MyMach1/TX-ID
+	
+		# bird's view with detailed pipes
+		am-vis --bird --render-detailed-pipes \
+			render-dump mymach.gob.br mach://MyMach1/TX-ID
+	
+		# map view with inherited states
+		am-vis --render-inherited \
+			render-dump mymach.gob.br mach://MyMach1/t234
+	
+		# map view
+		am-vis --map render-dump mymach.gob.br
+	`)
+}
+
+// nolint:lll
+type RenderDumpCmd struct {
+	DumpFilename string `arg:"-f,--dump-file" help:"Input dbg dump file" default:"am-dbg-dump.gob.br"`
+	MachUrl      string `arg:"positional"`
+}
+
+// TODO DbgServerCmd
+// nolint:lll
+// type DbgServerCmd struct {
+// 	ListenAddr   string   `arg:"-l,--listen-addr" default:"127.0.0.1:7452"`
+// 	FwdAddrs     []string `arg:"-f,--fwd-addr,separate" help:"Forward msgs to these addresses"`
+// 	DumpFilename string   `arg:"positional,required" help:"Load a baseline dump file"`
+// }
+
+var args Args
+
+func main() {
+	ctx := context.Background()
+	p := arg.MustParse(&args)
+	if p.Subcommand() == nil {
+		p.Fail("missing subcommand (" + types.CmdRenderDump + ")")
+	}
+
+	switch {
+	case args.RenderDump != nil:
+		if err := renderDump(ctx, args, os.Args[1:]); err != nil {
+			_ = p.FailSubcommand(err.Error(), types.CmdRenderDump)
+		}
+	}
+}
+
+var ss = states.VisualizerStates
+
+func renderDump(ctx context.Context, args Args, cliArgs []string) error {
+	// go server.StartRpc(mach, p.ServerAddr, nil, p.FwdData)
+
+	vis, err := visualizer.New(ctx, "am-vis")
+	if err != nil {
+		return err
+	}
+
+	// parse mach URL
+	if args.RenderDump.MachUrl == "" && !args.Map {
+		return errors.New("machine URL is required when not using --map")
+	}
+	addr, err := dbgtypes.ParseMachUrl(args.RenderDump.MachUrl)
+	if err != nil {
+		return err
+	}
+
+	// init & import
+	vis.Mach.Add1(ss.Start, nil)
+	// TODO pass to StartState
+	err = vis.HImportData(args.RenderDump.DumpFilename)
+	if err != nil {
+		return err
+	}
+	clients := slices.Collect(maps.Values(vis.Clients()))
+	fmt.Printf("Imported %d clients\n", len(clients))
+	found := slices.ContainsFunc(clients, func(c amgraph.Client) bool {
+		return c.Id == addr.MachId
+	})
+	if !found {
+		return fmt.Errorf("machine %s not found in the dump file", addr.MachId)
+	}
+
+	// presets
+	switch {
+	case args.Map:
+		visualizer.PresetMap(vis.R)
+	case args.Bird:
+		visualizer.PresetBird(vis.R)
+	default:
+		visualizer.PresetSingle(vis.R)
+	}
+	applyOverrides(args, cliArgs, vis.R)
+
+	// render
+	vis.R.RenderMachs = []string{addr.MachId}
+	vis.R.OutputFilename = args.OutputFilename
+	vis.R.OutputMermaid = false
+	fmt.Printf("Rendering... please wait\n")
+	if err := vis.R.GenDiagrams(ctx); err != nil {
+		return err
+	}
+	fmt.Printf("Rendered %s\n", args.OutputFilename+".svg")
+	fmt.Printf("Rendered %s\n", args.OutputFilename+".d2")
+
+	return nil
+}
+
+func applyOverrides(args Args, cliArgs []string, vis *visualizer.Renderer) {
+	if slices.Contains(cliArgs, "--render-detailed-pipes") {
+		vis.RenderDetailedPipes = args.RenderDetailedPipes
+	}
+	if slices.Contains(cliArgs, "--render-pipes") {
+		vis.RenderPipes = args.RenderPipes
+	}
+	if slices.Contains(cliArgs, "--render-exception") {
+		vis.RenderException = args.RenderException
+	}
+	if slices.Contains(cliArgs, "--render-tags") {
+		vis.RenderTags = args.RenderTags
+	}
+	if slices.Contains(cliArgs, "--render-inherited") {
+		vis.RenderInherited = args.RenderInherited
+	}
+	if slices.Contains(cliArgs, "--render-relations") {
+		vis.RenderRelations = args.RenderRelations
+	}
+	if slices.Contains(cliArgs, "--render-conns") {
+		vis.RenderConns = args.RenderConns
+	}
+	if slices.Contains(cliArgs, "--render-parent-rel") {
+		vis.RenderParentRel = args.RenderParentRel
+	}
+	if slices.Contains(cliArgs, "--render-half-conns") {
+		vis.RenderHalfConns = args.RenderHalfConns
+	}
+	if slices.Contains(cliArgs, "--render-half-pipes") {
+		vis.RenderHalfPipes = args.RenderHalfPipes
+	}
+	if slices.Contains(cliArgs, "--render-nest-submachines") {
+		vis.RenderNestSubmachines = args.RenderNestSubmachines
+	}
+	if slices.Contains(cliArgs, "--render-start") {
+		vis.RenderStart = args.RenderStart
+	}
+	if slices.Contains(cliArgs, "--render-ready") {
+		vis.RenderReady = args.RenderReady
+	}
+	if slices.Contains(cliArgs, "--render-depth") {
+		vis.RenderDepth = args.RenderDepth
+	}
+	if slices.Contains(cliArgs, "--render-states") {
+		vis.RenderStates = args.RenderStates
+	}
+	if slices.Contains(cliArgs, "--output-elk") {
+		vis.OutputElk = args.OutputElk
+	}
+}

--- a/tools/relay/relay.go
+++ b/tools/relay/relay.go
@@ -1,0 +1,263 @@
+package relay
+
+import (
+	"context"
+	"encoding/gob"
+	"os"
+	"path"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/joho/godotenv"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
+	"github.com/pancsta/asyncmachine-go/tools/relay/states"
+	"github.com/pancsta/asyncmachine-go/tools/relay/types"
+)
+
+var ss = states.RelayStates
+
+type Relay struct {
+	Mach *am.Machine
+	Args *types.Args
+
+	clients    map[string]*server.Client
+	out        types.OutputFunc
+	lastExport time.Time
+}
+
+// New creates a new Relay - state machine, RPC server.
+func New(
+	ctx context.Context, args *types.Args, out types.OutputFunc,
+) (*Relay, error) {
+	if args.Debug {
+		out("debugging enabled\n")
+		// load .env
+		_ = godotenv.Load()
+	}
+
+	r := &Relay{
+		Args:       args,
+		lastExport: time.Now(),
+		out:        out,
+		clients:    make(map[string]*server.Client),
+	}
+	mach, err := am.NewCommon(ctx, "relay", states.RelaySchema, ss.Names(),
+		r, nil, &am.Opts{
+			DontPanicToException: args.Debug,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if args.Debug {
+		amhelp.MachDebugEnv(mach)
+	}
+	r.Mach = mach
+
+	return r, nil
+}
+
+func (r *Relay) StartState(e *am.Event) {
+	a := r.Args.RotateDbg
+	r.out("starting relay server on %s\n", a.ListenAddr)
+	for _, addr := range a.FwdAddr {
+		r.out("forwarding to %s\n", addr)
+	}
+	go server.StartRpc(r.Mach, a.ListenAddr, nil, a.FwdAddr, false)
+}
+
+// TODO StartEnd
+
+// RPC SERVER
+
+func (r *Relay) ClientMsgEnter(e *am.Event) bool {
+	_, ok1 := e.Args["msgs_tx"].([]*telemetry.DbgMsgTx)
+	_, ok2 := e.Args["conn_ids"].([]string)
+	return ok1 && ok2
+}
+
+func (r *Relay) ClientMsgState(e *am.Event) {
+	msgs := e.Args["msgs_tx"].([]*telemetry.DbgMsgTx)
+	connIds := e.Args["conn_ids"].([]string)
+
+	for i, msg := range msgs {
+
+		// TODO check tokens
+		machId := msg.MachineID
+		c := r.clients[machId]
+		if _, ok := r.clients[machId]; !ok {
+			r.Mach.Log("Error: client not found: %s\n", machId)
+			continue
+		}
+
+		if c.MsgStruct == nil {
+			r.Mach.Log("Error: schema missing for %s, ignoring tx\n", machId)
+			continue
+		}
+
+		// verify it's from the same client
+		if c.ConnId != connIds[i] {
+			r.Mach.Log("Error: conn_id mismatch for %s, ignoring tx\n", machId)
+			continue
+		}
+
+		// append the msg
+		c.MsgTxs = append(c.MsgTxs, msg)
+	}
+
+	a := r.Args.RotateDbg
+	if time.Since(r.lastExport) > a.IntervalTime || r.msgsCount() > a.IntervalTx {
+		r.lastExport = time.Now()
+		if err := r.hExportData(); err != nil {
+			// TODO err handler
+			r.out("Error: export failed %s\n", err)
+			r.Mach.AddErr(err, nil)
+		}
+	}
+}
+
+func (r *Relay) ConnectEventEnter(e *am.Event) bool {
+	msg, ok1 := e.Args["msg_struct"].(*telemetry.DbgMsgStruct)
+	_, ok2 := e.Args["conn_id"].(string)
+	if !ok1 || !ok2 || msg.ID == "" {
+		r.Mach.Log("Error: msg_struct malformed\n")
+		return false
+	}
+
+	return true
+}
+
+func (r *Relay) ConnectEventState(e *am.Event) {
+	// initial structure data
+	msg := e.Args["msg_struct"].(*telemetry.DbgMsgStruct)
+	connId := e.Args["conn_id"].(string)
+	var c *server.Client
+
+	// update existing client
+	if existing, ok := r.clients[msg.ID]; ok {
+		if existing.ConnId != "" && existing.ConnId == connId {
+			r.Mach.Log("schema changed for %s", msg.ID)
+			r.out("schema changed for %s\n", msg.ID)
+			// TODO use MsgStructPatch
+			// TODO keep old revisions
+			existing.MsgStruct = msg
+			c = existing
+			c.ParseSchema()
+
+		} else {
+			r.Mach.Log("client %s already exists, overriding", msg.ID)
+			r.out("client %s already exists, overriding\n", msg.ID)
+		}
+	}
+
+	// create a new client
+	if c == nil {
+		r.out("new client %s\n", msg.ID)
+		// TODO server.NewClient
+		c = &server.Client{
+			Id:         msg.ID,
+			ConnId:     connId,
+			SchemaHash: amhelp.SchemaHash(msg.States),
+			Exportable: &server.Exportable{
+				MsgStruct: msg,
+			},
+		}
+		c.Connected.Store(true)
+		r.clients[msg.ID] = c
+	}
+
+	// TODO remove the last active client if over the limit
+	// if len(r.clients) > maxClients {
+	// 	var (
+	// 		lastActiveTime time.Time
+	// 		lastActiveID   string
+	// 	)
+	// 	// TODO get time from msgs
+	// 	for id, c := range r.clients {
+	// 		active := c.LastActive()
+	// 		if active.After(lastActiveTime) || lastActiveID == "" {
+	// 			lastActiveTime = active
+	// 			lastActiveID = id
+	// 		}
+	// 	}
+	// 	r.Mach.Add1(ss.RemoveClient, am.A{"Client.id": lastActiveID})
+	// }
+
+	r.Mach.Add1(ss.InitClient, am.A{"id": msg.ID})
+}
+
+func (r *Relay) DisconnectEventEnter(e *am.Event) bool {
+	_, ok := e.Args["conn_id"].(string)
+	if !ok {
+		r.Mach.Log("Error: DisconnectEvent malformed\n")
+		return false
+	}
+
+	return true
+}
+
+func (r *Relay) DisconnectEventState(e *am.Event) {
+	connID := e.Args["conn_id"].(string)
+	for _, c := range r.clients {
+		if c.ConnId != "" && c.ConnId == connID {
+			// mark as disconnected
+			c.Connected.Store(false)
+			r.Mach.Log("client %s disconnected", c.Id)
+			r.out("client %s disconnected\n", c.Id)
+			break
+		}
+	}
+}
+
+func (r *Relay) hExportData() error {
+	count := r.msgsCount()
+	r.out("exporting %d transitions for %d clients\n", count, len(r.clients))
+
+	a := r.Args.RotateDbg
+	filename := a.Filename + "-" + time.Now().Format("2006-01-02_15-04-05")
+
+	// create file
+	gobPath := path.Join(a.Dir, filename+".gob.br")
+	fw, err := os.Create(gobPath)
+	if err != nil {
+		return err
+	}
+	defer fw.Close()
+
+	// prepare the format
+	data := make([]*server.Exportable, len(r.clients))
+	i := 0
+	for _, c := range r.clients {
+		data[i] = c.Exportable
+		i++
+	}
+
+	// create a new brotli writer
+	brCompress := brotli.NewWriter(fw)
+	defer brCompress.Close()
+
+	// encode
+	encoder := gob.NewEncoder(brCompress)
+	err = encoder.Encode(data)
+	if err != nil {
+		return err
+	}
+
+	// flush old msgs
+	for _, c := range r.clients {
+		c.Exportable.MsgTxs = nil
+	}
+
+	return nil
+}
+
+func (r *Relay) msgsCount() int {
+	count := 0
+	for _, c := range r.clients {
+		count += len(c.MsgTxs)
+	}
+	return count
+}

--- a/tools/relay/states/ss_relay.go
+++ b/tools/relay/states/ss_relay.go
@@ -1,0 +1,50 @@
+// Package states contains a stateful schema-v2 for Relay.
+// Bootstrapped with am-gen. Edit manually or re-gen & merge.
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+	. "github.com/pancsta/asyncmachine-go/pkg/states/global"
+	ssdbg "github.com/pancsta/asyncmachine-go/tools/debugger/states"
+)
+
+// RelayStatesDef contains all the states of the Relay state machine.
+type RelayStatesDef struct {
+	*am.StatesBase
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+	// inherit from DisposedStatesDef
+	*ss.DisposedStatesDef
+	// inherit from [ssdbg.ServerStatesDef]
+	*ssdbg.ServerStatesDef
+}
+
+// RelayGroupsDef contains all the state groups Relay state machine.
+type RelayGroupsDef struct {
+}
+
+// RelaySchema represents all relations and properties of RelayStates.
+var RelaySchema = SchemaMerge(
+	// inherit from BasicStruct
+	ss.BasicSchema,
+	// inherit from DisposedStruct
+	ss.DisposedSchema,
+	// inherit from ServerSchema
+	ssdbg.ServerSchema,
+	am.Schema{
+		// TODO own states
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssV = am.NewStates(RelayStatesDef{})
+	sgV = am.NewStateGroups(RelayGroupsDef{})
+
+	// RelayStates contains all the states for the Relay machine.
+	RelayStates = ssV
+	// RelayGroups contains all the state groups for the Relay machine.
+	RelayGroups = sgV
+)

--- a/tools/relay/types/relay_cli.go
+++ b/tools/relay/types/relay_cli.go
@@ -1,0 +1,26 @@
+package types
+
+import "time"
+
+const CmdRotateDbg = "rotate-dbg"
+
+type OutputFunc func(msg string, args ...any)
+
+// nolint:lll
+type Args struct {
+	RotateDbg *ArgsRotateDbg `arg:"subcommand:rotate-dbg" help:"Rotate dbg protocol with fragmented dump files"`
+	Debug     bool           `arg:"--debug" help:"Enable debugging for asyncmachine"`
+	// TODO ID suffix
+}
+
+// ArgsRotateDbg converts dbg dumps to other formats / versions.
+// am-relay convert-dbg am-dbg-dump.gob.br -o am-vis
+// nolint:lll
+type ArgsRotateDbg struct {
+	ListenAddr   string        `arg:"-l,--listen-addr" default:"localhost:2732" help:"Listen address for RPC server"`
+	FwdAddr      []string      `arg:"-f,--fwd-addr,separate" help:"Address of an RPC server to forward data to (repeatable)"`
+	IntervalTx   int           `arg:"--interval-tx" default:"10000" help:"Amount of transitions to create a dump file"`
+	IntervalTime time.Duration `arg:"--interval-duration" default:"24h" help:"Amount of human time to create a dump file"`
+	Filename     string        `arg:"-o,--output" default:"am-dbg-dump" help:"Output file base name"`
+	Dir          string        `arg:"-d,--dir" default:"." help:"Output directory"`
+}


### PR DESCRIPTION
`am-relay` converts formats and relays connections. It's an early version that for now can only rotate [dbg telemetry](/pkg/telemetry/README.md#dbg)
into chunked file dumps.

```bash
.rw-r--r--@ 713k foo 17 Nov 12:19 am-dbg-dump-2025-11-17_12-19-35.gob.br
.rw-r--r--@ 737k foo 17 Nov 12:20 am-dbg-dump-2025-11-17_12-20-02.gob.br
.rw-r--r--@ 749k foo 17 Nov 12:20 am-dbg-dump-2025-11-17_12-20-28.gob.br
```