### PR TITLE
docs(examples): add WASM example with REPL

### DIFF
--- a/examples/wasm/Taskfile.yml
+++ b/examples/wasm/Taskfile.yml
@@ -1,0 +1,55 @@
+version: '3'
+
+dotenv:
+  - .env
+
+vars:
+  PKG: "github.com/pancsta/asyncmachine-go/examples/wasm"
+
+tasks:
+  build:
+    desc: Development build
+    env:
+      GOOS: js
+      GOARCH: wasm
+    cmds:
+      - cp $(go env GOROOT)/lib/wasm/wasm_exec.js ./client
+      - go build -o client/main.wasm ./client
+
+  start:
+    desc: Build and start server
+    silent: true
+    deps:
+      - build
+    cmds:
+      - rm tmp/*.addr
+      - echo "Open http://{{.RELAY_HTTP_ADDR}}"
+      - echo ""
+      - go run ./server
+
+  repl:
+    desc: Start REPL for both server and browser
+    dir: ../../
+    cmd: task arpc -- --dir examples/wasm/tmp
+
+  pprof: go tool pprof -http=:8081 http://localhost:6060/debug/pprof/profile?seconds=10
+
+  build-prod:
+    desc: Optimized build
+    env:
+      GOOS: js
+      GOARCH: wasm
+    cmds:
+      - go build -ldflags="-s -w" -o client/prod.wasm ./client
+      - wasm-opt -O3 client/prod.wasm -o client/prod.wasm --enable-bulk-memory-opt
+
+  deps-graph:
+    desc: Render dependencies graph in deps-graph.svg
+    cmd: godepgraph -tags "wasm,js" -s . | dot -Tsvg -o deps-graph.svg
+
+  deps:
+    desc: List dependencies in deps.md
+    cmd: go list -deps 
+      -f '{{ "{{" }}.ImportPath{{ "}}" }} {{ "{{" }}.Imports{{ "}}" }}'
+      -tags wasm,js ./client 
+        > deps.md

--- a/examples/wasm/client/index.html
+++ b/examples/wasm/client/index.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+  <script src="wasm_exec.js"></script>
+  <script>
+      function onDomReady(callback) {
+          if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', callback);
+          } else {
+              callback();
+          }
+      }
+
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+          onDomReady(() => {
+              go.run(result.instance);
+          })
+      });
+  </script>
+  <style>
+      .inline-pre {
+          font-family: monospace;
+          white-space: pre;
+      }
+      body {
+          background-color: black;
+          color: white;
+      }
+  </style>
+</head>
+<body>
+
+<h1>asyncmachine-go WASM demo</h1>
+<p>See <span class="inline-pre">README.md</span> for the list of commands.</p>
+<input id="input" type="text" placeholder="msg input">
+<ul id="list"></ul>
+
+</body>
+</html>

--- a/examples/wasm/client/wasm_client.go
+++ b/examples/wasm/client/wasm_client.go
@@ -1,0 +1,149 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"honnef.co/go/js/dom/v2"
+
+	example "github.com/pancsta/asyncmachine-go/examples/wasm"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// DOM
+
+	uiList := dom.GetWindow().Document().QuerySelector("#list")
+	uiDoc := dom.GetWindow().Document()
+	uiInput := dom.GetWindow().Document().QuerySelector("#input")
+
+	// handlers
+
+	barHandlers := &BarHandlers{
+		uiDoc:   uiDoc,
+		uiList:  uiList,
+		uiInput: uiInput.(*dom.HTMLInputElement),
+	}
+	fooHandlers := &FooHandlers{
+		uiDoc:  uiDoc,
+		uiList: uiList,
+	}
+
+	// machines
+
+	barMach, fooClient, fooHandMach := initMachines(ctx, barHandlers, fooHandlers)
+	barHandlers.rpcFoo = fooClient
+	barHandlers.machBar = barMach
+	barHandlers.machFooHand = fooHandMach
+	fooHandlers.rpcFoo = fooClient
+	fooHandlers.machBar = barMach
+	fooHandlers.machFooHand = fooHandMach
+
+	// wait
+	select {}
+}
+
+//
+
+// Server machine handlers
+
+//
+
+type FooHandlers struct {
+	uiDoc  dom.Document
+	uiList dom.Element
+
+	rpcFoo      *arpc.Client
+	machBar     *am.Machine
+	machFooHand *am.Machine
+}
+
+func (h *FooHandlers) BoredState(e *am.Event) {
+	log.Printf("foo is bored...\n")
+	addLi(h.uiDoc, h.uiList, "foo is bored...")
+}
+
+//
+
+// Browser machine handlers
+
+//
+
+type BarHandlers struct {
+	uiDoc   dom.Document
+	uiList  dom.Element
+	uiInput *dom.HTMLInputElement
+
+	rpcFoo      *arpc.Client
+	machBar     *am.Machine
+	machFooHand *am.Machine
+}
+
+func (h *BarHandlers) StartState(e *am.Event) {
+	log.Println("[bar] StartState")
+	addLi(h.uiDoc, h.uiList, "[bar] StartState\n")
+
+	h.uiInput.AddEventListener("keydown", false, func(event dom.Event) {
+		keyEvent := event.(*dom.KeyboardEvent)
+		if keyEvent.Key() != "Enter" {
+			return
+		}
+
+		// submit
+		event.PreventDefault()
+		h.machBar.EvAdd1(e, ssB.SubmitMsg, nil)
+	})
+}
+
+func (h *BarHandlers) SubmitMsgState(e *am.Event) {
+	txt := h.uiInput.Value()
+	h.uiInput.SetValue("")
+	args := PassRpc(&ARpc{
+		Msg: txt,
+	})
+
+	// push to self
+	h.machBar.EvAdd1(e, ssB.Msg, args)
+
+	// unblock
+	go func() {
+		// push to server (blocking)
+		h.rpcFoo.NetMach.EvAdd1(e, ssF.Msg, args)
+	}()
+}
+
+func (h *BarHandlers) MsgEnter(e *am.Event) bool {
+	return example.ParseArgs(e.Args).Msg != ""
+}
+
+func (h *BarHandlers) MsgState(e *am.Event) {
+	args := example.ParseArgs(e.Args)
+
+	// both foo and bar mutate this state
+	author := "bar"
+	if e.Mutation().Source != nil {
+		author = e.Mutation().Source.MachId
+	}
+
+	msg := fmt.Sprintf("[%s] %s\n", author, args.Msg)
+	log.Print(msg)
+	addLi(h.uiDoc, h.uiList, msg)
+}
+
+//
+
+// Misc
+
+//
+
+func addLi(doc dom.Document, ul dom.Element, text string) {
+	li := doc.CreateElement("li")
+	li.SetTextContent(text)
+	ul.AppendChild(li)
+}

--- a/examples/wasm/client/wasm_client_machs.go
+++ b/examples/wasm/client/wasm_client_machs.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	example "github.com/pancsta/asyncmachine-go/examples/wasm"
+	"github.com/pancsta/asyncmachine-go/examples/wasm/states"
+	"github.com/pancsta/asyncmachine-go/internal/utils"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
+)
+
+var ssF = states.FooStates
+var ssB = states.BarStates
+var Pass = example.Pass
+var PassRpc = example.PassRpc
+
+type A = example.A
+type ARpc = example.ARpc
+
+func initMachines(
+	ctx context.Context, barHandlers any, fooHandlers any,
+) (*am.Machine, *arpc.Client, *am.Machine) {
+
+	//
+
+	// Browser machine (local)
+
+	//
+
+	sessId := utils.RandId(3)
+	barMach, err := am.NewCommon(ctx, "browser-bar-"+sessId, states.BarSchema, ssB.Names(), barHandlers, nil, nil)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	barMach.SemLogger().SetArgsMapper(example.LogArgs)
+	amhelp.MachDebugEnv(barMach)
+	arpc.MachReplWs(barMach, example.EnvRelayHttpAddr, &arpc.ReplOpts{
+		// TODO should be automatic in WASM
+		WebSocketTunnel: arpc.WsListenPath("repl-"+barMach.Id(), example.EnvBarReplAddr),
+		Args:            ARpc{},
+		ParseRpc:        example.ParseRpc,
+	})
+
+	// RPC Server
+
+	srv, err := arpc.NewServer(ctx, example.EnvRelayHttpAddr, barMach.Id(), barMach, &arpc.ServerOpts{
+		// eg localhost:8080/listen/bar/localhost:7070 opens 7070 for "bar"
+		// TODO should be automatic in WASM
+		WebSocketTunnel: arpc.WsListenPath(barMach.Id(), example.EnvBarTcpAddr),
+		Parent:          barMach,
+	})
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	srv.Start(nil)
+
+	//
+
+	// Server machine (remote)
+
+	//
+
+	// RPC Handlers Machine
+
+	fooHandlerMach, err := am.NewCommon(ctx, "browser-foo-"+sessId, states.FooSchema, ssF.Names(), fooHandlers, barMach, &am.Opts{
+		Tags: []string{"rpc-handler"},
+	})
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	amhelp.MachDebugEnv(fooHandlerMach)
+	fooHandlerMach.SemLogger().SetArgsMapper(example.LogArgs)
+
+	// RPC Client (Net Machine)
+
+	// TODO enable
+	foo, err := arpc.NewClient(ctx, example.EnvFooWsAddr, fooHandlerMach.Id(), states.FooSchema, &arpc.ClientOpts{
+		Parent: fooHandlerMach,
+		// automatic in WASM
+		WebSocket: "/",
+	})
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// wait for RPC
+	foo.Start(nil)
+	<-foo.Mach.When1(ssrpc.ClientStates.Ready, nil)
+
+	// bind and sync the handler mach to net mach
+	if err := ampipe.BindAny(foo.NetMach, fooHandlerMach); err != nil {
+		log.Fatal(err.Error())
+	}
+	fooHandlerMach.Set(foo.NetMach.ActiveStates(nil), nil)
+
+	// start and wait
+	barMach.Add1(ssB.Start, nil)
+
+	return barMach, foo, fooHandlerMach
+}

--- a/examples/wasm/client/wasm_client_test.go
+++ b/examples/wasm/client/wasm_client_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	example "github.com/pancsta/asyncmachine-go/examples/wasm"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+)
+
+func TestWasmClient(t *testing.T) {
+	if amhelp.IsTestRunner() {
+		t.Skip("skipping WASM mock test")
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// handlers
+
+	barHandlers := &BarHandlersMock{t: t}
+	fooHandlers := &FooHandlersMock{t: t}
+
+	// machines
+
+	barMach, fooClient, fooHandMach := initMachines(ctx, barHandlers, fooHandlers)
+	barHandlers.rpcFoo = fooClient
+	barHandlers.machBar = barMach
+	barHandlers.machFooHand = fooHandMach
+	fooHandlers.rpcFoo = fooClient
+	fooHandlers.machBar = barMach
+	fooHandlers.machFooHand = fooHandMach
+
+	<-ctx.Done()
+}
+
+//
+
+// Server machine handlers
+
+//
+
+type FooHandlersMock struct {
+	t           *testing.T
+	rpcFoo      *arpc.Client
+	machBar     *am.Machine
+	machFooHand *am.Machine
+}
+
+func (h *FooHandlersMock) BoredState(e *am.Event) {
+	h.t.Log("foo is bored...")
+}
+
+//
+
+// Browser machine handlers
+
+//
+
+type BarHandlersMock struct {
+	t           *testing.T
+	rpcFoo      *arpc.Client
+	machBar     *am.Machine
+	machFooHand *am.Machine
+}
+
+func (h *BarHandlersMock) StartState(e *am.Event) {
+	h.t.Log("[bar] StartState")
+
+	go func() {
+		time.Sleep(3 * time.Second)
+		h.machBar.EvAdd1(e, ssB.SubmitMsg, nil)
+	}()
+}
+
+func (h *BarHandlersMock) SubmitMsgState(e *am.Event) {
+	txt := "mock msg"
+	args := PassRpc(&ARpc{
+		Msg: txt,
+	})
+
+	// push to self
+	h.machBar.EvAdd1(e, ssB.Msg, args)
+
+	// push to server
+	h.rpcFoo.NetMach.EvAdd1(e, ssF.Msg, args)
+}
+
+func (h *BarHandlersMock) MsgState(e *am.Event) {
+	args := example.ParseArgs(e.Args)
+
+	// both foo and bar mutate this state
+	author := "bar"
+	if e.Mutation().Source != nil {
+		author = e.Mutation().Source.MachId
+	}
+
+	msg := fmt.Sprintf("[%s] %s", author, args.Msg)
+	h.t.Log(msg)
+}

--- a/examples/wasm/server/wasm_server.go
+++ b/examples/wasm/server/wasm_server.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof"
+	"regexp"
+	"sync/atomic"
+	"time"
+
+	"github.com/joho/godotenv"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ssam "github.com/pancsta/asyncmachine-go/pkg/states"
+	amrelay "github.com/pancsta/asyncmachine-go/tools/relay"
+	amrelayt "github.com/pancsta/asyncmachine-go/tools/relay/types"
+
+	example "github.com/pancsta/asyncmachine-go/examples/wasm"
+	"github.com/pancsta/asyncmachine-go/examples/wasm/states"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
+)
+
+var ssF = states.FooStates
+var ssB = states.BarStates
+var PassRpc = example.PassRpc
+
+type ARpc = example.ARpc
+
+func init() {
+	_ = godotenv.Load()
+}
+
+func main() {
+	ctx := context.Background()
+
+	// debug
+
+	go func() {
+		http.ListenAndServe("localhost:6060", nil)
+	}()
+
+	// net source machine
+
+	handlers := &HandlersFoo{
+		lastMsg: time.Now(),
+	}
+	fooMach, err := am.NewCommon(ctx, "server-foo", states.FooSchema, ssF.Names(), handlers, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	amhelp.MachDebugEnv(fooMach)
+	fooMach.SemLogger().SetArgsMapper(example.LogArgs)
+	handlers.machFoo = fooMach
+	arpc.MachRepl(fooMach, example.EnvFooReplAddr, &arpc.ReplOpts{
+		// TODO config
+		AddrDir:  "tmp",
+		Args:     ARpc{},
+		ParseRpc: example.ParseRpc,
+	})
+	fooMach.Add1(ssF.Start, nil)
+
+	// RPC Server
+
+	s, err := arpc.NewServer(ctx, example.EnvFooWsAddr, "server-foo", fooMach, &arpc.ServerOpts{
+		// manual web socket, no tcp, not relayed
+		WebSocket: true,
+		Parent:    fooMach,
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.Start(nil)
+	handlers.s = s
+
+	// websocket relay
+
+	newClient := func(ctx context.Context, id string, conn net.Conn) (*arpc.Client, error) {
+		// RPC Client (Net Machine)
+		bar, err := arpc.NewClient(ctx, "localhost:0", "server-bar", states.BarSchema, &arpc.ClientOpts{
+			Parent: fooMach,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		// inject the connection, store and start
+		bar.Conn = conn
+		handlers.rpcBar.Store(bar)
+		bar.Start(nil)
+		go func() {
+			<-bar.Mach.When1(ssrpc.ClientStates.Ready, nil)
+			fmt.Printf("aRPC connected via WebSocket\n")
+		}()
+
+		return bar, nil
+	}
+	relay, err := amrelay.New(ctx, amrelayt.Args{
+		Name:   "wasm-demo",
+		Debug:  true,
+		Parent: fooMach,
+		Wasm: &amrelayt.ArgsWasm{
+			ListenAddr: example.EnvRelayHttpAddr,
+			StaticDir:  "./client",
+			// TODO config
+			ReplAddrDir: "tmp",
+			ClientMatchers: []amrelayt.ClientMatcher{{
+				Id:        regexp.MustCompile("^browser-bar-"),
+				NewClient: newClient,
+			}},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	relay.Start(nil)
+
+	// wait
+	select {}
+}
+
+type HandlersFoo struct {
+	machFoo *am.Machine
+	// last connected browser machine
+	rpcBar atomic.Pointer[arpc.Client]
+	s      *arpc.Server
+
+	lastMsg   time.Time
+	lastHello time.Time
+}
+
+func (h *HandlersFoo) StartState(e *am.Event) {
+	ctx := h.machFoo.NewStateCtx(ssF.Start)
+
+	h.machFoo.Fork(ctx, e, func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-ticker.C:
+				// bored? 15sec after the last msg
+				if time.Since(h.lastMsg) > 15*time.Second && h.machFoo.Not1(ssF.Bored) {
+					// periodic sync without args
+					h.machFoo.Add1(ssF.Bored, nil)
+				}
+
+				// hello? try 10 times, only if browser-bar connected
+				bar := h.rpcBar.Load()
+				if bar != nil && time.Since(h.lastHello) > 10*time.Second &&
+					bar.Mach.Is1(ssam.BasicStates.Ready) &&
+					bar.NetMach.Tick(ssB.Msg) < 20 {
+
+					// instant sync with args
+					args := PassRpc(&ARpc{
+						Msg: "hello",
+					})
+					bar.NetMach.EvAdd1(e, ssF.Msg, args)
+					h.machFoo.EvAdd1(e, ssF.Msg, args)
+					h.lastHello = time.Now()
+				}
+			}
+		}
+	})
+}
+
+func (h *HandlersFoo) MsgEnter(e *am.Event) bool {
+	return example.ParseArgs(e.Args).Msg != ""
+}
+
+func (h *HandlersFoo) MsgState(e *am.Event) {
+	h.machFoo.Remove1(ssF.Msg, nil)
+	args := example.ParseArgs(e.Args)
+
+	// both foo and bar mutate this state
+	author := "bar"
+	if e.Mutation().Source != nil {
+		author = e.Mutation().Source.MachId
+	}
+
+	msg := fmt.Sprintf("[%s] %s\n", author, args.Msg)
+	fmt.Print(msg)
+	h.lastMsg = time.Now()
+}
+
+func (h *HandlersFoo) BoredState(e *am.Event) {
+	fmt.Println("foo is bored...")
+}

--- a/examples/wasm/states/ss_wa_sm.go
+++ b/examples/wasm/states/ss_wa_sm.go
@@ -1,0 +1,150 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ssrpc "github.com/pancsta/asyncmachine-go/pkg/rpc/states"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+//
+
+// FOO (server)
+
+//
+
+// FooStatesDef contains all the states of the Server state machine "foo".
+type FooStatesDef struct {
+	*am.StatesBase
+
+	// Timeout without msgs.
+	Bored string
+
+	// inherit from SharedStatesDef
+	*SharedStatesDef
+}
+
+// FooGroupsDef contains all the state groups Foo state machine.
+type FooGroupsDef struct {
+	// GroupName S
+}
+
+// FooSchema represents all relations and properties of FooStates.
+var FooSchema = SchemaMerge(
+	// inherit from SharedSchema
+	SharedSchema,
+	am.Schema{
+
+		ssF.Bored: {},
+		ssF.Msg: StateAdd(
+			SharedSchema[ssF.Msg],
+			am.State{
+				Remove: S{ssF.Bored},
+			}),
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssF = am.NewStates(FooStatesDef{})
+	sgF = am.NewStateGroups(FooGroupsDef{
+		// GroupName: S{...},
+	})
+
+	// FooStates contains all the states for the Foo machine.
+	FooStates = ssF
+	// FooGroups contains all the state groups for the Foo machine.
+	FooGroups = sgF
+)
+
+//
+
+// BAR (browser)
+
+//
+
+// BarStatesDef contains all the states of the Browser state machine "bar".
+type BarStatesDef struct {
+	*am.StatesBase
+
+	SubmitMsg string
+
+	// inherit from SharedStatesDef
+	*SharedStatesDef
+}
+
+// BarGroupsDef contains all the state groups Bar state machine.
+type BarGroupsDef struct {
+	// GroupName S
+}
+
+// BarSchema represents all relations and properties of BarStates.
+var BarSchema = SchemaMerge(
+	// inherit from SharedSchema
+	SharedSchema,
+	am.Schema{
+
+		ssB.SubmitMsg: {Multi: true},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssB = am.NewStates(BarStatesDef{})
+	sgB = am.NewStateGroups(BarGroupsDef{
+		// GroupName: S{...},
+	})
+
+	// BarStates contains all the states for the Bar machine.
+	BarStates = ssB
+	// BarGroups contains all the state groups for the Bar machine.
+	BarGroups = sgB
+)
+
+//
+
+// SHARED (common for both server and browser)
+
+//
+
+// SharedStatesDef contains all the states of the Shared state machine.
+type SharedStatesDef struct {
+	*am.StatesBase
+
+	// Message received and should be processed.
+	Msg string
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+	// inherit from rpc/StateSourceStatesDef
+	*ssrpc.StateSourceStatesDef
+}
+
+// SharedGroupsDef contains all the state groups Shared state machine.
+type SharedGroupsDef struct {
+	// GroupName S
+}
+
+// SharedSchema represents all relations and properties of SharedStates.
+var SharedSchema = SchemaMerge(
+	// inherit from BasicSchema
+	ss.BasicSchema,
+	// inherit from rpc/WorkerSchema
+	ssrpc.StateSourceSchema,
+	am.Schema{
+
+		ssS.Msg: {Multi: true},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssS = am.NewStates(SharedStatesDef{})
+	sgS = am.NewStateGroups(SharedGroupsDef{
+		// GroupName: S{...},
+	})
+
+	// SharedStates contains all the states for the Shared machine.
+	SharedStates = ssS
+	// SharedGroups contains all the state groups for the Shared machine.
+	SharedGroups = sgS
+)

--- a/examples/wasm/states/states_utils.go
+++ b/examples/wasm/states/states_utils.go
@@ -1,0 +1,19 @@
+package states
+
+import am "github.com/pancsta/asyncmachine-go/pkg/machine"
+
+// S is a type alias for a list of state names.
+type S = am.S
+
+// SAdd is a func alias for merging lists of states.
+var SAdd = am.SAdd
+
+// StateAdd is a func alias for adding to an existing state definition.
+var StateAdd = am.StateAdd
+
+// StateSet is a func alias for replacing parts of an existing state
+// definition.
+var StateSet = am.StateSet
+
+// SchemaMerge is a func alias for extending an existing state structure.
+var SchemaMerge = am.SchemaMerge

--- a/examples/wasm/wasm_example.go
+++ b/examples/wasm/wasm_example.go
@@ -1,0 +1,115 @@
+package example
+
+import (
+	_ "embed"
+	"encoding/gob"
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+)
+
+var (
+	EnvFooWsAddr   string
+	EnvFooReplAddr string
+)
+
+var (
+	EnvBarTcpAddr  string
+	EnvBarReplAddr string
+)
+
+var EnvRelayHttpAddr string
+
+//go:embed .env
+var env string
+
+func init() {
+	reader := strings.NewReader(env)
+	envMap, err := godotenv.Parse(reader)
+	if err == nil {
+		for k, v := range envMap {
+			os.Setenv(k, v)
+		}
+	}
+
+	EnvFooWsAddr = os.Getenv("FOO_WS_ADDR")
+	EnvFooReplAddr = os.Getenv("FOO_REPL_ADDR")
+	EnvBarTcpAddr = os.Getenv("BAR_TCP_ADDR")
+	EnvBarReplAddr = os.Getenv("BAR_REPL_ADDR")
+	EnvRelayHttpAddr = os.Getenv("RELAY_HTTP_ADDR")
+}
+
+// ///// ///// /////
+
+// ///// ARGS
+
+// ///// ///// /////
+
+func init() {
+	gob.Register(ARpc{})
+}
+
+const APrefix = "wasm"
+
+// A is a struct for node arguments. It's a typesafe alternative to [am.A].
+type A struct {
+	Msg string `log:"msg"`
+
+	// non-rpc fields
+
+	ReturnCh chan<- []string
+}
+
+// ARpc is a subset of A, that can be passed over RPC.
+type ARpc struct {
+	Msg string `log:"msg"`
+}
+
+// ParseArgs extracts A from [am.Event.Args][APrefix].
+func ParseArgs(args am.A) *A {
+	if r, ok := args[APrefix].(*ARpc); ok {
+		return amhelp.ArgsToArgs(r, &A{})
+	} else if r, ok := args[APrefix].(ARpc); ok {
+		return amhelp.ArgsToArgs(&r, &A{})
+	}
+	if a, _ := args[APrefix].(*A); a != nil {
+		return a
+	}
+	return &A{}
+}
+
+// Pass prepares [am.A] from A to pass to further mutations.
+func Pass(args *A) am.A {
+	return am.A{APrefix: args}
+}
+
+// PassRpc prepares [am.A] from A to pass over RPC.
+func PassRpc(args *ARpc) am.A {
+	return am.A{APrefix: amhelp.ArgsToArgs(args, &ARpc{})}
+}
+
+// LogArgs is an args logger for A.
+func LogArgs(args am.A) map[string]string {
+	a := ParseArgs(args)
+	if a == nil {
+		return nil
+	}
+
+	return amhelp.ArgsToLogMap(a, 0)
+}
+
+// ParseRpc parses am.A to *ARpc wrapped in am.A. Useful for REPLs.
+func ParseRpc(args am.A) am.A {
+	ret := am.A{APrefix: &ARpc{}}
+	jsonArgs, err := json.Marshal(args)
+	if err == nil {
+		json.Unmarshal(jsonArgs, ret[APrefix])
+	}
+
+	return ret
+}


### PR DESCRIPTION
A documented example of using the new WASM features. See [/examples/wasm/README.md](/examples/wasm/README.md).

![wasm-am-vis-small](https://github.com/user-attachments/assets/1c001126-6c36-40c1-9ca2-0ce1c1565b5b)
