### PR TITLE
fix(machine): fix self handlers only triggered for called states

### DIFF
--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -931,13 +931,25 @@ func TestPartialAutoStatesByStateState(t *testing.T) {
 
 	// CB cancels
 	_ = m.BindHandlers(&struct {
-		CB HandlerNegotiation
+		CB     HandlerNegotiation
+		BState HandlerFinal
 	}{
-		CB: func(e *Event) bool { return false },
+		CB:     func(e *Event) bool { return false },
+		BState: func(e *Event) { t.Log("BState should not be called") },
 	})
 
-	// trigger auto
-	m.Add1("C", nil)
+	// trigger mut
+	go m.Add1("C", nil)
+	select {
+	case <-m.When(S{"C"}, nil):
+	case <-time.After(200 * time.Millisecond):
+	}
+	// wait for auto
+	select {
+	case <-m.WhenQueueEnds():
+	case <-time.After(200 * time.Millisecond):
+	}
+
 	assertStates(t, m, S{"C", "A"}, "only C and A auto state should be active")
 }
 
@@ -960,13 +972,66 @@ func TestPartialAutoStatesByEnter(t *testing.T) {
 	// BEnter cancels
 	_ = m.BindHandlers(&struct {
 		BEnter HandlerNegotiation
+		BState HandlerFinal
 	}{
 		BEnter: func(e *Event) bool { return false },
+		BState: func(e *Event) { t.Log("BState should not be called") },
 	})
 
-	// trigger auto
-	m.Add1("C", nil)
+	// trigger mut
+	go m.Add1("C", nil)
+	select {
+	case <-m.When(S{"C"}, nil):
+	case <-time.After(200 * time.Millisecond):
+	}
+	// wait for auto
+	select {
+	case <-m.WhenQueueEnds():
+	case <-time.After(200 * time.Millisecond):
+	}
+
 	assertStates(t, m, S{"C", "A"}, "only A auto state should be active")
+}
+
+func TestPartialAutoStatesBySelfHandler(t *testing.T) {
+	if os.Getenv(EnvAmTestDbgAddr) == "" {
+		t.Parallel()
+	}
+
+	enableDebugging()
+
+	// init
+	m := NewCustomStates(t, Schema{
+		"A": {Auto: true},
+		"B": {Auto: true},
+		"C": {},
+	})
+
+	// CB cancels
+	_ = m.BindHandlers(&struct {
+		CC     HandlerNegotiation
+		BState HandlerFinal
+	}{
+		// C rejects the 2nd auto tx
+		CC: func(e *Event) bool { return false },
+		BState: func(e *Event) {
+			t.Log("BState should not be called")
+		},
+	})
+
+	// trigger mut
+	go m.Add1("C", nil)
+	select {
+	case <-m.When(S{"C"}, nil):
+	case <-time.After(200 * time.Millisecond):
+	}
+	// wait for auto
+	select {
+	case <-m.WhenQueueEnds():
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	assertStates(t, m, S{"C"}, "only C, auto cancelled by CC")
 }
 
 // TestNegotiationRemove

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -403,6 +403,7 @@ func (t *Transition) emitSelfEvents() Result {
 			continue
 		}
 
+		autoState := t.cacheSchema[s].Auto
 		name := s + s
 		t.latestHandlerToState = s
 		ret, handlerCalled = m.handle(name, t.Mutation.Args, false, false, true)
@@ -412,7 +413,16 @@ func (t *Transition) emitSelfEvents() Result {
 			t.addSteps(step)
 		}
 		if ret == Canceled {
-			break
+			// partial auto state acceptance
+			if t.IsAuto() && autoState {
+				targetStates := t.TargetStates()
+				idx := slices.Index(targetStates, s)
+				t.TargetIndexes = slices.Delete(t.TargetIndexes, idx, idx+1)
+				targetStates = slices.Delete(targetStates, idx, idx+1)
+				t.cacheTargetStates.Store(&targetStates)
+			} else {
+				return ret
+			}
 		}
 	}
 
@@ -422,11 +432,12 @@ func (t *Transition) emitSelfEvents() Result {
 func (t *Transition) emitEnterEvents() Result {
 	for _, toState := range t.Enters {
 		args := t.Mutation.Args
+		autoState := t.cacheSchema[toState].Auto
 
 		// FooEnter
 		ret := t.emitHandler("", toState, false, true, toState+SuffixEnter, args)
 		if ret == Canceled {
-			if t.IsAuto() {
+			if t.IsAuto() && autoState {
 				// partial auto state acceptance
 				targetStates := t.TargetStates()
 				idx := slices.Index(targetStates, toState)
@@ -444,11 +455,14 @@ func (t *Transition) emitEnterEvents() Result {
 
 func (t *Transition) emitExitEvents() Result {
 	for _, fromState := range t.Exits {
+		args := t.Mutation.Args
+		autoState := t.cacheSchema[fromState].Auto
+
 		// FooExit
 		ret := t.emitHandler(fromState, "", false, false, fromState+SuffixExit,
-			t.Mutation.Args)
+			args)
 		if ret == Canceled {
-			if t.IsAuto() {
+			if t.IsAuto() && autoState {
 				// partial auto state acceptance
 				targetStates := t.TargetStates()
 				idx := slices.Index(targetStates, fromState)
@@ -524,6 +538,7 @@ func (t *Transition) emitStateStateEvents() Result {
 				continue
 			}
 
+			autoState := t.cacheSchema[after[ii]].Auto
 			handler := before[i] + after[ii]
 			t.latestHandlerToState = ""
 			ret, handlerCalled := t.Machine.handle(handler, t.Mutation.Args, false,
@@ -538,8 +553,8 @@ func (t *Transition) emitStateStateEvents() Result {
 				continue
 			}
 
-			// negotiation canceled
-			if t.IsAuto() {
+			// partial auto state acceptance
+			if t.IsAuto() && autoState {
 				if newAfter == nil {
 					newAfter = slices.Clone(after)
 				}
@@ -556,6 +571,7 @@ func (t *Transition) emitStateStateEvents() Result {
 				newAfter = slices.Delete(newAfter, idx, idx+1)
 				t.cacheTargetStates.Store(&newAfter)
 
+				// negotiation canceled
 			} else {
 				return ret
 			}


### PR DESCRIPTION
Till now `FooFoo` was triggered only for called states. Now it's for all active before and after, with the previous behavior being achievable via checking `Transition.CalledStates()`.