### PR TITLE
feat(rpc): add support for WebSocket clients and servers

### DIFF
--- a/pkg/rpc/mux.go
+++ b/pkg/rpc/mux.go
@@ -115,12 +115,15 @@ func (m *Mux) StartState(e *am.Event) {
 	addr := m.Addr
 	mach := m.Mach
 
+	// TODO websocket srv, RpcMuxState
+
 	// unblock
 	go func() {
 		if ctx.Err() != nil {
 			return // expired
 		}
-		// create a listener if not provided
+
+		// create a listener if not provided TODO websockets
 		if m.Listener == nil {
 			// use Start as the context
 			cfg := net.ListenConfig{}
@@ -146,7 +149,7 @@ func (m *Mux) StartState(e *am.Event) {
 
 		// fork
 		l := m.cmux.Match(cmux.Any())
-		go m.accept(l)
+		go m.accept(e, l)
 
 		// TODO healthcheck loop
 
@@ -183,7 +186,8 @@ func (m *Mux) HealthcheckState(e *am.Event) {
 
 // ///// ///// /////
 
-func (m *Mux) accept(l net.Listener) {
+// TODO RpcAcceptingState
+func (m *Mux) accept(e *am.Event, l net.Listener) {
 	mach := m.Mach
 	defer mach.PanicToErr(nil)
 
@@ -215,7 +219,7 @@ func (m *Mux) accept(l net.Listener) {
 		// new instance
 		var server *Server
 		if m.NewServerFn == nil {
-			server, err = NewServer(m.Mach.Ctx(), ":0",
+			server, err = NewServer(m.Mach.Context(), ":0",
 				m.Name+"-"+strconv.Itoa(int(num)), m.Source, &ServerOpts{
 					Parent:   m.Mach,
 					Args:     m.Args,
@@ -233,7 +237,7 @@ func (m *Mux) accept(l net.Listener) {
 
 		// inject net.Conn
 		server.Conn = conn
-		server.Start()
+		server.Start(e)
 
 		// TODO optimize: re-use old instances?
 		// TODO handle with a state, not a goroutine
@@ -242,17 +246,17 @@ func (m *Mux) accept(l net.Listener) {
 			muxCtx := m.Mach.NewStateCtx(ssM.Start)
 			<-server.Mach.When1(ssS.ClientConnected, muxCtx)
 			<-server.Mach.WhenNot1(ssS.ClientConnected, muxCtx)
-			server.Stop(true)
+			server.Stop(e, true)
 		}()
 	}
 }
 
-func (m *Mux) Start() am.Result {
-	return m.Mach.Add1(ssM.Start, nil)
+func (m *Mux) Start(e *am.Event) am.Result {
+	return m.Mach.EvAdd1(e, ssM.Start, nil)
 }
 
-func (m *Mux) Stop(dispose bool) am.Result {
-	res := m.Mach.Remove1(ssM.Start, nil)
+func (m *Mux) Stop(e *am.Event, dispose bool) am.Result {
+	res := m.Mach.EvRemove1(e, ssM.Start, nil)
 	if dispose {
 		m.Mach.Dispose()
 	}
@@ -269,7 +273,7 @@ func (m *Mux) log(msg string, args ...any) {
 
 // ///// ///// /////
 
-// ///// MUX
+// ///// MISC
 
 // ///// ///// /////
 
@@ -288,3 +292,31 @@ type MuxOpts struct {
 	// // See WsListenPath.
 	// WebSocketTunnel string
 }
+
+// WEBSOCKET
+
+// type wsHandlerMux struct {
+// 	m     *Mux
+// 	event *am.Event
+// }
+//
+// // ServeHTTP continues [Server.RpcStartingState].
+// func (h *wsHandlerMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// 	mach := h.m.Mach
+//
+// 	connWs, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+// 		// TODO security
+// 		InsecureSkipVerify: true,
+// 	})
+// 	if err != nil {
+// 		log.Printf("Upgrade error: %v", err)
+// 		return
+// 	}
+// 	conn := websocket.NetConn(mach.Context(), connWs, websocket.MessageBinary)
+//
+// 	// TODO RpcAcceptingState
+// 	// next and stay alive
+// 	mach.EvAdd1(h.event, ssM.RpcAccepting, nil)
+// 	<-mach.WhenNot1(ss.Start, nil)
+// 	print()
+// }

--- a/pkg/rpc/netmach.go
+++ b/pkg/rpc/netmach.go
@@ -25,6 +25,7 @@ type ClockUpdateFunc func(now am.Time, qTick uint64, machTick uint32)
 // It's meant to be (optionally) injected by whatever creates network machines,
 // so they can communicate with the server (or another source).
 type NetMachConn interface {
+	// TODO take event for tracing errors
 	Call(ctx context.Context, method ServerMethod, args any, resp any) bool
 	Notify(ctx context.Context, method ServerMethod, args any) bool
 }
@@ -111,7 +112,7 @@ type NetworkMachine struct {
 	filterMutations bool
 }
 
-var ssNS = states.NetSourceStates
+var ssNS = states.StateSourceStates
 
 var _ am.Api = &NetworkMachine{}
 
@@ -140,7 +141,7 @@ func NewNetworkMachine(
 
 		conn:            conn,
 		id:              id,
-		ctx:             parent.Ctx(),
+		ctx:             parent.Context(),
 		schema:          schema,
 		stateNames:      stateNames,
 		indexWhen:       am.IndexWhen{},
@@ -197,7 +198,7 @@ func (m *NetworkMachine) Add(states am.S, args am.A) am.Result {
 		States: amhelp.StatesToIndexes(m.StateNames(), states),
 		Args:   args,
 	}
-	if !m.conn.Call(m.Ctx(), ServerAdd, rpcArgs, resp) {
+	if !m.conn.Call(m.Context(), ServerAdd, rpcArgs, resp) {
 		return am.Canceled
 	}
 
@@ -233,7 +234,7 @@ func (m *NetworkMachine) AddNS(states am.S, args am.A) am.Result {
 		States: amhelp.StatesToIndexes(m.StateNames(), states),
 		Args:   args,
 	}
-	if !m.conn.Notify(m.Ctx(), ServerAddNS, rpcArgs) {
+	if !m.conn.Notify(m.Context(), ServerAddNS, rpcArgs) {
 		return am.Canceled
 	}
 
@@ -267,7 +268,7 @@ func (m *NetworkMachine) Remove(states am.S, args am.A) am.Result {
 		States: amhelp.StatesToIndexes(m.StateNames(), states),
 		Args:   args,
 	}
-	if !m.conn.Call(m.Ctx(), ServerRemove, rpcArgs, resp) {
+	if !m.conn.Call(m.Context(), ServerRemove, rpcArgs, resp) {
 		return am.Canceled
 	}
 
@@ -301,7 +302,7 @@ func (m *NetworkMachine) Set(states am.S, args am.A) am.Result {
 		States: amhelp.StatesToIndexes(m.StateNames(), states),
 		Args:   args,
 	}
-	if !m.conn.Call(m.Ctx(), ServerSet, rpcArgs, resp) {
+	if !m.conn.Call(m.Context(), ServerSet, rpcArgs, resp) {
 		return am.Canceled
 	}
 
@@ -364,7 +365,8 @@ func (m *NetworkMachine) EvAdd(
 		Args:   args,
 		Event:  event.Export(),
 	}
-	if !m.conn.Call(m.Ctx(), ServerAdd, rpcArgs, resp) {
+	// TODO pass event for tracing
+	if !m.conn.Call(m.Context(), ServerAdd, rpcArgs, resp) {
 		return am.Canceled
 	}
 
@@ -412,7 +414,7 @@ func (m *NetworkMachine) EvRemove(
 		Args:   args,
 		Event:  event.Export(),
 	}
-	if !m.conn.Call(m.Ctx(), ServerRemove, rpcArgs, resp) {
+	if !m.conn.Call(m.Context(), ServerRemove, rpcArgs, resp) {
 		return am.Canceled
 	}
 
@@ -874,7 +876,7 @@ func (m *NetworkMachine) Tick(state string) uint64 {
 }
 
 func (m *NetworkMachine) tick(state string) uint64 {
-	// TODO validate
+	m.MustParseStates(am.S{state})
 	return m.machClock[state]
 }
 
@@ -944,7 +946,7 @@ func (m *NetworkMachine) NewStateCtx(state string) context.Context {
 		State: state,
 		Tick:  m.machClock[state],
 	}
-	stateCtx, cancel := context.WithCancel(context.WithValue(m.Ctx(),
+	stateCtx, cancel := context.WithCancel(context.WithValue(m.Context(),
 		am.CtxKey, v))
 
 	// cancel early
@@ -984,7 +986,7 @@ func (m *NetworkMachine) StatesVerified() bool {
 }
 
 // Ctx return worker's root context.
-func (m *NetworkMachine) Ctx() context.Context {
+func (m *NetworkMachine) Context() context.Context {
 	return m.ctx
 }
 
@@ -1227,7 +1229,7 @@ func (m *NetworkMachine) Export() (*am.Serialized, am.Schema, error) {
 		StateNames:  m.StateNames(),
 		MachineTick: m.machTick,
 		QueueTick:   m.queueTick,
-	}, am.CloneSchema(m.schema), nil
+	}, am.SchemaClone(m.schema), nil
 }
 
 // Schema returns a copy of machine's state structure.

--- a/pkg/rpc/netmach_test.go
+++ b/pkg/rpc/netmach_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+
 	sst "github.com/pancsta/asyncmachine-go/internal/testing/states"
 	"github.com/pancsta/asyncmachine-go/internal/testing/utils"
 	amhelpt "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
@@ -33,7 +35,7 @@ func TestSingleStateActive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, nil)
+	m := utils.NewNoRelsNetSrc(t, nil, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -55,7 +57,7 @@ func TestMultipleStatesActive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, nil)
+	m := utils.NewNoRelsNetSrc(t, nil, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -78,7 +80,7 @@ func TestExposeAllStateNames(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, S{"A"})
+	m := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -98,7 +100,7 @@ func TestStateSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, S{"A"})
+	m := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -120,7 +122,7 @@ func TestStateAdd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, S{"A"})
+	m := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -142,7 +144,7 @@ func TestStateRemove(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, S{"B", "C"})
+	m := utils.NewNoRelsNetSrc(t, S{"B", "C"}, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 
 	// test
@@ -290,9 +292,12 @@ func disposeTest(t *testing.T, c *Client, s *Server, checkErrs bool) {
 		amhelpt.AssertNoErrEver(t, c.Mach)
 		amhelpt.AssertNoErrEver(t, s.Mach)
 	}
-	c.Stop(context.TODO(), true)
+	if os.Getenv(dbg.EnvAmDbgAddr) != "" {
+		time.Sleep(time.Second)
+	}
+	c.Stop(context.TODO(), nil, true)
 	<-c.Mach.WhenDisposed()
-	s.Stop(true)
+	s.Stop(nil, true)
 }
 
 func TestAddRelation(t *testing.T) {
@@ -533,7 +538,7 @@ func TestWhen2(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, nil)
+	mach := utils.NewNoRelsNetSrc(t, nil, "")
 
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
@@ -578,7 +583,7 @@ func TestWhenActive(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
 	w := c.NetMach
@@ -602,7 +607,7 @@ func TestWhenNot2(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"}, "")
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
 	w := c.NetMach
@@ -646,7 +651,7 @@ func TestWhenNotActive(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
 	w := c.NetMach
@@ -862,7 +867,7 @@ func TestWhenTime(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"}, "")
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
 	w := c.NetMach
@@ -1149,7 +1154,7 @@ func TestString(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A", "B"}, "")
 
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
@@ -1188,7 +1193,7 @@ func TestNestedMutation(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, nil)
+	mach := utils.NewNoRelsNetSrc(t, nil, "")
 	// bind handlers
 	err := mach.BindHandlers(&TestNestedMutationHandlers{})
 	assert.NoError(t, err)
@@ -1215,7 +1220,7 @@ func TestIsClock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, nil)
+	m := utils.NewNoRelsNetSrc(t, nil, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -1240,7 +1245,7 @@ func TestIsTime(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := utils.NewNoRelsNetSrc(t, nil)
+	m := utils.NewNoRelsNetSrc(t, nil, "")
 	_, _, s, c := NewTest(t, ctx, m, nil, 0, false, nil, nil)
 	w := c.NetMach
 
@@ -1317,7 +1322,7 @@ func TestWhenQueue(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, nil)
+	mach := utils.NewNoRelsNetSrc(t, nil, "")
 
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
@@ -1352,7 +1357,7 @@ func TestWhenQuery(t *testing.T) {
 	defer cancel()
 
 	// machine
-	mach := utils.NewNoRelsNetSrc(t, S{"A"})
+	mach := utils.NewNoRelsNetSrc(t, S{"A"}, "")
 
 	// worker
 	_, _, s, c := NewTest(t, ctx, mach, nil, 0, false, nil, nil)
@@ -1410,8 +1415,8 @@ func TestPipes(t *testing.T) {
 
 	// machine
 	ctx := context.Background()
-	netSrc := utils.NewNoRelsNetSrc(t, S{"A"})
-	local := utils.NewNoRels(t, nil, "-local")
+	netSrc := utils.NewNoRelsNetSrc(t, S{"A"}, "")
+	local := utils.NewNoRelsNetSrc(t, nil, "-local")
 	// amhelp.MachDebugEnv(local)
 
 	// connect

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -45,7 +46,12 @@ const (
 	// $AM_REPL_DIR/mach-id.addr. Optional.
 	EnvAmReplDir = "AM_REPL_DIR"
 
+	TagRpcHandler = "rpc-handler"
+	TagRpcClient  = "rpc-client"
+	TagRpcServer  = "rpc-server"
+
 	PrefixNetMach = "rnm-"
+	WsPathListen  = "/listen/"
 )
 
 var ss = states.SharedStates
@@ -220,10 +226,17 @@ type ReplOpts struct {
 	ErrCh chan<- error
 	// optional channel to send the address to, once ready
 	AddrCh chan<- string
-	// optional prefix for typesafe args. Requires Args.
-	ArgsPrefix string
-	// optional typed args instance. Requires ArgsPrefix
+	// optional typed args struct value
 	Args any
+	// optional RPC args parser
+	ParseRpc func(args am.A) am.A
+	// Listen on a WebSocket connection instead of TCP.
+	WebSocket bool
+	// HTTP URL without proto to tunnel the TCP listen over a WebSocket conn.
+	// See WsListenPath.
+	WebSocketTunnel string
+
+	// TODO accept Name
 }
 
 // ///// ///// /////
@@ -383,6 +396,10 @@ func AddErrNetwork(e *am.Event, mach *am.Machine, err error) {
 	mach.AddErrState(ss.ErrNetwork, err, nil)
 }
 
+func AddErrNetworkTimeout(e *am.Event, mach *am.Machine, err error) {
+	mach.AddErrState(ss.ErrNetworkTimeout, err, nil)
+}
+
 func AddErrNoConn(e *am.Event, mach *am.Machine, err error) {
 	err = fmt.Errorf("%w: %w", ErrNoConn, err)
 	mach.AddErrState(ss.ErrNetwork, err, nil)
@@ -451,6 +468,10 @@ type semLogger struct {
 var _ am.SemLogger = &semLogger{}
 
 func (s *semLogger) SetArgsMapper(mapper am.LogArgsMapperFn) {
+	// TODO
+}
+
+func (s *semLogger) SetArgsMapperDef(additional ...string) {
 	// TODO
 }
 
@@ -827,7 +848,7 @@ func (t *sourceTracer) SchemaChange(mach am.Api, oldSchema am.Schema) {
 		defer s.lockExport.Unlock()
 
 		// send
-		err := client.CallWithContext(mach.Ctx(), ClientSchemaChange.Value, msg,
+		err := client.CallWithContext(mach.Context(), ClientSchemaChange.Value, msg,
 			&MsgEmpty{})
 		mach.AddErr(err, nil)
 	}()
@@ -948,9 +969,19 @@ func (c *msgpackCoded) Close() error {
 
 // ///// ///// /////
 
+func EnableDebuggingRpc(stdout bool) {
+	amhelp.EnableDebugging(stdout)
+	_ = os.Setenv(EnvAmRpcLogClient, "1")
+	_ = os.Setenv(EnvAmRpcLogServer, "1")
+	_ = os.Setenv(EnvAmRpcLogMux, "1")
+}
+
 // MachReplEnv sets up a machine for a REPL connection in case AM_REPL_ADDR env
 // var is set. See MachRepl.
-func MachReplEnv(mach am.Api) (error, <-chan error) {
+func MachReplEnv(mach am.Api, opts *ReplOpts) (error, <-chan error) {
+	if opts == nil {
+		opts = &ReplOpts{}
+	}
 	addr := os.Getenv(EnvAmReplAddr)
 	dir := os.Getenv(EnvAmReplDir)
 
@@ -964,22 +995,27 @@ func MachReplEnv(mach am.Api) (error, <-chan error) {
 
 	// MachRepl closes errCh
 	errCh := make(chan error, 1)
-	opts := &ReplOpts{
-		AddrDir: dir,
-		ErrCh:   errCh,
+	opts2 := &ReplOpts{
+		AddrDir:  dir,
+		ErrCh:    errCh,
+		Args:     opts.Args,
+		ParseRpc: opts.ParseRpc,
 	}
-	if err := MachRepl(mach, addr, opts); err != nil {
-		return err, errCh
+	var err error
+	if runtime.GOOS == "wasm" {
+		err = MachReplWs(mach, addr, opts2)
+	} else {
+		err = MachRepl(mach, addr, opts2)
 	}
 
-	return nil, errCh
+	return err, errCh
 }
 
 // MachRepl sets up a machine for a REPL connection, which allows for
 // mutations, like any other RPC connection. See [/tools/cmd/arpc] for usage.
 // This function is considered a debugging helper and can panic.
 //
-// addr: address to listen on, default to 127.0.0.1:0
+// addr: address to listen on, defaults to 127.0.0.1:0
 // addrDir: optional dir path to save the address file as addrDir/mach-id.addr
 // addrCh: optional channel to send the address to, once ready
 // errCh: optional channel for errors
@@ -1001,7 +1037,7 @@ func MachRepl(mach am.Api, addr string, opts *ReplOpts) error {
 
 	if mach.HasHandlers() && !mach.Has(ssW.Names()) {
 		err := fmt.Errorf(
-			"%w: REPL source has to implement pkg/rpc/states/NetSourceStatesDef",
+			"%w: REPL source has to implement pkg/rpc/states/StateSourceStatesDef",
 			am.ErrSchema)
 
 		return err
@@ -1015,17 +1051,17 @@ func MachRepl(mach am.Api, addr string, opts *ReplOpts) error {
 		}
 	}
 
-	mux, err := NewMux(mach.Ctx(), "repl-"+mach.Id(), nil, &MuxOpts{
-		Parent:     mach,
-		Args:       opts.Args,
-		ArgsPrefix: opts.ArgsPrefix,
+	mux, err := NewMux(mach.Context(), "repl-"+mach.Id(), nil, &MuxOpts{
+		Parent:   mach,
+		Args:     opts.Args,
+		ParseRpc: opts.ParseRpc,
 	})
 	if err != nil {
 		return err
 	}
 	mux.Addr = addr
 	mux.Source = mach
-	mux.Start()
+	mux.Start(nil)
 
 	if addrCh == nil && addrDir == "" {
 		if errCh != nil {
@@ -1072,6 +1108,110 @@ func MachRepl(mach am.Api, addr string, opts *ReplOpts) error {
 			err = os.WriteFile(
 				filepath.Join(addrDir, mach.Id()+".addr"),
 				[]byte(mux.Addr), 0o644,
+			)
+			if errCh != nil {
+				errCh <- err
+			}
+		}
+	}()
+
+	return nil
+}
+
+// MachReplWs is a non-muxed REPL over WebSocket, See [MachRepl].
+func MachReplWs(mach am.Api, addr string, opts *ReplOpts) error {
+	if opts == nil {
+		opts = &ReplOpts{}
+	}
+	addrDir := opts.AddrDir
+	addrCh := opts.AddrCh
+	errCh := opts.ErrCh
+
+	if amhelp.IsTestRunner() {
+		return amhelp.ErrTestAutoDisable
+	}
+
+	if addr == "" {
+		addr = "127.0.0.1:0"
+	}
+
+	if mach.HasHandlers() && !mach.Has(ssW.Names()) {
+		err := fmt.Errorf(
+			"%w: REPL source has to implement pkg/rpc/states/StateSourceStatesDef",
+			am.ErrSchema)
+
+		return err
+	}
+
+	// verify args is a value struct
+	if opts.Args != nil {
+		t := reflect.TypeOf(opts.Args)
+		if t.Kind() != reflect.Struct {
+			return fmt.Errorf("expected a struct, got %s", t.Kind())
+		}
+	}
+
+	s, err := NewServer(mach.Context(), addr, "repl-"+mach.Id(), mach,
+		&ServerOpts{
+			Parent:          mach,
+			Args:            opts.Args,
+			ParseRpc:        opts.ParseRpc,
+			WebSocket:       opts.WebSocket,
+			WebSocketTunnel: opts.WebSocketTunnel,
+		})
+	if err != nil {
+		return err
+	}
+	s.Addr = addr
+	s.Source = mach
+	s.Start(nil)
+
+	if addrCh == nil && addrDir == "" {
+		if errCh != nil {
+			close(errCh)
+		}
+
+		return nil
+	}
+
+	go func() {
+		// dispose ret channels
+		defer func() {
+			if errCh != nil {
+				close(errCh)
+			}
+			if addrCh != nil {
+				close(addrCh)
+			}
+		}()
+
+		// prep the dir
+		dirOk := false
+		if addrDir != "" {
+			if _, err := os.Stat(addrDir); os.IsNotExist(err) {
+				err := os.MkdirAll(addrDir, 0o755)
+				if err == nil {
+					dirOk = true
+				} else if errCh != nil {
+					errCh <- err
+				}
+			} else {
+				dirOk = true
+			}
+		}
+
+		// wait for an addr
+		<-s.Mach.When1(ssS.Ready, nil)
+		if addrCh != nil {
+			addrCh <- s.Addr
+		}
+
+		// save to dir
+		if dirOk && addrDir != "" {
+			err = os.WriteFile(
+				filepath.Join(addrDir, mach.Id()+".addr"),
+				// add / HTTP path suffix (mark as WS)
+				[]byte(s.Addr+"/"), 0o644,
 			)
 			if errCh != nil {
 				errCh <- err
@@ -1155,4 +1295,10 @@ func newClosedChan() chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
 	return ch
+}
+
+// WsListenPath creates a WebSocket remote listen URL path.
+// Eg /listen/MyMach/localhost:1234
+func WsListenPath(machId, addr string) string {
+	return WsPathListen + machId + "/" + addr
 }

--- a/pkg/rpc/rpc_client.go
+++ b/pkg/rpc/rpc_client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/rpc2"
+	"github.com/coder/websocket"
 
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 
@@ -54,6 +55,9 @@ type Client struct {
 	// ReconnectOn decides if the client will try to [RetryingConn] after a
 	// clean [Disconnect].
 	ReconnectOn bool
+	// Custom connection (wg WebSocket)
+	Conn net.Conn
+	Opts ClientOpts
 
 	// sync settings (read-only)
 
@@ -74,30 +78,30 @@ type Client struct {
 	// ConnTimeout is the maximum time to wait for a connection to be established.
 	// Default 3s.
 	ConnTimeout time.Duration
-	// ConnRetries is the number of retries for a connection. Default 15.
+	// ConnRetries is the number of retries for a connection.
 	ConnRetries int
-	// ConnRetryTimeout is the maximum time to retry a connection. Default 1m.
+	// ConnRetryTimeout is the maximum time to retry a connection.
 	ConnRetryTimeout time.Duration
-	// ConnRetryDelay is the time to wait between retries. Default 100ms. If
-	// ConnRetryBackoff is set, this is the initial delay, and doubles on each
+	// ConnRetryDelay is the time to wait between retries. If
+	// ConnRetryBackoff is set, this is the initial delay and doubles on each
 	// retry.
 	ConnRetryDelay time.Duration
-	// ConnRetryBackoff is the maximum time to wait between retries. Default 3s.
+	// ConnRetryBackoff is the maximum time to wait between retries.
 	ConnRetryBackoff time.Duration
 
 	// failsafe - calls (writable when stopped)
 
-	// CallTimeout is the maximum time to wait for a call to complete. Default 3s.
+	// CallTimeout is the maximum time to wait for a call to complete.
 	CallTimeout time.Duration
-	// CallRetries is the number of retries for a call. Default 15.
+	// CallRetries is the number of retries for a call.
 	CallRetries int
-	// CallRetryTimeout is the maximum time to retry a call. Default 1m.
+	// CallRetryTimeout is the maximum time to retry a call.
 	CallRetryTimeout time.Duration
-	// CallRetryDelay is the time to wait between retries. Default 100ms. If
-	// CallRetryBackoff is set, this is the initial delay, and doubles on each
+	// CallRetryDelay is the time to wait between retries. If
+	// CallRetryBackoff is set, this is the initial delay and doubles on each
 	// retry.
 	CallRetryDelay time.Duration
-	// CallRetryBackoff is the maximum time to wait between retries. Default 3s.
+	// CallRetryBackoff is the maximum time to wait between retries.
 	CallRetryBackoff time.Duration
 	DisconnTimeout   time.Duration
 
@@ -111,7 +115,6 @@ type Client struct {
 	rpc      atomic.Pointer[rpc2.Client]
 	// schema of the network machine
 	schema am.Schema
-	conn   net.Conn
 	// tmpTestErr is an error to return on the next call or notify, only for
 	// testing.
 	tmpTestErr error
@@ -122,6 +125,7 @@ type Client struct {
 	trackedStates  am.S
 	// tracked idx -> machine idx
 	trackedStateIdxs []int
+	// connect via WebSocket
 }
 
 // interfaces
@@ -132,7 +136,7 @@ var (
 
 // NewClient creates a new RPC client and exposes a remote state machine as
 // a remote worker, with a subst of the API under Client.NetMach. Optionally
-// takes a consumer, which is a state machine with a WorkerPayload state. See
+// takes a consumer, which is a state machine with a ServerPayload state. See
 // states.ConsumerStates.
 func NewClient(
 	ctx context.Context, netSrcAddr string, name string, netSrcSchema am.Schema,
@@ -148,10 +152,13 @@ func NewClient(
 	if !opts.NoSchema && netSrcSchema == nil {
 		netSrcSchema = am.Schema{}
 	}
+	if amhelp.IsWasm() {
+		opts.WebSocket = "/"
+	}
 
 	// validate
 	if netSrcAddr == "" {
-		return nil, errors.New("rpcc: workerAddr required")
+		return nil, errors.New("rpcc: netSrcAddr required")
 	}
 
 	c := &Client{
@@ -164,6 +171,7 @@ func NewClient(
 		DisconnTimeout:   3 * time.Second,
 		DisconnCooldown:  10 * time.Millisecond,
 		ReconnectOn:      true,
+		Opts:             *opts,
 
 		SyncNoSchema:          opts.NoSchema,
 		SyncAllowedStates:     opts.AllowedStates,
@@ -172,27 +180,23 @@ func NewClient(
 		SyncShallowClocks:     opts.SyncShallowClocks,
 		SyncMutationFiltering: opts.MutationFiltering,
 
-		ConnRetryTimeout: 1 * time.Minute,
-		ConnRetries:      15,
-		ConnRetryDelay:   100 * time.Millisecond,
-		ConnRetryBackoff: 3 * time.Second,
+		ConnRetryTimeout: 5 * time.Minute,
+		ConnRetries:      50,
+		ConnRetryDelay:   time.Second,
+		ConnRetryBackoff: 10 * time.Second,
 
 		CallRetryTimeout: 1 * time.Minute,
 		CallRetries:      15,
 		CallRetryDelay:   100 * time.Millisecond,
-		CallRetryBackoff: 3 * time.Second,
+		CallRetryBackoff: 10 * time.Second,
 
-		schema: am.CloneSchema(netSrcSchema),
-	}
-
-	if amhelp.IsDebug() {
-		c.CallTimeout = 100 * time.Second
+		schema: am.SchemaClone(netSrcSchema),
 	}
 
 	// state machine
 	mach, err := am.NewCommon(ctx, GetClientId(name), states.ClientSchema,
 		ssC.Names(), c, opts.Parent, &am.Opts{Tags: []string{
-			"rpc-client",
+			TagRpcClient,
 			"addr:" + netSrcAddr,
 		}})
 	if err != nil {
@@ -219,6 +223,11 @@ func NewClient(
 			return nil, err
 		}
 		c.Consumer = opts.Consumer
+	}
+
+	if amhelp.IsDebug() {
+		c.log("debug enabled, increasing some timeouts")
+		c.CallTimeout = 10 * c.CallTimeout
 	}
 
 	return c, nil
@@ -266,45 +275,57 @@ func (c *Client) StartEnd(e *am.Event) {
 }
 
 func (c *Client) ConnectingState(e *am.Event) {
-	ctx := c.Mach.NewStateCtx(ssC.Connecting)
+	mach := c.Mach
+	ctx := mach.NewStateCtx(ssC.Connecting)
+	ctxStart := mach.NewStateCtx(ssC.Start)
 
 	// async
-	go func() {
-		if ctx.Err() != nil {
-			return // expired
-		}
-
-		// net dial
+	mach.Fork(ctx, e, func() {
+		// net dial TODO TLS
 		timeout := c.ConnTimeout
 		if amhelp.IsDebug() {
 			timeout = 100 * time.Second
 		}
-		// TODO TLS
-		d := net.Dialer{
-			Timeout: timeout,
+		if c.Conn == nil && c.Opts.WebSocket != "" {
+			mach.Log("dialing WS %s", c.Addr)
+			wsConn, _, err := websocket.Dial(ctx,
+				"ws://"+c.Addr+c.Opts.WebSocket, nil)
+			if err != nil {
+				mach.EvAdd1(e, ssC.Disconnected, nil)
+				AddErrNetwork(e, mach, err)
+				return
+			}
+			c.Conn = websocket.NetConn(ctxStart, wsConn, websocket.MessageBinary)
+
+		} else if c.Conn == nil {
+			d := net.Dialer{
+				Timeout: timeout,
+			}
+			mach.Log("dialing TCP %s", c.Addr)
+			conn, err := d.DialContext(ctx, "tcp4", c.Addr)
+			if ctx.Err() != nil {
+				return // expired
+			}
+			if err != nil {
+				mach.EvAdd1(e, ssC.Disconnected, nil)
+				AddErrNetwork(e, mach, err)
+				return
+			}
+			c.Conn = conn
 		}
-		c.Mach.Log("dialing %s", c.Addr)
-		conn, err := d.DialContext(ctx, "tcp4", c.Addr)
-		if ctx.Err() != nil {
-			return // expired
-		}
-		if err != nil {
-			c.Mach.EvAdd1(e, ssC.Disconnected, nil)
-			AddErrNetwork(e, c.Mach, err)
-			return
-		}
-		c.conn = conn
 
 		// rpc
-		client := c.bindRpcHandlers(conn)
-		go client.Run()
-
-		c.Mach.EvAdd1(e, ssC.Connected, nil)
-	}()
+		client := c.bindRpcHandlers(c.Conn)
+		mach.Go(ctx, func() {
+			go mach.EvAdd1(e, ssC.Connected, nil)
+			// block
+			client.Run()
+		})
+	})
 }
 
 func (c *Client) DisconnectingEnter(e *am.Event) bool {
-	return c.rpc.Load() != nil && c.conn != nil
+	return c.rpc.Load() != nil && c.Conn != nil
 }
 
 func (c *Client) DisconnectingState(e *am.Event) {
@@ -354,6 +375,10 @@ func (c *Client) ConnectedState(e *am.Event) {
 
 	// loop
 	go func() {
+		if ctx.Err() != nil {
+			return // expired
+		}
+
 		select {
 
 		case <-ctx.Done():
@@ -372,6 +397,8 @@ func (c *Client) DisconnectedEnter(e *am.Event) bool {
 }
 
 func (c *Client) DisconnectedState(e *am.Event) {
+	c.Conn = nil
+
 	// try to reconnect
 	wasAny := e.Transition().TimeBefore.Any1
 	if wasAny(c.Mach.Index1(ssC.Connected), c.Mach.Index1(ssC.Connecting)) &&
@@ -382,8 +409,8 @@ func (c *Client) DisconnectedState(e *am.Event) {
 	}
 
 	// ignore error when disconnecting
-	if c.conn != nil {
-		_ = c.conn.Close()
+	if c.Conn != nil {
+		_ = c.Conn.Close()
 	}
 }
 
@@ -464,11 +491,6 @@ func (c *Client) HandshakingState(e *am.Event) {
 		// set schema and states
 		c.updateStatesSchema(resp)
 
-		// optional env debug on 1st call
-		if c.Mach.Tick(ssC.Handshaking) == 1 && os.Getenv(EnvAmRpcDbg) != "" {
-			_ = amhelp.MachDebugEnv(c.NetMach)
-		}
-
 		// ID as tag TODO find-n-replace the tag, not via index [1]
 		c.NetMach.tags[1] = "src-id:" + resp.Serialized.ID
 		// TODO setter
@@ -502,6 +524,11 @@ func (c *Client) HandshakeDoneState(e *am.Event) {
 	netMach.id = PrefixNetMach + c.Name
 	c.clockSet(args.MachTime, args.QueueTick, args.MachTick)
 
+	// optional env debug on 1st call
+	if c.Mach.Tick(ssC.HandshakeDone) == 1 && os.Getenv(EnvAmRpcDbg) != "" {
+		_ = amhelp.MachDebugEnv(c.NetMach)
+	}
+
 	c.log("connected to %s", netMach.remoteId)
 	c.log("time t%d q%d: %v",
 		netMach.Time(nil).Sum(nil), netMach.QueueTick(), args.MachTime)
@@ -523,12 +550,10 @@ func (c *Client) ExceptionState(e *am.Event) {
 	// call super
 	c.ExceptionHandler.ExceptionState(e)
 	c.Mach.EvRemove1(e, am.StateException, nil)
-	// TODO handle am.ErrSchema:
-	//  "worker has to implement pkg/rpc/states/NetSourceStatesDef"
-	//  only for nondeterministic machs
 }
 
-// RetryingConnState should be set without Connecting in the same tx
+// RetryingConnState should be set without [ssC.Connecting] in the same
+// mutation.
 func (c *Client) RetryingConnState(e *am.Event) {
 	ctx := c.Mach.NewStateCtx(ssC.RetryingConn)
 	delay := c.ConnRetryDelay
@@ -567,6 +592,7 @@ func (c *Client) RetryingConnState(e *am.Event) {
 				}
 			}
 
+			// timeout
 			if c.ConnRetryTimeout > 0 && time.Since(start) > c.ConnRetryTimeout {
 				break
 			}
@@ -581,7 +607,7 @@ func (c *Client) RetryingConnState(e *am.Event) {
 	}()
 }
 
-func (c *Client) WorkerPayloadEnter(e *am.Event) bool {
+func (c *Client) ServerPayloadEnter(e *am.Event) bool {
 	if c.Consumer == nil {
 		return false
 	}
@@ -598,14 +624,14 @@ func (c *Client) WorkerPayloadEnter(e *am.Event) bool {
 	return true
 }
 
-func (c *Client) WorkerPayloadState(e *am.Event) {
+func (c *Client) ServerPayloadState(e *am.Event) {
 	args := ParseArgs(e.Args)
 	argsOut := &A{
 		Name:    args.Name,
 		Payload: args.Payload,
 	}
 
-	c.Consumer.EvAdd1(e, ssCo.WorkerPayload, Pass(argsOut))
+	c.Consumer.EvAdd1(e, ssCo.ServerPayload, Pass(argsOut))
 }
 
 func (c *Client) HealthcheckState(e *am.Event) {
@@ -621,21 +647,26 @@ func (c *Client) HealthcheckState(e *am.Event) {
 
 // Start connects the client to the server and initializes the worker.
 // Results in the Ready state.
-func (c *Client) Start() am.Result {
-	return c.Mach.Add(am.S{ssC.Start, ssC.Connecting}, nil)
+func (c *Client) Start(e *am.Event) am.Result {
+	return c.Mach.EvAdd(e, am.S{ssC.Start, ssC.Connecting}, nil)
 }
 
 // Stop disconnects the client from the server and disposes the worker.
 //
 // waitTillExit: if passed, waits for the client to disconnect using the
 // context.
-func (c *Client) Stop(waitTillExit context.Context, dispose bool) am.Result {
-	res := c.Mach.Remove1(ssC.Start, nil)
+func (c *Client) Stop(
+	waitTillExit context.Context, e *am.Event, dispose bool,
+) am.Result {
+	res := c.Mach.EvAdd1(e, ssC.Disconnecting, nil)
 	// wait for the client to disconnect
 	if res != am.Canceled && waitTillExit != nil {
 		// TODO timeout config
-		_ = amhelp.WaitForAll(waitTillExit, 2*time.Second,
-			c.Mach.When1(ssC.Disconnected, nil))
+		err := amhelp.WaitForAll(waitTillExit, 2*time.Second,
+			c.Mach.When1(ssC.Disconnected, waitTillExit))
+		if err != nil {
+			c.Mach.EvRemove1(e, ssC.Start, nil)
+		}
 	}
 
 	if dispose {
@@ -667,7 +698,7 @@ func (c *Client) Sync() am.Time {
 
 	// call rpc
 	resp := &MsgSrvSync{}
-	ok := c.callFailsafe(c.Mach.Ctx(), ServerSync.Value, &MsgEmpty{}, resp)
+	ok := c.callFailsafe(c.Mach.Context(), ServerSync.Value, &MsgEmpty{}, resp)
 	if !ok {
 		return nil
 	}
@@ -691,7 +722,7 @@ func (c *Client) Args() []string {
 
 	// call rpc
 	resp := &MsgSrvArgs{}
-	ok := c.callFailsafe(c.Mach.Ctx(), ServerArgs.Value, &MsgEmpty{}, resp)
+	ok := c.callFailsafe(c.Mach.Context(), ServerArgs.Value, &MsgEmpty{}, resp)
 	if !ok {
 		return nil
 	}
@@ -1099,7 +1130,7 @@ func (c *Client) notify(
 	mName := ServerMethods.Parse(method).Value
 
 	// timeout
-	err := c.conn.SetDeadline(time.Now().Add(c.CallTimeout))
+	err := c.Conn.SetDeadline(time.Now().Add(c.CallTimeout))
 	if err != nil {
 		AddErr(nil, c.Mach, mName, err)
 		return false
@@ -1119,7 +1150,7 @@ func (c *Client) notify(
 	}
 
 	// remove timeout
-	err = c.conn.SetDeadline(time.Time{})
+	err = c.Conn.SetDeadline(time.Time{})
 	if err != nil {
 		AddErr(nil, c.Mach, mName, err)
 		return false
@@ -1179,7 +1210,7 @@ func (c *Client) RemoteSendingPayload(
 ) error {
 	// TODO test
 	c.log("RemoteSendingPayload %s", payload.Name)
-	c.Mach.Add1(ssC.WorkerDelivering, Pass(&A{
+	c.Mach.Add1(ssC.ServerDelivering, Pass(&A{
 		Payload: payload,
 		Name:    payload.Name,
 	}))
@@ -1188,13 +1219,13 @@ func (c *Client) RemoteSendingPayload(
 }
 
 // RemoteSendPayload receives a payload from the server and triggers
-// WorkerPayload. The Consumer should bind his handlers and handle this state to
-// receive the data.
+// [states.ClientStatesDef.ServerPayload]. The Consumer should bind his
+// handlers and handle this state to receive the data.
 func (c *Client) RemoteSendPayload(
 	_ *rpc2.Client, payload *MsgSrvPayload, _ *MsgEmpty,
 ) error {
 	c.log("RemoteSendPayload %s:%s", payload.Name, payload.Token)
-	c.Mach.Add1(ssC.WorkerPayload, Pass(&A{
+	c.Mach.Add1(ssC.ServerPayload, Pass(&A{
 		Payload: payload,
 		Name:    payload.Name,
 	}))
@@ -1248,6 +1279,8 @@ type ClientOpts struct {
 	// based on locally active states. Doesn't work with [ClientOpts.NoSchema].
 	// TODO not implemented yet
 	MutationFiltering bool
+	// Connect via WebSocket using path, eg "/" (default for WASM).
+	WebSocket string
 }
 
 // GetClientId returns an RPC Client machine ID from a name. This ID will be

--- a/pkg/rpc/rpc_server.go
+++ b/pkg/rpc/rpc_server.go
@@ -5,7 +5,9 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
+	"net/http"
 	"os"
 	"reflect"
 	"slices"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/rpc2"
+	"github.com/coder/websocket"
 
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
@@ -24,7 +27,7 @@ import (
 
 var (
 	ssS = states.ServerStates
-	ssW = states.NetSourceStates
+	ssW = states.StateSourceStates
 )
 
 // Server is an RPC server that can be bound to a worker machine and provide
@@ -37,17 +40,14 @@ type Server struct {
 	Source am.Api
 	// Addr is the address of the server on the network.
 	Addr string
-	// DeliveryTimeout is a timeout for SendPayload to the client.
+	// DeliveryTimeout is a timeout to SendPayload to the client.
 	DeliveryTimeout time.Duration
 	// Listener can be set manually before starting the server.
 	Listener atomic.Pointer[net.Listener]
-	// Conn can be set manually before starting the server.
-	Conn net.Conn
-	// NoNewListener will prevent the server from creating a new listener if
-	// one is not provided or has been closed. Useful for cmux.
-	NoNewListener bool
-	LogEnabled    bool
-	CallCount     uint64
+	// Conn can be set manually before starting the server. TODO atomic?
+	Conn       net.Conn
+	LogEnabled bool
+	CallCount  uint64
 	// Typed arguments struct value with defaults
 	Args any
 	Opts ServerOpts
@@ -59,6 +59,25 @@ type Server struct {
 	// 0 means pushes are disabled. Setting to a very small value will make
 	// pushes instant.
 	PushInterval atomic.Pointer[time.Duration]
+	// AllowId will limit clients to a specific ID, if set.
+	AllowId string
+
+	// failsafe - connection (writable when stopped)
+
+	// WsTunConnTimeout is the maximum time to wait for a WebSocket tunnel
+	// connection to be established.
+	WsTunConnTimeout time.Duration
+	// WsTunConnRetries is the number of retries for a connection.
+	WsTunConnRetries int
+	// WsTunConnRetryTimeout is the maximum time to retry a connection.
+	WsTunConnRetryTimeout time.Duration
+	// WsTunConnRetryDelay is the time to wait between retries. If
+	// WsTunConnRetryBackoff is set, this is the initial delay and doubles on each
+	// retry.
+	WsTunConnRetryDelay time.Duration
+	// WsTunConnRetryBackoff is the maximum time to wait between retries.
+	WsTunConnRetryBackoff time.Duration
+
 	// syncMutations will push all clock changes for each mutation, enabling
 	// client-side mutation filtering.
 	syncMutations     bool
@@ -68,9 +87,6 @@ type Server struct {
 	syncShallowClocks bool
 
 	// security
-
-	// AllowId will limit clients to a specific ID, if set.
-	AllowId string
 
 	// internal
 
@@ -93,6 +109,9 @@ type Server struct {
 	deliveryHandlers any
 	lastPush         time.Time
 	lastPushData     *tracerData
+	httpSrv          *http.Server
+	wsTunRetryRound  atomic.Int32
+	wsConn           *websocket.Conn
 }
 
 // interfaces
@@ -102,19 +121,28 @@ var (
 )
 
 // NewServer creates a new RPC server, bound to a worker machine.
-// The source machine has to implement [states.NetSourceStatesDef] interface.
+// The source machine has to implement [states.StateSourceStatesDef] interface.
 func NewServer(
 	ctx context.Context, addr string, name string, netSrcMach am.Api,
 	opts *ServerOpts,
 ) (*Server, error) {
+	// TODO SPLIT
+
 	if name == "" {
 		name = "rpc"
 	}
 	if opts == nil {
 		opts = &ServerOpts{}
 	}
+	// TODO WASM auto-tunnel
+	if opts.WebSocketTunnel != "" && addr == "" {
+		return nil, fmt.Errorf("addr required for WebSocketTunnel")
+	}
 
 	// check the source
+	if netSrcMach == nil {
+		return nil, fmt.Errorf("netSrcMach required")
+	}
 	if !netSrcMach.StatesVerified() {
 		return nil, fmt.Errorf(
 			"net source states not verified, call VerifyStates()")
@@ -124,7 +152,7 @@ func NewServer(
 		// error only when some handlers bound, skip deterministic machines
 		err := fmt.Errorf(
 			"%w: NetSourceMach with handlers has to implement "+
-				"pkg/rpc/states/NetSourceStatesDef",
+				"pkg/rpc/states/StateSourceStatesDef",
 			am.ErrSchema)
 
 		return nil, err
@@ -139,7 +167,13 @@ func NewServer(
 		LogEnabled:       os.Getenv(EnvAmRpcLogServer) != "",
 		Source:           netSrcMach,
 		Args:             opts.Args,
-		ArgsPrefix:       opts.ArgsPrefix,
+		Opts:             *opts,
+
+		WsTunConnTimeout:      3 * time.Second,
+		WsTunConnRetryTimeout: 5 * time.Minute,
+		WsTunConnRetries:      50,
+		WsTunConnRetryDelay:   time.Second,
+		WsTunConnRetryBackoff: 10 * time.Second,
 
 		lastPushData: &tracerData{},
 	}
@@ -148,7 +182,9 @@ func NewServer(
 
 	// state machine
 	mach, err := am.NewCommon(ctx, "rs-"+name, states.ServerSchema, ssS.Names(),
-		s, opts.Parent, &am.Opts{Tags: []string{"rpc-server"}})
+		s, opts.Parent, &am.Opts{
+			Tags: []string{TagRpcServer},
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -167,6 +203,11 @@ func NewServer(
 	// optional env debug
 	if os.Getenv(EnvAmRpcDbg) != "" {
 		_ = amhelp.MachDebugEnv(mach)
+	}
+
+	// states
+	if opts.WebSocketTunnel != "" {
+		mach.Add1(ssS.WebSocketTunnel, nil)
 	}
 
 	// bind to source via Tracer API (inactive until activated)
@@ -215,6 +256,16 @@ func NewServer(
 		})
 	}
 
+	// longer timeouts
+	if amhelp.IsDebug() {
+		s.log("debug, extending timeouts")
+		s.WsTunConnRetryTimeout *= 10
+	}
+
+	// debug
+	// mach.AddBreakpoint1("", ssS.RpcReady, true)
+	// mach.AddBreakpoint1("", ssS.RpcReady, false)
+
 	return s, nil
 }
 
@@ -224,17 +275,79 @@ func NewServer(
 
 // ///// ///// /////
 
+func (s *Server) ExceptionState(e *am.Event) {
+	// call super
+	s.ExceptionHandler.ExceptionState(e)
+
+	// WebsocketTunnel
+	if s.Mach.Is1(ssS.WebSocketTunnel) {
+		// clean up on errs
+		if s.wsConn != nil {
+			_ = s.wsConn.Close(websocket.StatusInternalError, "")
+		}
+		if s.Conn != nil {
+			_ = s.Conn.Close()
+		}
+
+		// retry?
+		add, _ := e.Transition().TimeIndexDiff()
+		shouldRetry := s.wsTunRetryRound.Load() < int32(s.WsTunConnRetries)
+		if add.Is1(ssS.ErrNetwork) && shouldRetry {
+			s.log("WebSocket exception retry")
+			s.Mach.Remove1(ssS.Exception, nil)
+			s.Mach.Add1(ssS.RpcStarting, nil)
+		}
+	}
+}
+
+func (s *Server) StartState(e *am.Event) {
+	ctx := s.Mach.NewStateCtx(ssS.Start)
+
+	// start websocket server early
+	if s.Opts.WebSocket {
+		s.httpSrv = &http.Server{
+			Addr: s.Addr,
+			Handler: &wsHandlerServer{
+				s:     s,
+				event: e.Export(),
+			},
+		}
+
+		// fork2
+		go func() {
+			if ctx.Err() != nil {
+				return // expired
+			}
+
+			err := s.httpSrv.ListenAndServe()
+			if err != nil {
+				// add err to mach
+				AddErrNetwork(e, s.Mach, err)
+				// add outcome to mach
+				s.Mach.Remove1(ssS.RpcStarting, nil)
+
+				return
+			}
+		}()
+	}
+}
+
 func (s *Server) StartEnd(e *am.Event) {
+	if s.Opts.WebSocket {
+		go func() {
+			_ = s.httpSrv.Shutdown(s.Mach.Context())
+		}()
+	} else if s.Mach.Is1(ssS.WebSocketTunnel) && s.wsConn != nil {
+		_ = s.wsConn.Close(websocket.StatusNormalClosure, "")
+	}
 	if ParseArgs(e.Args).Dispose {
 		s.Mach.Dispose()
 	}
 }
 
 func (s *Server) RpcStartingEnter(e *am.Event) bool {
-	if s.Listener.Load() == nil && s.NoNewListener {
-		return false
-	}
-	if s.Addr == "" {
+	// check listening
+	if s.Addr == "" && s.Listener.Load() == nil && s.Conn == nil {
 		return false
 	}
 
@@ -242,24 +355,104 @@ func (s *Server) RpcStartingEnter(e *am.Event) bool {
 }
 
 func (s *Server) RpcStartingState(e *am.Event) {
-	ctxRpcStarting := s.Mach.NewStateCtx(ssS.RpcStarting)
 	ctxStart := s.Mach.NewStateCtx(ssS.Start)
 	s.log("Starting RPC on %s", s.Addr)
 	s.bindRpcHandlers()
-	srv := s.rpcServer
 
-	// unblock
+	// skip for websocket server
+	if s.Opts.WebSocket {
+		return
+	}
+
+	// fork1 TODO mach.Fork
 	go func() {
-		// has to be ctxStart, not ctxRpcStarting TODO why?
+		// has to be ctxStart, not ctxRpcStarting TODO why? reconns?
 		if ctxStart.Err() != nil {
 			return // expired
 		}
 
-		if s.Conn != nil {
+		// websocket listener (HTTP)
+		if s.Opts.WebSocketTunnel != "" {
+			addr := "ws://" + s.Addr + s.Opts.WebSocketTunnel
+			delay := s.WsTunConnRetryDelay
+			start := time.Now()
+
+			// TODO WsTunConnectingState
+			// go func() {
+			// retry loop
+			for ctxStart.Err() == nil &&
+				s.wsTunRetryRound.Load() < int32(s.WsTunConnRetries) {
+
+				// wait for time or exit
+				s.wsTunRetryRound.Add(1)
+				if !amhelp.Wait(ctxStart, delay) {
+					return // expired
+				}
+
+				// dial
+				ctxWs, cancel := context.WithTimeout(ctxStart, s.WsTunConnTimeout)
+				// ctxWs, _ := context.WithTimeout(ctxStart, s.WsTunConnTimeout)
+				s.log("Dialing (round %d) %s", s.wsTunRetryRound.Load(), addr)
+				ws, _, err := websocket.Dial(ctxWs, addr, nil)
+				if err != nil {
+					s.log("WebSocket err")
+					if ctxStart.Err() == nil && ctxWs.Err() != nil {
+						AddErrNetworkTimeout(e, s.Mach, err)
+					} else {
+						AddErrNetwork(e, s.Mach, err)
+					}
+
+				} else {
+					s.log("WebSocket OK")
+					s.wsConn = ws
+					if err != nil {
+						AddErrNetwork(e, s.Mach, err)
+					} else {
+						s.log("Tunnel OK")
+						s.Conn = websocket.NetConn(ctxStart, ws, websocket.MessageBinary)
+						// reset the retry counter
+						s.wsTunRetryRound.Store(0)
+					}
+					cancel()
+					break
+				}
+				cancel()
+
+				// double the delay when backoff set
+				if s.WsTunConnRetryBackoff > 0 {
+					delay *= 2
+					if delay > s.WsTunConnRetryBackoff {
+						delay = s.WsTunConnRetryBackoff
+					}
+				}
+
+				// last try?
+				if t := s.WsTunConnRetryTimeout; t > 0 && time.Since(start) > t {
+					s.log("WebSocket RetryTimeout")
+					break
+				}
+
+				// try again
+			}
+
+			// failed?
+			if s.Conn == nil {
+				s.log("WebSocket tunnel failure")
+				s.Mach.EvRemove1(e, ssS.RpcStarting, nil)
+				return
+			}
+
+			// existing connection
+		} else if s.Conn != nil {
+			s.log("Using existing connection %s", s.Conn.LocalAddr())
 			s.Addr = s.Conn.LocalAddr().String()
+
+			// existing listener
 		} else if l := s.Listener.Load(); l != nil {
 			// update Addr from listener (support for external and :0)
 			s.Addr = (*l).Addr().String()
+
+			// new listener
 		} else {
 			// create a listener if not provided
 			// use Start as the context
@@ -269,7 +462,7 @@ func (s *Server) RpcStartingState(e *am.Event) {
 				// add err to mach
 				AddErrNetwork(e, s.Mach, err)
 				// add outcome to mach
-				s.Mach.Remove1(ssS.RpcStarting, nil)
+				s.Mach.EvRemove1(e, ssS.RpcStarting, nil)
 
 				return
 			}
@@ -279,29 +472,54 @@ func (s *Server) RpcStartingState(e *am.Event) {
 			s.Addr = lis.Addr().String()
 		}
 
-		s.log("RPC started on %s", s.Addr)
+		// next
+		s.Mach.EvAdd1(e, ssS.RpcAccepting, nil)
+	}()
+}
 
-		// fork to accept
+func (s *Server) RpcAcceptingEnter(e *am.Event) bool {
+	return s.Listener.Load() != nil || s.Conn != nil
+}
+
+func (s *Server) RpcAcceptingState(e *am.Event) {
+	ctxRpcAccepting := s.Mach.NewStateCtx(ssS.RpcAccepting)
+	ctxStart := s.Mach.NewStateCtx(ssS.Start)
+	srv := s.rpcServer
+
+	s.log("RPC started on %s", s.Addr)
+
+	// unblock
+	go func() {
+		if ctxRpcAccepting.Err() != nil {
+			return // expired
+		}
+
+		// fork to accept TODO state?
 		go func() {
-			if ctxRpcStarting.Err() != nil {
+			if ctxRpcAccepting.Err() != nil {
 				return // expired
 			}
 			s.Mach.EvAdd1(e, ssS.RpcReady, Pass(&A{Addr: s.Addr}))
 
 			// accept (block)
-			lisP := s.Listener.Load()
+			lis := s.Listener.Load()
 			if s.Conn != nil {
 				srv.ServeConn(s.Conn)
+			} else if lis != nil {
+				srv.Accept(*lis)
 			} else {
-				srv.Accept(*lisP)
+				AddErrNetwork(e, s.Mach, fmt.Errorf("no listener"))
+				s.Mach.EvRemove1(e, ssS.RpcReady, nil)
+
+				return
 			}
 			if ctxStart.Err() != nil {
 				return // expired
 			}
 
 			// clean up
-			if lisP != nil {
-				(*lisP).Close()
+			if lis != nil {
+				(*lis).Close()
 				s.Listener.Store(nil)
 			}
 			if ctxStart.Err() != nil {
@@ -310,12 +528,13 @@ func (s *Server) RpcStartingState(e *am.Event) {
 
 			// restart on failed listener
 			if s.Mach.Is1(ssS.Start) {
+				s.log("restarting on failed listener")
 				s.Mach.EvRemove1(e, ssS.RpcReady, nil)
 				s.Mach.EvAdd1(e, ssS.RpcStarting, nil)
 			}
 		}()
 
-		// bind to client events
+		// bind to RPC server events (or override)
 		srv.OnDisconnect(func(client *rpc2.Client) {
 			s.Mach.EvRemove1(e, ssS.ClientConnected, Pass(&A{Client: client}))
 		})
@@ -326,12 +545,16 @@ func (s *Server) RpcStartingState(e *am.Event) {
 }
 
 func (s *Server) RpcReadyEnter(e *am.Event) bool {
-	// only from RpcStarting
-	return s.Mach.Is1(ssS.RpcStarting)
+	// only from RpcAccepting
+	return s.Mach.Is1(ssS.RpcAccepting)
 }
 
 // RpcReadyState starts a ticker to compensate for clock push debounces.
 func (s *Server) RpcReadyState(e *am.Event) {
+	if s.Opts.WebSocketTunnel != "" {
+		s.log("ws tunnel ok: %s", s.Opts.WebSocketTunnel)
+	}
+
 	// no ticker for instant clocks
 	if *s.PushInterval.Load() == 0 {
 		return
@@ -381,30 +604,29 @@ func (s *Server) HandshakeDoneEnd(e *am.Event) {
 
 // Start starts the server, optionally creating a Listener (if Addr provided).
 // Results in either RpcReady or Exception.
-func (s *Server) Start() am.Result {
-	return s.Mach.Add1(ssS.Start, nil)
+func (s *Server) Start(e *am.Event) am.Result {
+	return s.Mach.EvAdd1(e, ssS.Start, nil)
 }
 
 // Stop stops the server, and optionally disposes resources.
-func (s *Server) Stop(dispose bool) am.Result {
+func (s *Server) Stop(e *am.Event, dispose bool) am.Result {
+	// TODO waitTillCtx?
 	if s.Mach == nil {
 		return am.Canceled
 	}
 	if dispose {
 		s.log("disposing")
 	}
-	// TODO use Disposing
-	res := s.Mach.Remove1(ssS.Start, Pass(&A{
-		Dispose: dispose,
-	}))
+	amhelp.DisposeEv(s.Mach, e)
 
-	return res
+	return am.Executed
 }
 
-// SendPayload sends a payload to the client. It's usually called by a handler
-// for SendPayload. [event] is optional.
+// SendPayload sends a payload to the client.
+//
+// srcEvent: optional event for tracing.
 func (s *Server) SendPayload(
-	ctx context.Context, event *am.Event, payload *MsgSrvPayload,
+	ctx context.Context, srcEvent *am.Event, payload *MsgSrvPayload,
 ) error {
 	// TODO add SendPayloadAsync calling RemoteSendingPayload first
 	// TODO bind to an async state
@@ -422,9 +644,9 @@ func (s *Server) SendPayload(
 	defer s.Mach.PanicToErr(nil)
 
 	payload.Token = utils.RandId(0)
-	if event != nil {
-		payload.Source = event.MachineId
-		payload.SourceTx = event.TransitionId
+	if srcEvent != nil {
+		payload.Source = srcEvent.MachineId
+		payload.SourceTx = srcEvent.TransitionId
 	}
 	s.log("sending payload %s from %s to %s", payload.Name, payload.Source,
 		payload.Destination)
@@ -458,6 +680,9 @@ func (s *Server) log(msg string, args ...any) {
 func (s *Server) bindRpcHandlers() {
 	// new RPC instance, release prev resources
 	s.rpcServer = rpc2.NewServer()
+	if os.Getenv(EnvAmRpcLogServer) != "" {
+		rpc2.DebugLog = true
+	}
 
 	s.rpcServer.Handle(ServerHello.Value, s.RemoteHello)
 	s.rpcServer.Handle(ServerHandshake.Value, s.RemoteHandshake)
@@ -873,10 +1098,10 @@ func (s *Server) RemoteArgs(
 	if s.Mach.Not1(ssS.Start) {
 		return am.ErrCanceled
 	}
-	s.Mach.Add1(ssS.MetricSync, nil)
 
 	// args TODO cache
 	if s.Args != nil {
+		// TODO use JSON field names
 		args, err := utils.StructFields(s.Args)
 		if err != nil {
 			return err
@@ -928,10 +1153,12 @@ func (s *Server) RemoteBye(
 
 // ///// ///// /////
 
-// BindServer binds RpcReady and ClientConnected with Add/Remove, to custom
+// BindServer binds RpcReady and HandshakeDone with Add/Remove, to custom
 // states.
-func BindServer(source, target *am.Machine, rpcReady, clientConn string) error {
-	if rpcReady == "" || clientConn == "" {
+func BindServer(
+	source, target *am.Machine, rpcReady, clientReady string,
+) error {
+	if rpcReady == "" || clientReady == "" {
 		return fmt.Errorf("rpcReady and clientConn must be set")
 	}
 
@@ -946,9 +1173,9 @@ func BindServer(source, target *am.Machine, rpcReady, clientConn string) error {
 		RpcReadyEnd:   ampipe.Remove(source, target, ssS.RpcReady, rpcReady),
 
 		HandshakeDoneState: ampipe.Add(source, target, ssS.ClientConnected,
-			clientConn),
+			clientReady),
 		HandshakeDoneEnd: ampipe.Remove(source, target, ssS.ClientConnected,
-			clientConn),
+			clientReady),
 	}
 
 	return source.BindHandlers(h)
@@ -1193,4 +1420,34 @@ func genShallowUpdate(
 	}
 
 	return indexes, ticks
+}
+
+// WEBSOCKET SERVER (not tunnel)
+
+type wsHandlerServer struct {
+	s     *Server
+	event *am.Event
+}
+
+// ServeHTTP continues [Server.RpcStartingState].
+func (h *wsHandlerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	mach := h.s.Mach
+
+	connWs, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// TODO security
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		log.Printf("Upgrade error: %v", err)
+		return
+	}
+	conn := websocket.NetConn(mach.Context(), connWs, websocket.MessageBinary)
+	h.s.Conn = conn
+
+	// next and stay alive
+	mach.EvAdd1(h.event, ssS.RpcAccepting, nil)
+	select {
+	case <-mach.WhenNot1(ss.Start, nil):
+	case <-r.Context().Done():
+	}
 }

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+
 	sst "github.com/pancsta/asyncmachine-go/internal/testing/states"
 	"github.com/pancsta/asyncmachine-go/internal/testing/utils"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	amhelpt "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 )
 
 func init() {
@@ -27,9 +28,6 @@ func init() {
 
 	if os.Getenv(am.EnvAmTestDebug) != "" {
 		amhelp.EnableDebugging(true)
-		_ = os.Setenv(EnvAmRpcLogClient, "1")
-		_ = os.Setenv(EnvAmRpcLogServer, "1")
-		_ = os.Setenv(EnvAmRpcLogMux, "1")
 	}
 }
 
@@ -44,11 +42,11 @@ func TestBasic(t *testing.T) {
 	defer cancel()
 
 	// init worker
-	schema := am.SchemaMerge(ssrpc.NetSourceSchema, am.Schema{
+	schema := am.SchemaMerge(ssrpc.StateSourceSchema, am.Schema{
 		"Foo": {},
 		"Bar": {Require: am.S{"Foo"}},
 	})
-	names := am.SAdd(ssrpc.NetSourceStates.Names(), am.S{"Foo", "Bar"})
+	names := am.SAdd(ssrpc.StateSourceStates.Names(), am.S{"Foo", "Bar"})
 	netSrc := am.New(ctx, schema, &am.Opts{Id: "ns-" + t.Name()})
 	err := netSrc.VerifyStates(names)
 	if err != nil {
@@ -87,7 +85,7 @@ func TestTypeSafe(t *testing.T) {
 	}
 
 	// read env
-	amDbgAddr := os.Getenv(telemetry.EnvAmDbgAddr)
+	amDbgAddr := os.Getenv(dbg.EnvAmDbgAddr)
 	logLvl := am.EnvLogLevel("")
 
 	// config
@@ -308,8 +306,8 @@ func TestManyStates(t *testing.T) {
 	end := make(chan struct{})
 
 	// reuse the net src and add many rand states
-	schema := am.SchemaMerge(ssrpc.NetSourceSchema, sst.States)
-	names := am.SAdd(ssrpc.NetSourceStates.Names(), sst.Names)
+	schema := am.SchemaMerge(ssrpc.StateSourceSchema, sst.States)
+	names := am.SAdd(ssrpc.StateSourceStates.Names(), sst.Names)
 	randAmount := 100
 	for i := 0; i < randAmount; i++ {
 		n := fmt.Sprintf("State%d", i)
@@ -484,7 +482,7 @@ func TestRetryConn(t *testing.T) {
 	if os.Getenv(am.EnvAmTestDbgAddr) == "" {
 		t.Parallel()
 	}
-	// amhelp.EnableDebugging(true)
+	// EnableDebuggingRpc(true)
 
 	// config
 	ctx, cancel := context.WithCancel(context.Background())
@@ -500,12 +498,12 @@ func TestRetryConn(t *testing.T) {
 	go func() {
 		// wait for client to reconnect and then start the server
 		<-c.Mach.WhenTime1(ssC.Connecting, 3, nil)
-		s.Start()
+		s.Start(nil)
 	}()
 
 	// client ready
-	c.Start()
-	amhelpt.WaitForAll(t, "client-server Ready", ctx, 3*time.Second,
+	c.Start(nil)
+	amhelpt.WaitForAll(t, "client-server Ready", ctx, 5*time.Second,
 		c.Mach.When1(ssC.Ready, ctx),
 		s.Mach.When1(ssS.Ready, ctx))
 
@@ -641,8 +639,8 @@ type TestPayloadConsumer struct {
 	delivered bool
 }
 
-func (c *TestPayloadConsumer) WorkerPayloadState(e *am.Event) {
-	e.Machine().Remove1(ssCo.WorkerPayload, nil)
+func (c *TestPayloadConsumer) ServerPayloadState(e *am.Event) {
+	e.Machine().Remove1(ssCo.ServerPayload, nil)
 
 	args := ParseArgs(e.Args)
 	assert.Equal(c.t, "TestPayload", args.Name)
@@ -670,19 +668,19 @@ func TestPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// worker
-	worker := utils.NewNoRelsNetSrc(t, nil)
-	err = worker.BindHandlers(&TestPayloadHandlers{})
+	// source mach
+	source := utils.NewNoRelsNetSrc(t, nil, "")
+	err = source.BindHandlers(&TestPayloadHandlers{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// init RPC
-	_, _, s, c := NewTest(t, ctx, worker, nil, 0, false, &ClientOpts{
+	_, _, s, c := NewTest(t, ctx, source, nil, 0, false, &ClientOpts{
 		Consumer: consMach,
 	}, nil)
 
-	whenDelivered := consMach.When1(ssCo.WorkerPayload, nil)
+	whenDelivered := consMach.When1(ssCo.ServerPayload, nil)
 	// Consumer requests a payload from the remote worker
 	c.NetMach.Add1(sst.C, PassRpc(&A{Name: "TestPayload"}))
 	// Consumer waits for WorkerDelivered
@@ -759,7 +757,7 @@ func TestMux(t *testing.T) {
 	}
 	amhelpt.MachDebugEnv(t, mux.Mach)
 	mux.Listener = listener
-	mux.Start()
+	mux.Start(nil)
 	amhelpt.WaitForAll(t, "mux Ready", ctx, 2*time.Second,
 		mux.Mach.When1(ssM.Ready, nil))
 
@@ -770,7 +768,7 @@ func TestMux(t *testing.T) {
 	// connect 10 clients to the worker
 	for i := 0; i < numClients; i++ {
 		c := newC(i)
-		c.Start()
+		c.Start(nil)
 		clients = append(clients, c)
 		netMachs = append(netMachs, c.NetMach)
 		clientsApi = append(clientsApi, c.Mach)
@@ -811,7 +809,7 @@ func TestPartial(t *testing.T) {
 	defer cancel()
 
 	// net source mach with non-zero clocks
-	source := utils.NewNoRelsNetSrc(t, nil)
+	source := utils.NewNoRelsNetSrc(t, nil, "")
 	source.Add1(sst.C, nil)
 	source.Remove1(sst.C, nil)
 
@@ -1152,7 +1150,7 @@ func NewTest(t *testing.T, ctx context.Context, netSrc *am.Machine,
 		<-s.Mach.WhenDisposed()
 		<-c.Mach.WhenDisposed()
 		// cool off am-dbg and free the ports
-		if os.Getenv(telemetry.EnvAmDbgAddr) != "" {
+		if os.Getenv(dbg.EnvAmDbgAddr) != "" {
 			time.Sleep(100 * time.Millisecond)
 		}
 	})
@@ -1162,12 +1160,12 @@ func NewTest(t *testing.T, ctx context.Context, netSrc *am.Machine,
 	}
 
 	// server start
-	s.Start()
+	s.Start(nil)
 	amhelpt.WaitForAll(t, "RpcReady", ctx, 3*time.Second,
 		s.Mach.When1(ssS.RpcReady, ctx))
 
 	// client ready
-	c.Start()
+	c.Start(nil)
 	amhelpt.WaitForAll(t, "client-server Ready", ctx, 3*time.Second,
 		c.Mach.When1(ssC.Ready, ctx),
 		s.Mach.When1(ssS.Ready, ctx))

--- a/pkg/rpc/states/ss_rpc.go
+++ b/pkg/rpc/states/ss_rpc.go
@@ -14,6 +14,7 @@ import (
 
 // SharedStatesDef contains all the states of the Shared state machine.
 type SharedStatesDef struct {
+	*am.StatesBase
 
 	// errors
 
@@ -28,6 +29,8 @@ type SharedStatesDef struct {
 
 	// inherit from BasicStatesDef
 	*states.BasicStatesDef
+	// inherit from rpc/StateSourceStatesDef
+	*StateSourceStatesDef
 }
 
 // SharedGroupsDef contains all the state groups of the Shared state machine.
@@ -37,25 +40,20 @@ type SharedGroupsDef struct {
 	Handshake S
 }
 
-// SharedSchema represents all relations and properties of NetSourceStates.
+// SharedSchema represents all relations and properties of StateSourceStates.
 var SharedSchema = SchemaMerge(
 	// inherit from BasicStruct
 	states.BasicSchema,
+	// inherit from rpc/WorkerSchema
+	StateSourceSchema,
 	am.Schema{
 
 		// Errors
-		s.ErrNetworkTimeout: {
-			Add:     S{s.Exception},
-			Require: S{s.Exception},
-		},
-		s.ErrRpc: {
-			Add:     S{s.Exception},
-			Require: S{s.Exception},
-		},
-		s.ErrDelivery: {
-			Add:     S{s.Exception},
-			Require: S{s.Exception},
-		},
+		// ErrNetwork is nota Multi (needs handling)
+		s.ErrNetwork:        {Require: S{s.Exception}},
+		s.ErrNetworkTimeout: {Require: S{s.Exception}},
+		s.ErrRpc:            {Require: S{s.Exception}},
+		s.ErrDelivery:       {Require: S{s.Exception}},
 
 		// Handshake
 		s.Handshaking: {
@@ -71,10 +69,10 @@ var SharedSchema = SchemaMerge(
 // EXPORTS AND GROUPS
 
 var (
-	// ws is worker states from SharedStatesDef.
+	// s is shared states from SharedStatesDef.
 	s = am.NewStates(SharedStatesDef{})
 
-	// wg is worker groups from SharedGroupsDef.
+	// g is shared groups from SharedGroupsDef.
 	g = am.NewStateGroups(SharedGroupsDef{
 		Handshake: S{s.Handshaking, s.HandshakeDone},
 	})
@@ -88,13 +86,13 @@ var (
 
 // ///// ///// /////
 
-// ///// NETWORK SOURCE
+// ///// STATE SOURCE
 
 // ///// ///// /////
 
-// NetSourceStatesDef contains all the states of the Network Source state
+// StateSourceStatesDef contains all the states of the Network Source state
 // machine.
-type NetSourceStatesDef struct {
+type StateSourceStatesDef struct {
 	*am.StatesBase
 
 	// errors
@@ -114,29 +112,30 @@ type NetSourceStatesDef struct {
 	SendPayload string
 }
 
-// NetSourceSchema represents all relations and properties of NetSourceStates.
-var NetSourceSchema = SchemaMerge(
+// StateSourceSchema represents all relations and properties of
+// [StateSourceStates].
+var StateSourceSchema = SchemaMerge(
 	am.Schema{
 
 		// errors
 
-		ssNS.ErrOnClient:    {Require: S{Exception}},
-		ssNS.ErrProviding:   {Require: S{Exception}},
-		ssNS.ErrSendPayload: {Require: S{Exception}},
+		ssSS.ErrOnClient:    {Require: S{Exception}},
+		ssSS.ErrProviding:   {Require: S{Exception}},
+		ssSS.ErrSendPayload: {Require: S{Exception}},
 
 		// RPC getter
 
-		ssNS.SendPayload: {Multi: true},
+		ssSS.SendPayload: {Multi: true},
 	})
 
 // EXPORTS AND GROUPS
 
 var (
-	// ssNS are states from NetSourceStatesDef.
-	ssNS = am.NewStates(NetSourceStatesDef{})
+	// ssSS are states from [StateSourceStatesDef].
+	ssSS = am.NewStates(StateSourceStatesDef{})
 
-	// NetSourceStates contains all the states for the Network Source machine.
-	NetSourceStates = ssNS
+	// StateSourceStates contains all the states for the Network Source machine.
+	StateSourceStates = ssSS
 )
 
 // ///// ///// /////
@@ -147,6 +146,7 @@ var (
 
 // ServerStatesDef contains all the states of the Client state machine.
 type ServerStatesDef struct {
+	*am.StatesBase
 
 	// basics
 
@@ -155,19 +155,26 @@ type ServerStatesDef struct {
 
 	// rpc
 
+	// Starting listening
 	RpcStarting string
-	RpcReady    string
+	// setting up RPC accepting
+	RpcAccepting string
+	// RPC is accepting or has accepted connections
+	RpcReady string
 
 	// TODO failsafe
 	// RetryingCall    string
 	// CallRetryFailed string
 
+	// RPC client connected (technically)
 	ClientConnected string
-	// overrides shared HandshakeDone
+	// RPC client fully ysable
 	HandshakeDone string
 
 	// How many times the client requested a full sync.
 	MetricSync string
+	// TCP tunneled over websocket
+	WebSocketTunnel string
 
 	// inherit from SharedStatesDef
 	*SharedStatesDef
@@ -213,17 +220,20 @@ var ServerSchema = SchemaMerge(
 			Require: S{ssS.Start},
 			Remove:  sgS.Rpc,
 		},
+		ssS.RpcAccepting: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
 		ssS.RpcReady: {
 			Require: S{ssS.Start},
 			Remove:  sgS.Rpc,
 		},
-
 		ssS.ClientConnected: {
 			Require: S{ssS.RpcReady},
 		},
-		// TODO ClientBye for graceful shutdowns
 
-		ssS.MetricSync: {Multi: true},
+		ssS.MetricSync:      {Multi: true},
+		ssS.WebSocketTunnel: {},
 	})
 
 // EXPORTS AND GROUPS
@@ -232,7 +242,7 @@ var (
 	ssS = am.NewStates(ServerStatesDef{})
 	sgS = am.NewStateGroups(ServerGroupsDef{
 		// TODO remove 2-state group?
-		Rpc: S{ssS.RpcStarting, ssS.RpcReady},
+		Rpc: S{ssS.RpcStarting, ssS.RpcAccepting, ssS.RpcReady},
 	}, SharedGroups)
 
 	// ServerStates contains all the states for the Client machine.
@@ -263,18 +273,18 @@ type ClientStatesDef struct {
 
 	// local overrides
 
-	// Ready indicates the remote worker is ready to be used.
+	// Ready indicates the remote source (worker) is ready to be used.
 	Ready         string
 	HandshakeDone string
 
 	// worker delivers
 
-	// WorkerDelivering is an optional indication that the server has started a
+	// ServerDelivering is an optional indication that the server has started a
 	// data transmission to the Client.
-	WorkerDelivering string
-	// WorkPayload allows the Consumer to bind his handlers and receive data
-	// from the Client.
-	WorkerPayload string
+	ServerDelivering string
+	// ServerPayload allows the Consumer to bind his handlers and receive data
+	// from the Server via the Client.
+	ServerPayload string
 
 	// How many times the client requested a full sync.
 	MetricSync string
@@ -298,6 +308,7 @@ var ClientSchema = SchemaMerge(
 	SharedSchema,
 	// inherit from ConnectedStruct
 	states.ConnectedSchema,
+
 	am.Schema{
 
 		// Try to RetryingConn on ErrNetwork.
@@ -349,11 +360,11 @@ var ClientSchema = SchemaMerge(
 
 		// worker delivers
 
-		ssC.WorkerDelivering: {
+		ssC.ServerDelivering: {
 			Multi:   true,
 			Require: S{ssC.Connected},
 		},
-		ssC.WorkerPayload: {
+		ssC.ServerPayload: {
 			Multi:   true,
 			Require: S{ssC.Connected},
 		},
@@ -449,18 +460,18 @@ type ConsumerStatesDef struct {
 	*am.StatesBase
 	Exception string
 
-	// WorkerPayload RPC server delivers the requested payload to the Client.
-	WorkerPayload string
+	// ServerPayload RPC server delivers the requested payload to the Client.
+	ServerPayload string
 }
 
 // ConsumerSchema represents all relations and properties of ConsumerStates.
 var ConsumerSchema = am.Schema{
-	ssCo.WorkerPayload: {Multi: true},
+	ssCo.ServerPayload: {Multi: true},
 }
 
 // ConsumerHandlers is the required interface for Consumer's state handlers.
 type ConsumerHandlers interface {
-	WorkerPayloadState(e *am.Event)
+	ServerPayloadState(e *am.Event)
 }
 
 // EXPORTS AND GROUPS


### PR DESCRIPTION
The highlight of `v0.18.0` - WebAssembly support. It's now possible to control async state machines **in**-and-**from** the browser. For that, the aRPC server is now also a WebSocket-tunnel client with auto-reconnect logic. Muxing still come...

More info in the dedicated [/examples/wasm/README.md](https://github.com/pancsta/asyncmachine-go/blob/main/examples/wasm/README.md).

![example-wasm d2 dark](https://github.com/user-attachments/assets/05d80dd0-8c06-4865-8720-c9a2aa10baf7)
