### PR TITLE
feat(repl): add typed args support with completion

### DIFF
--- a/pkg/rpc/netmach.go
+++ b/pkg/rpc/netmach.go
@@ -336,8 +336,12 @@ func (m *NetworkMachine) AddErrState(
 	// build args
 	argsT := &am.AT{Err: err}
 
+	errStates := am.S{state, am.StateException}
 	// mark errors added locally with ErrOnClient
-	errStates := am.S{ssNS.ErrOnClient, state, am.StateException}
+	if m.Has1(ssNS.ErrOnClient) {
+		errStates = append(errStates, ssNS.ErrOnClient)
+	}
+
 	return m.Add(errStates, am.PassMerge(args, argsT))
 }
 
@@ -445,8 +449,12 @@ func (m *NetworkMachine) EvAddErrState(
 	// build args
 	argsT := &am.AT{Err: err}
 
+	errStates := am.S{state, am.StateException}
 	// mark errors added locally with ErrOnClient
-	errStates := am.S{ssNS.ErrOnClient, state, am.StateException}
+	if m.Has1(ssNS.ErrOnClient) {
+		errStates = append(errStates, ssNS.ErrOnClient)
+	}
+
 	return m.EvAdd(event, errStates, am.PassMerge(args, argsT))
 }
 

--- a/pkg/rpc/states/ss_rpc.go
+++ b/pkg/rpc/states/ss_rpc.go
@@ -101,7 +101,7 @@ type NetSourceStatesDef struct {
 
 	// ErrOnClient indicates an error added on the Network Machine.
 	ErrOnClient string
-	// ErrProviding - Worker had issues providing the requested payload.
+	// ErrProviding - NetMach had issues providing the requested payload.
 	ErrProviding string
 	// ErrSendPayload - RPC server had issues sending the requested payload to
 	// the RPC client.
@@ -400,6 +400,11 @@ type MuxStatesDef struct {
 	*states.BasicStatesDef
 }
 
+// MuxGroupsDef contains all the state groups of the Mux state machine.
+type MuxGroupsDef struct {
+	// TODO remove when InferStructure lands
+}
+
 // MuxSchema represents all relations and properties of MuxStatesDef.
 var MuxSchema = SchemaMerge(
 	states.BasicSchema,
@@ -425,9 +430,12 @@ var MuxSchema = SchemaMerge(
 
 var (
 	ssD = am.NewStates(MuxStatesDef{})
+	sgD = am.NewStateGroups(MuxGroupsDef{})
 
 	// MuxStates contains all the states for the Mux machine.
 	MuxStates = ssD
+	// MuxGroups contains all the state groups for the Mux machine.
+	MuxGroups = sgD
 )
 
 // ///// ///// /////

--- a/tools/cmd/arpc/cmd_arpc.go
+++ b/tools/cmd/arpc/cmd_arpc.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	"github.com/pancsta/asyncmachine-go/tools/repl"
@@ -14,7 +13,8 @@ import (
 )
 
 var ss = states.ReplStates
-var randomId = false
+
+// var randomId = false
 
 func init() {
 	// amhelp.EnableDebugging(false)
@@ -40,10 +40,11 @@ func main() {
 	}
 
 	// repl
-	id := "repl"
-	if randomId {
-		id = "repl-" + utils.RandId(4)
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
 	}
+	id := "repl-" + amhelp.Hash(wd, 6)
 	r, err := repl.New(ctx, id)
 	if err != nil {
 		panic(err)

--- a/tools/repl/misc_repl.go
+++ b/tools/repl/misc_repl.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/reeflective/console"
 	"github.com/reeflective/readline"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
@@ -155,6 +157,7 @@ func completionsNarrowDown(
 	toComplete string, resources []string,
 ) ([]string, cobra.ShellCompDirective) {
 	// prefix-filtering (case insensitive)
+	// TODO update mutation args
 	if toComplete != "" {
 		filtered := []string{}
 		for _, resource := range resources {
@@ -294,4 +297,40 @@ func (h *History) Len() int {
 // Dump returns the entire history file.
 func (h *History) Dump() interface{} {
 	return h.lines
+}
+
+// ///// ///// /////
+
+// ///// FUNCS
+
+// ///// ///// /////
+
+// setupPrompt is a function which sets up the prompts for the main menu.
+func setupPrompt(m *console.Menu) {
+	p := m.Prompt()
+
+	p.Primary = func() string {
+		// TODO color per connection status (yellow all, green some, grey none)
+		return "\x1b[33marpc>\x1b[0m "
+	}
+
+	// p.Right = func() string {
+	// 	return "\x1b[1;30m" + time.Now().Format("03:04:05.000") + "\x1b[0m"
+	// }
+
+	// p.Transient = func() string { return "\x1b[1;30m" + ">> " + "\x1b[0m" }
+}
+
+func listCmdFlags(cmd *cobra.Command) []string {
+	flags := []string{}
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		// skip some
+		if flag.Name == "help" || flag.Name == "completion" {
+			return
+		}
+
+		flags = append(flags, "--"+flag.Name)
+	})
+
+	return flags
 }


### PR DESCRIPTION
- feat(repl): only suggest non-empty transition states
- feat(repl): use pseudo-unique IDs
- fix(repl): fix duplicated reconnects
- fix(rpc): fix REPL schemas
- fix(rpc): panic less

`v0.17.1` is all about the REPL, which should be faster to work with, thanks to smarter completion:
- only inactive or `Multi` states can be added
- `--arg` will complete names from typed args struct

Fixes #338.