### PR TITLE
feat(am-dbg): add `--output-tx` to output current tx in MD and diagrams

### DIFF
--- a/tools/debugger/dbg_handlers.go
+++ b/tools/debugger/dbg_handlers.go
@@ -1702,9 +1702,38 @@ func (d *Debugger) hSetCursor1(e *am.Event, args am.A) {
 		}
 
 		// tx file
-		if d.Opts.OutputTx {
+		if d.Opts.OutputTx && tx != nil {
 			index := d.C.MsgStruct.StatesIndex
-			_, _ = d.txListFile.WriteAt([]byte(tx.TxString(index)), 0)
+			_ = d.txFileMd.Truncate(0)
+			_ = d.txFileD2.Truncate(0)
+			_ = d.txFileD2Svg.Truncate(0)
+			_ = d.txFileMermaid.Truncate(0)
+			_ = d.txFileMermaidAscii.Truncate(0)
+			_, _ = d.txFileMd.WriteAt([]byte(tx.TxString(index)), 0)
+
+			// TODO move to diagrams state
+			if tx.Steps != nil {
+				visTx := visualizer.Transition{Tx: tx}
+
+				// D2
+				d2Diag, d2Svg, err := visTx.D2(d.Mach.Context(),
+					amhelp.MachToSlog(d.Mach), index)
+				_, _ = d.txFileD2.WriteAt([]byte(d2Diag), 0)
+				if err != nil {
+					d.Mach.Log(err.Error())
+				} else {
+					_, _ = d.txFileD2Svg.WriteAt([]byte(d2Svg), 0)
+				}
+
+				// mermaid
+				mermaid, ascii, err := visTx.Mermaid(index)
+				_, _ = d.txFileMermaid.WriteAt([]byte(mermaid), 0)
+				if err != nil {
+					d.Mach.AddErr(err, nil)
+				} else {
+					_, _ = d.txFileMermaidAscii.WriteAt([]byte(ascii), 0)
+				}
+			}
 		}
 	}
 

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -121,17 +121,21 @@ type Debugger struct {
 	tagsBar         *cview.TextView
 	clip            clipper.Clipboard
 	// toolbarItems is a list of row of toolbars items
-	toolbarItems     [][]toolbarItem
-	clientListFile   *os.File
-	txListFile       *os.File
-	msgsDelayed      []*telemetry.DbgMsgTx
-	msgsDelayedConns []string
-	currTxBar        *cview.Flex
-	nextTxBar        *cview.Flex
-	mainGridCols     []int
-	readerExpanded   map[string]bool
-	treeGroups       *cview.DropDown
-	treeLayout       *cview.Flex
+	toolbarItems       [][]toolbarItem
+	clientListFile     *os.File
+	txFileMd           *os.File
+	txFileD2           *os.File
+	txFileD2Svg        *os.File
+	txFileMermaid      *os.File
+	txFileMermaidAscii *os.File
+	msgsDelayed        []*dbg.DbgMsgTx
+	msgsDelayedConns   []string
+	currTxBar          *cview.Flex
+	nextTxBar          *cview.Flex
+	mainGridCols       []int
+	readerExpanded     map[string]bool
+	treeGroups         *cview.DropDown
+	treeLayout         *cview.Flex
 	// list of states to show, bypassing other ones from the schema
 	schemaTreeStates  am.S
 	lastSelectedGroup string
@@ -262,8 +266,33 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 
 	// tx file
 	if d.Opts.OutputTx {
-		p := path.Join(d.Opts.OutputDir, "am-dbg-tx.md")
-		txListFile, err := os.Create(p)
+		p := path.Join(d.Opts.OutputDir, "tx.md")
+		txFile, err := os.Create(p)
+		if err != nil {
+			mach.AddErr(err, nil)
+		}
+		d.txFileMd = txFile
+
+		// D2
+		txD2File := path.Join(d.Opts.OutputDir, "tx.d2")
+		d.txFileD2, err = os.Create(txD2File)
+		if err != nil {
+			mach.AddErr(err, nil)
+		}
+		txD2SvgFile := path.Join(d.Opts.OutputDir, "tx.d2.svg")
+		d.txFileD2Svg, err = os.Create(txD2SvgFile)
+		if err != nil {
+			mach.AddErr(err, nil)
+		}
+
+		// mermaid
+		txMermaidFile := path.Join(d.Opts.OutputDir, "tx.mermaid")
+		d.txFileMermaid, err = os.Create(txMermaidFile)
+		if err != nil {
+			mach.AddErr(err, nil)
+		}
+		txMermaidAsciiFile := path.Join(d.Opts.OutputDir, "tx.mermaid.txt")
+		d.txFileMermaidAscii, err = os.Create(txMermaidAsciiFile)
 		if err != nil {
 			mach.AddErr(fmt.Errorf("tx list file open: %w", err), nil)
 		}


### PR DESCRIPTION
Detailed transition info is created in `--dir` in Markdown format, as well as various visualizations. This is useful for very large transitions (eg auto transitions).

```markdown
mach://cook/5064f50f92a8b17cc0a0043eac213284
2026-02-21T12:01:27.251627709Z

[add] CharacterReady
- called **CharacterReady**
- activate **CharacterReady**
- **DBReady** require **Start**
- **SSHReady** require **UIMode**
- **WebRPCReady** require **UIMode**
- **CheckStories** require **Start**
- **WebHTTPReady** require **UIMode**
- **BrowserRPCReady** require **WebHTTPReady**
- **HistoryDBStarting** require **Start**
- **Msg** require **Start**
- **RestoreCharacter** require **DBReady**
- **WebConnected** require **WebHTTPReady**
- **WebSSHReady** require **SSHReady**
- **BaseDBReady** require **Start**
- **CharacterReady** remove **RestoreCharacter**
- deactivate **RestoreCharacter**
- **RestoreCharacter** remove **CharacterReady**
- **DBReady** require **Start**
- **SSHReady** require **UIMode**
- **WebRPCReady** require **UIMode**
- **CheckStories** require **Start**
- **WebHTTPReady** require **UIMode**
- **BrowserRPCReady** require **WebHTTPReady**
- **HistoryDBStarting** require **Start**
- **Msg** require **Start**
- **WebConnected** require **WebHTTPReady**
- **WebSSHReady** require **SSHReady**
- **BaseDBReady** require **Start**
- handler **CharacterReady**Enter
- handler **CharacterReady**State
- handler **Any**State
```