### PR TITLE
feat(machine): add OnChange handler

### DIFF
--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -144,6 +144,7 @@ type Machine struct {
 	breakpointsMx sync.Mutex
 	breakpoints   []*breakpoint
 	onError       atomic.Pointer[HandlerError]
+	onChange       atomic.Pointer[HandlerChange]
 }
 
 // NewCommon creates a new Machine instance with all the common options set.
@@ -3338,8 +3339,7 @@ func (m *Machine) Backoff() bool {
 // OnChange is the most basic state-change handler, useful for machines without
 // any handlers.
 func (m *Machine) OnChange(fn HandlerChange) {
-	// TODO #262
-	panic("OnChange not implemented")
+	m.onChange.Store(&fn)
 }
 
 func (m *Machine) SetGroups(groups any, optStates States) {

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -672,6 +672,11 @@ func (t *Transition) emitEvents() Result {
 				StateAny+SuffixState, t.Mutation.Args)
 		}
 
+		// basic OnChange handler
+		if onChange := m.onChange.Load(); onChange != nil {
+			(*onChange)(m, t.TimeBefore, t.TimeAfter)
+		}
+
 		// AUTO STATES
 		if result == Canceled {
 			t.IsAccepted.Store(false)

--- a/pkg/machine/types.go
+++ b/pkg/machine/types.go
@@ -606,7 +606,7 @@ const (
 
 type (
 	HandlerError  func(mach *Machine, err error)
-	HandlerChange func(mach *Machine, err error)
+	HandlerChange func(mach *Machine, before, after Time)
 )
 
 // Options


### PR DESCRIPTION
`OnChange` is the most basic state change handler and almost always should be replaced with `BindHandlers`. The only exception is when we need a handler-less machine (eg for clean aRPC), but still need to react to mutations (eg from REPL).