### PR TITLE
fix(machine): dont call handlers of partially rejected auto states

### DIFF
--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -632,6 +632,7 @@ func (t *Transition) emitEvents() Result {
 			targetStates := m.resolver.TargetStates(t, toSet, m.StateNames())
 			t.TargetIndexes = m.Index(targetStates)
 			t.cacheTargetStates.Store(&targetStates)
+			t.setupExitEnter()
 			// TODO cache states before?
 		}
 


### PR DESCRIPTION
Rejecting in `FooEnter` for **Foo** being `Auto` would still call `FooState`. Fortunately using an expiration ctx mitigated most of side effects, but...