### PR TITLE
feat(helpers): add `AM_LOG_PRINT`

### DIFF
--- a/pkg/helpers/help.go
+++ b/pkg/helpers/help.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	// EnvAmLogPrint prints machine log to stdout.
+	EnvAmLogPrint = "AM_LOG_PRINT"
 	// EnvAmHealthcheck enables a healthcheck ticker for every debugged machine.
 	EnvAmHealthcheck = "AM_HEALTHCHECK"
 	// EnvAmTestRunner indicates the main test tunner, disables any telemetry.
@@ -309,7 +311,7 @@ func SemConfig(forceFull bool) *am.SemConfig {
 func MachDebugEnv(mach am.Api) {
 	amDbgAddr := os.Getenv(telemetry.EnvAmDbgAddr)
 	logLvl := am.EnvLogLevel("")
-	stdout := os.Getenv(am.EnvAmDebug) == "2"
+	stdout := os.Getenv(EnvAmLogPrint) != ""
 
 	// expand the default addr
 	if amDbgAddr == "1" {


### PR DESCRIPTION
`AM_LOG_PRINT` will start printing the output to stdout, for all machines using `amhelp.MachDebugEnv()`. This replaces the previous behavior of `AM_DEBUG=2`, so printing doesn't depend on bumped timeouts anymore.
