### PR TITLE
docs(examples): add CLI, CLI Daemon, and TUI examples

### DIFF
--- a/examples/cli/main.go
+++ b/examples/cli/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alexflint/go-arg"
+	"github.com/joho/godotenv"
+
+	"github.com/pancsta/asyncmachine-go/examples/cli/states"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+var ss = states.CliStates
+
+type Args struct {
+	Foo1     bool          `arg:"--foo-1" help:"Foo help"`
+	Bar2     bool          `arg:"--bar-2" help:"Bar help"`
+	Duration time.Duration `arg:"-d,--duration" default:"3s" help:"Duration of the demo"`
+	Debug    bool          `default:"true" help:"Enable debugging for asyncmachine"`
+}
+
+type cli struct {
+	*am.ExceptionHandler
+
+	Mach *am.Machine
+	Args *Args
+}
+
+var args Args
+
+func main() {
+	p := arg.MustParse(&args)
+	ctx := context.Background()
+	cli, err := newCli(ctx, &args)
+	if err != nil {
+		panic(err)
+	}
+
+	if args.Foo1 {
+		cli.Mach.Add1(ss.Foo1, nil)
+	} else if args.Bar2 {
+		cli.Mach.Add1(ss.Bar2, nil)
+	} else {
+		p.Fail("no flag")
+	}
+
+	<-cli.Mach.WhenNot1(ss.Start, nil)
+}
+
+// newCli creates a new CLI with a state machine.
+func newCli(ctx context.Context, args *Args) (*cli, error) {
+	if args.Debug {
+		fmt.Printf("debugging enabled\n")
+		// load .env
+		_ = godotenv.Load()
+	}
+
+	ret := &cli{
+		Args: args,
+	}
+	mach, err := am.NewCommon(ctx, "cli", states.CliSchema, ss.Names(),
+		ret, nil, &am.Opts{
+			DontPanicToException: args.Debug,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if args.Debug {
+		amhelp.MachDebugEnv(mach)
+	}
+	ret.Mach = mach
+
+	return ret, nil
+}
+
+func (c *cli) StartState(e *am.Event) {
+	ctx := c.Mach.NewStateCtx(ss.Start)
+	fmt.Printf("starting for %s\n", e.Transition().CalledStates())
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-time.After(c.Args.Duration):
+		}
+		fmt.Printf("start done\n")
+		c.Mach.Remove1(ss.Start, nil)
+	}()
+}

--- a/examples/cli/states/ss_cli.go
+++ b/examples/cli/states/ss_cli.go
@@ -1,0 +1,55 @@
+// Package states contains a stateful schema-v2 for a CLI.
+// Bootstrapped with am-gen. Edit manually or re-gen & merge.
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+	. "github.com/pancsta/asyncmachine-go/pkg/states/global"
+)
+
+// CliStatesDef contains all the states of the Cli state machine.
+type CliStatesDef struct {
+	*am.StatesBase
+
+	Foo1 string
+	Bar2 string
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+	// inherit from DisposedStatesDef
+	*ss.DisposedStatesDef
+}
+
+// CliGroupsDef contains all the state groups Cli state machine.
+type CliGroupsDef struct {
+}
+
+// CliSchema represents all relations and properties of CliStates.
+var CliSchema = SchemaMerge(
+	// inherit from BasicStruct
+	ss.BasicSchema,
+	// inherit from DisposedStruct
+	ss.DisposedSchema,
+	am.Schema{
+		ssV.Foo1: {
+			Add:   S{ssV.Start},
+			After: S{ssV.Start},
+		},
+		ssV.Bar2: {
+			Add:   S{ssV.Start},
+			After: S{ssV.Start},
+		},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssV = am.NewStates(CliStatesDef{})
+	sgV = am.NewStateGroups(CliGroupsDef{})
+
+	// CliStates contains all the states for the Cli machine.
+	CliStates = ssV
+	// CliGroups contains all the state groups for the Cli machine.
+	CliGroups = sgV
+)

--- a/examples/cli_daemon/cli/main.go
+++ b/examples/cli_daemon/cli/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alexflint/go-arg"
+	"github.com/joho/godotenv"
+
+	"github.com/pancsta/asyncmachine-go/examples/cli_daemon/states"
+	"github.com/pancsta/asyncmachine-go/examples/cli_daemon/types"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+var ss = states.DaemonStates
+
+type Args struct {
+	Foo1     bool          `arg:"--foo-1" help:"Foo help"`
+	Bar2     bool          `arg:"--bar-2" help:"Bar help"`
+	Addr     string        `default:"localhost:8090"`
+	Duration time.Duration `arg:"-d,--duration" default:"3s" help:"Duration of the op"`
+	Debug    bool          `default:"true" help:"Enable debugging for asyncmachine"`
+}
+
+var args Args
+
+func main() {
+	p := arg.MustParse(&args)
+	ctx := context.Background()
+	cli, err := newCli(ctx, &args)
+	if err != nil {
+		p.Fail(err.Error())
+	}
+	netmach := cli.C.NetMach
+
+	if args.Foo1 {
+		netmach.Add1(ss.OpFoo1, types.PassRpc(&types.ARpc{
+			Duration: args.Duration,
+		}))
+	} else if args.Bar2 {
+		netmach.Add1(ss.OpBar2, types.PassRpc(&types.ARpc{
+			Duration: args.Duration,
+		}))
+	} else {
+		p.Fail("no flag")
+	}
+
+	err = amhelp.WaitForAll(ctx, 5*time.Second,
+		cli.Mach.When1(ssrpc.ConsumerStates.WorkerPayload, nil))
+	if err != nil {
+		p.Fail(err.Error())
+	}
+}
+
+// newCli creates a new CLI with a state machine.
+func newCli(ctx context.Context, args *Args) (*cli, error) {
+	if args.Debug {
+		fmt.Printf("debugging enabled\n")
+		// load .env
+		_ = godotenv.Load()
+	}
+
+	// init cli
+	consumer := am.New(ctx, ssrpc.ConsumerSchema, nil)
+	err := consumer.BindHandlers(&cli{})
+	if err != nil {
+		return nil, err
+	}
+
+	// init aRPC client
+	c, err := newClient(ctx, args.Addr, consumer, states.DaemonSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	// connect
+	c.Start()
+	err = amhelp.WaitForAll(ctx, 3*time.Second,
+		c.Mach.When1(ssrpc.ClientStates.Ready, ctx))
+	fmt.Printf("Connected to aRPC %s\n", c.Addr)
+
+	return &cli{
+		Mach: consumer,
+		C:    c,
+		Args: args,
+	}, nil
+}
+
+func newClient(
+	ctx context.Context, addr string, consumer *am.Machine, netSrcSchema am.Schema,
+) (*arpc.Client, error) {
+
+	// init
+	id := "cli-" + time.Now().Format(time.RFC3339Nano)
+	c, err := arpc.NewClient(ctx, addr, id, netSrcSchema, &arpc.ClientOpts{
+		Consumer: consumer,
+	})
+	if err != nil {
+		return nil, err
+	}
+	amhelp.MachDebugEnv(c.Mach)
+
+	return c, nil
+}
+
+type cli struct {
+	*am.ExceptionHandler
+
+	Mach *am.Machine
+	C    *arpc.Client
+	Args *Args
+}
+
+func (c *cli) WorkerPayloadState(e *am.Event) {
+	e.Machine().Remove1(ssrpc.ConsumerStates.WorkerPayload, nil)
+
+	args := arpc.ParseArgs(e.Args)
+	println("Payload: " + args.Payload.Data.(string))
+}

--- a/examples/cli_daemon/daemon/main.go
+++ b/examples/cli_daemon/daemon/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alexflint/go-arg"
+	"github.com/joho/godotenv"
+	"github.com/teivah/onecontext"
+
+	"github.com/pancsta/asyncmachine-go/examples/cli_daemon/states"
+	"github.com/pancsta/asyncmachine-go/examples/cli_daemon/types"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+)
+
+var ss = states.DaemonStates
+
+type Args struct {
+	Addr  string `default:"localhost:8090"`
+	Debug bool   `default:"true" help:"Enable debugging for asyncmachine"`
+}
+
+type daemon struct {
+	Mach *am.Machine
+	Args *Args
+	S    *arpc.Server
+}
+
+var args Args
+
+func main() {
+	p := arg.MustParse(&args)
+	ctx := context.Background()
+	d, err := newDaemon(ctx, &args)
+	if err != nil {
+		p.Fail(err.Error())
+	}
+
+	<-d.Mach.WhenQueue(d.Mach.Add1(ss.Start, nil))
+	<-d.Mach.WhenNot1(ss.Start, nil)
+}
+
+// newDaemon creates a new CLI with a state machine.
+func newDaemon(ctx context.Context, args *Args) (*daemon, error) {
+	if args.Debug {
+		fmt.Printf("debugging enabled\n")
+		// load .env
+		_ = godotenv.Load()
+	}
+
+	// init daemon
+	d := &daemon{
+		Args: args,
+	}
+	mach, err := am.NewCommon(ctx, "daemon", states.DaemonSchema, ss.Names(),
+		d, nil, &am.Opts{
+			DontPanicToException: args.Debug,
+			LogLevel:             am.LogChanges,
+			LogArgs:              types.LogArgs,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if args.Debug {
+		amhelp.MachDebugEnv(mach)
+	}
+	d.Mach = mach
+
+	// init aRPC server
+	s, err := arpc.NewServer(ctx, args.Addr, d.Mach.Id(), d.Mach, nil)
+	if err != nil {
+		return nil, err
+	}
+	if args.Debug {
+		amhelp.MachDebugEnv(s.Mach)
+	}
+	d.S = s
+	s.Start()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("listening on %s\n", args.Addr)
+
+	return d, nil
+}
+
+func (d *daemon) OpFoo1State(e *am.Event) {
+	d.hOp(e)
+}
+func (d *daemon) OpBar2State(e *am.Event) {
+	d.hOp(e)
+}
+
+// hOp is a sub-handler for common operation logic.
+func (d *daemon) hOp(e *am.Event) {
+	ctxDaemon := d.Mach.NewStateCtx(ss.Start)
+	ctxRpc := d.S.Mach.NewStateCtx(ssrpc.ServerStates.ClientConnected)
+	ctx, _ := onecontext.Merge(ctxDaemon, ctxRpc)
+	duration := types.ParseArgs(e.Args).Duration
+	called := e.Transition().CalledStates()
+
+	fmt.Printf("starting op %s for %s\n", called, duration)
+	go func() {
+		defer d.Mach.Remove(called, nil)
+		select {
+		case <-ctx.Done():
+			fmt.Printf("ctx done\n")
+			return
+		case <-time.After(duration):
+		}
+
+		fmt.Printf("op done\n")
+		// TODO
+		d.Mach.AddErr(d.S.SendPayload(ctx, e, &arpc.MsgSrvPayload{
+			Name: "opdone",
+			Data: fmt.Sprintf("done for %s", called),
+		}), nil)
+	}()
+}

--- a/examples/cli_daemon/states/ss_daemon.go
+++ b/examples/cli_daemon/states/ss_daemon.go
@@ -1,0 +1,63 @@
+// Package states contains a stateful schema-v2 for a CLI.
+// Bootstrapped with am-gen. Edit manually or re-gen & merge.
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+	. "github.com/pancsta/asyncmachine-go/pkg/states/global"
+)
+
+// DaemonStatesDef contains all the states of the Daemon state machine.
+type DaemonStatesDef struct {
+	*am.StatesBase
+
+	OpFoo1 string
+	OpBar2 string
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+	// inherit from DisposedStatesDef
+	*ss.DisposedStatesDef
+	// inherit from NetSourceStatesDef
+	*ssrpc.NetSourceStatesDef
+}
+
+// DaemonGroupsDef contains all the state groups Daemon state machine.
+type DaemonGroupsDef struct {
+	Ops S
+}
+
+// DaemonSchema represents all relations and properties of DaemonStates.
+var DaemonSchema = SchemaMerge(
+	// inherit from BasicStruct
+	ss.BasicSchema,
+	// inherit from DisposedStruct
+	ss.DisposedSchema,
+	// inherit from WorkerSchema
+	ssrpc.NetSourceSchema,
+	am.Schema{
+		ssD.OpFoo1: {
+			Require: S{ssD.Start},
+			Remove:  sgD.Ops,
+		},
+		ssD.OpBar2: {
+			Require: S{ssD.Start},
+			Remove:  sgD.Ops,
+		},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssD = am.NewStates(DaemonStatesDef{})
+	sgD = am.NewStateGroups(DaemonGroupsDef{
+		Ops: S{ssD.OpFoo1, ssD.OpBar2},
+	})
+
+	// DaemonStates contains all the states for the Daemon machine.
+	DaemonStates = ssD
+	// DaemonGroups contains all the state groups for the Daemon machine.
+	DaemonGroups = sgD
+)

--- a/examples/cli_daemon/types/args.go
+++ b/examples/cli_daemon/types/args.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"encoding/gob"
+	"time"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+func init() {
+	gob.Register(&ARpc{})
+}
+
+// ///// ///// /////
+
+// ///// ARGS
+
+// ///// ///// /////
+// TODO add RPC args example from pkg/node
+
+const APrefix = "daemon"
+
+// A is a struct for node arguments. It's a typesafe alternative to [am.A].
+type A struct {
+	Duration time.Duration `log:"duration"`
+}
+
+// ARpc is a subset of A, that can be passed over RPC.
+type ARpc struct {
+	Duration time.Duration `log:"duration"`
+}
+
+// ParseArgs extracts A from [am.Event.Args][APrefix].
+func ParseArgs(args am.A) *A {
+	if r, ok := args[APrefix].(*ARpc); ok {
+		return amhelp.ArgsToArgs(r, &A{})
+	} else if r, ok := args[APrefix].(ARpc); ok {
+		return amhelp.ArgsToArgs(&r, &A{})
+	}
+	if a, _ := args[APrefix].(*A); a != nil {
+		return a
+	}
+
+	return &A{}
+}
+
+// Pass prepares [am.A] from A to pass to further mutations.
+func Pass(args *A) am.A {
+	return am.A{APrefix: args}
+}
+
+// PassRpc prepares [am.A] from A to pass over RPC.
+func PassRpc(args *ARpc) am.A {
+	return am.A{APrefix: amhelp.ArgsToArgs(args, &ARpc{})}
+}
+
+// LogArgs is an args logger for A.
+func LogArgs(args am.A) map[string]string {
+	a := ParseArgs(args)
+	if a == nil {
+		return nil
+	}
+
+	return amhelp.ArgsToLogMap(a, 0)
+}

--- a/examples/tui/main.go
+++ b/examples/tui/main.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/joho/godotenv"
+	"github.com/pancsta/cview"
+
+	"github.com/pancsta/asyncmachine-go/examples/tui/states"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+var ss = states.TuiStates
+
+func init() {
+	_ = godotenv.Load()
+}
+
+func main() {
+	ctx := context.Background()
+
+	handlers := &tui{}
+	mach, err := am.NewCommon(ctx, "tui", states.TuiSchema, ss.Names(),
+		handlers, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	handlers.Mach = mach
+	amhelp.MachDebugEnv(mach)
+	mach.Add1(ss.Start, nil)
+	<-mach.WhenNot1(ss.Start, nil)
+
+	time.Sleep(time.Second)
+}
+
+// TUI
+
+type tui struct {
+	*am.ExceptionHandler
+
+	Mach *am.Machine
+	App  *cview.Application
+	// UI is currently being drawn
+	drawing atomic.Bool
+	// repaintScheduled controls the UI paint debounce
+	repaintScheduled atomic.Bool
+	// repaintPending indicates a skipped repaint
+	repaintPending atomic.Bool
+
+	// go -race flag passed
+	DbgRace bool
+}
+
+// handlers
+
+func (t *tui) StartState(e *am.Event) {
+	// cview TUI app
+	t.App = cview.NewApplication()
+	t.App.EnableMouse(true)
+
+	// forceful race solving
+	t.App.SetBeforeDrawFunc(func(_ tcell.Screen) bool {
+		// dont draw while transitioning
+		ok := t.Mach.Transition() == nil
+		if !ok {
+			// reschedule this repaint
+			// d.Mach.Log("postpone draw")
+			t.repaintPending.Store(true)
+			return true
+		}
+
+		// mark as in progress
+		t.drawing.Store(true)
+		return false
+	})
+	t.App.SetAfterDrawFunc(func(_ tcell.Screen) {
+		t.drawing.Store(false)
+	})
+	t.App.SetAfterResizeFunc(func(width int, height int) {
+		go func() {
+			time.Sleep(time.Millisecond * 300)
+			t.Mach.Add1(ss.Resized, nil)
+		}()
+	})
+
+	stateCtx := t.Mach.NewStateCtx(ss.Start)
+
+	// draw in a goroutine
+	go func() {
+		if stateCtx.Err() != nil {
+			return // expired
+		}
+		t.Mach.PanicToErr(nil)
+
+		t.App.SetRoot(t.initUi(), true)
+		err := t.App.Run()
+		if err != nil {
+			t.Mach.AddErr(err, nil)
+		}
+
+		t.Mach.Dispose()
+	}()
+
+	// post-start ops
+	go func() {
+		if stateCtx.Err() != nil {
+			return // expired
+		}
+
+		// TODO
+	}()
+}
+
+// AnyEnter prevents most of mutations during a UI redraw (and vice versa)
+// forceful race solving
+func (t *tui) AnyEnter(e *am.Event) bool {
+	// always pass network traffic
+	mach := t.Mach
+	mut := e.Mutation()
+	called := mut.CalledIndex(ss.Names())
+	pass := am.S{ss.IncomingData, am.StateException}
+	if called.Any1(pass...) {
+		return true
+	}
+
+	// dont allow mutations while drawing, pull 10 times
+	delay := mach.HandlerTimeout / 10
+	tries := 100
+	// compensate extended timeouts
+	if amhelp.IsDebug() {
+		delay = 10 * time.Millisecond
+	}
+	for e.IsValid() {
+		ok := !t.drawing.Load()
+		if ok {
+			// ok
+			return true
+		}
+
+		// delay, but avoid the race detector which gets stuck here
+		if !t.DbgRace {
+			time.Sleep(delay)
+		}
+
+		tries--
+		if tries <= 0 {
+			// not ok
+			break
+		}
+	}
+
+	// prepend this mutation to the queue and try again TODO loop guard
+	// d.Mach.Log("postpone mut")
+	go mach.PrependMut(mut)
+
+	return false
+}
+
+// AnyState is a global final handler
+func (t *tui) AnyState(e *am.Event) {
+	tx := e.Transition()
+
+	// redraw on auto states
+	// TODO this should be done better
+	if tx.IsAuto() && tx.IsAccepted.Load() {
+		t.repaintPending.Store(false)
+		t.draw()
+	} else if t.repaintPending.Swap(false) {
+		t.draw()
+	}
+}
+
+// methods
+
+func (t *tui) draw(components ...cview.Primitive) {
+	if !t.repaintScheduled.CompareAndSwap(false, true) {
+		return
+	}
+
+	go func() {
+		select {
+		case <-t.Mach.Ctx().Done():
+			return
+
+		// debounce every 16msec
+		case <-time.After(16 * time.Millisecond):
+		}
+
+		t.App.QueueUpdateDraw(func() {
+			t.repaintScheduled.Store(false)
+		}, components...)
+	}()
+}
+
+func (t *tui) initUi() cview.Primitive {
+	newPrimitive := func(text string) cview.Primitive {
+		tv := cview.NewTextView()
+		tv.SetTextAlign(cview.AlignCenter)
+		tv.SetText(text)
+		return tv
+	}
+	menu := newPrimitive("Menu")
+	main := newPrimitive("Main content")
+	sideBar := newPrimitive("Side Bar")
+
+	grid := cview.NewGrid()
+	grid.SetRows(3, 0, 3)
+	grid.SetColumns(30, 0, 30)
+	grid.SetBorders(true)
+	grid.AddItem(newPrimitive("Header"), 0, 0, 1, 3, 0, 0, false)
+	grid.AddItem(newPrimitive("Footer"), 2, 0, 1, 3, 0, 0, false)
+
+	// Layout for screens narrower than 100 cells (menu and side bar are hidden).
+	grid.AddItem(menu, 0, 0, 0, 0, 0, 0, false)
+	grid.AddItem(main, 1, 0, 1, 3, 0, 0, false)
+	grid.AddItem(sideBar, 0, 0, 0, 0, 0, 0, false)
+
+	// Layout for screens wider than 100 cells.
+	grid.AddItem(menu, 1, 0, 1, 1, 0, 100, false)
+	grid.AddItem(main, 1, 1, 1, 1, 0, 100, false)
+	grid.AddItem(sideBar, 1, 2, 1, 1, 0, 100, false)
+
+	return grid
+}

--- a/examples/tui/states/ss_tui.go
+++ b/examples/tui/states/ss_tui.go
@@ -1,0 +1,50 @@
+package states
+
+import (
+	"context"
+
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+// TuiStatesDef contains all the states of the Tui state-machine.
+type TuiStatesDef struct {
+	*am.StatesBase
+
+	Resized string
+	IncomingData string
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+}
+
+// TuiGroupsDef contains all the state groups Tui state-machine.
+type TuiGroupsDef struct {
+}
+
+// TuiSchema represents all relations and properties of TuiStates.
+var TuiSchema = SchemaMerge(
+	// inherit from BasicSchema
+	ss.BasicSchema,
+	am.Schema{
+
+		ssT.Resized: {},
+		ssT.IncomingData: {},
+})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssT = am.NewStates(TuiStatesDef{})
+	sgT = am.NewStateGroups(TuiGroupsDef{})
+
+	// TuiStates contains all the states for the Tui state-machine.
+	TuiStates = ssT
+	// TuiGroups contains all the state groups for the Tui state-machine.
+	TuiGroups = sgT
+)
+
+// NewTui creates a new Tui state-machine in the most basic form.
+func NewTui(ctx context.Context) *am.Machine {
+	return am.New(ctx, TuiSchema, nil)
+}

--- a/examples/tui/states/states_utils.go
+++ b/examples/tui/states/states_utils.go
@@ -1,0 +1,25 @@
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// State is a type alias for a state definition. See [am.State].
+type State = am.State
+
+// SAdd is a func alias for merging lists of states.
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition.
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition.
+var StateSet = am.StateSet
+
+// SchemaMerge is a func alias for extending an existing state structure.
+var SchemaMerge = am.SchemaMerge
+
+// Exception is a type alias for the exception state.
+var Exception = am.StateException


### PR DESCRIPTION
Small but practical examples / templates to bootstrap TTY tools quickly:

- `examples/cli_daemon` is the most interesting one, as it uses `aRPC` to mutate a singleton state-machine (the daemon)
- `examples/cli` is a minimal CLI app mapping params to states
- `examples/tui` uses a race-free fork of cview (tview), used by `am-dbg`
