### PR TITLE
feat(am-dbg): release `v0.18`

### DIFF
--- a/tools/cmd/am-dbg/cmd_dbg.go
+++ b/tools/cmd/am-dbg/cmd_dbg.go
@@ -3,10 +3,11 @@ package main
 
 import (
 	"context"
+	"log"
+	"net"
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -28,7 +29,7 @@ func main() {
 }
 
 // TODO error msgs
-func cliRun(c *cobra.Command, _ []string, p types.Params) {
+func cliRun(_ *cobra.Command, _ []string, p types.Params) {
 	ctx := context.Background()
 
 	// print the version
@@ -45,33 +46,53 @@ func cliRun(c *cobra.Command, _ []string, p types.Params) {
 	if stopProfile != nil {
 		defer stopProfile()
 	}
+	log.SetOutput(logger.Writer())
 
 	httpAddr := ""
+	sshAddr := ""
 	if p.ListenAddr != "-1" {
-		addr := strings.Split(p.ListenAddr, ":")
-		httpPort, _ := strconv.Atoi(addr[1])
-		httpPort += 1
-		httpAddr = addr[0] + ":" + strconv.Itoa(httpPort)
+		host, port, err := net.SplitHostPort(p.ListenAddr)
+		if err != nil {
+			panic(err)
+		}
+		dbgPort, _ := strconv.Atoi(port)
+		httpPort := dbgPort + 1
+		sshPort := httpPort + 1
+		httpAddr = host + ":" + strconv.Itoa(httpPort)
+		sshAddr = host + ":" + strconv.Itoa(sshPort)
+	}
+
+	if !p.UiSsh {
+		sshAddr = ""
+	}
+	if !p.UiWeb {
+		httpAddr = ""
 	}
 
 	// init the debugger
 	dbg, err := debugger.New(ctx, debugger.Opts{
-		Id:             p.Id,
-		DbgLogLevel:    p.LogLevel,
-		DbgLogger:      logger,
-		ImportData:     p.ImportData,
-		OutputClients:  p.OutputClients,
+		Id:            p.Id,
+		DbgLogLevel:   p.LogLevel,
+		DbgLogger:     logger,
+		ImportData:    p.ImportData,
+		OutputClients: p.OutputClients,
+		// TODO expose levels as states
 		OutputDiagrams: p.OutputDiagrams,
-		Timelines:      p.Timelines,
+		OutputTx:       p.OutputTx,
+		OutputLog:      p.OutputLog,
+		Timelines:      p.ViewTimelines,
 		// ...:           p.FilterLogLevel,
 		OutputDir:       p.OutputDir,
 		AddrRpc:         p.ListenAddr,
 		AddrHttp:        httpAddr,
+		AddrSsh:         sshAddr,
+		UiSsh:           p.UiSsh && sshAddr != "",
+		UiWeb:           p.UiWeb && httpAddr != "",
 		EnableMouse:     p.EnableMouse,
 		EnableClipboard: p.EnableClipboard,
 		MachUrl:         p.MachUrl,
 		SelectConnected: p.SelectConnected,
-		ShowReader:      p.Reader,
+		ShowReader:      p.ViewReader,
 		CleanOnConnect:  p.CleanOnConnect,
 		MaxMemMb:        p.MaxMemMb,
 		Log2Ttl:         p.LogOpsTtl,
@@ -105,13 +126,14 @@ func cliRun(c *cobra.Command, _ []string, p types.Params) {
 
 	// rpc server
 	if p.ListenAddr != "-1" {
-		go server.StartRpc(dbg.Mach, p.ListenAddr, nil, p.FwdData,
-			p.UiDiagrams)
+		go server.StartRpc(dbg.Mach, p.ListenAddr, nil, p)
 	}
 
 	// start and wait till the end
+	// TODO move to params
 	dbg.Start(p.StartupMachine, p.StartupTx, p.StartupView, p.StartupGroup)
 
+	// TODO notify ctx
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 

--- a/tools/debugger/client_list.go
+++ b/tools/debugger/client_list.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
+
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
 
 	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	ssam "github.com/pancsta/asyncmachine-go/pkg/states"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 )
 
@@ -296,7 +297,7 @@ func (d *Debugger) hGetClientListLabel(
 	hasFocus := d.Mach.Is1(ss.ClientListFocused)
 
 	var currCTxIdx int
-	var currCTx *telemetry.DbgMsgTx
+	var currCTx *dbg.DbgMsgTx
 	// current tx of the selected client
 	currSelTx := d.hCurrentTx()
 	if currSelTx != nil {

--- a/tools/debugger/dbg_handlers.go
+++ b/tools/debugger/dbg_handlers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -14,23 +15,24 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/charmbracelet/ssh"
 	"github.com/coder/websocket"
-	"github.com/gdamore/tcell/v2"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
 	"golang.org/x/exp/maps"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
-	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
-	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
-
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 	"github.com/pancsta/asyncmachine-go/tools/visualizer"
 )
 
@@ -46,6 +48,11 @@ func (d *Debugger) StartState(e *am.Event) {
 	d.App = cview.NewApplication()
 	if d.Opts.Screen != nil {
 		d.App.SetScreen(d.Opts.Screen)
+
+		// headless mode
+	} else if d.Opts.UiSsh {
+		d.Mach.Add1(ss.SshServer, nil)
+		d.App.SetScreen(tcell.NewSimulationScreen("UTF-8"))
 	}
 
 	// forceful race solving
@@ -205,7 +212,7 @@ func (d *Debugger) ReadyState(e *am.Event) {
 			case <-d.heartbeatT.C:
 				d.Mach.Add1(ss.Heartbeat, nil)
 
-			case <-d.Mach.Ctx().Done():
+			case <-d.Mach.Context().Done():
 				d.heartbeatT.Stop()
 			}
 		}
@@ -526,7 +533,7 @@ func (d *Debugger) TreeGroupsFocusedEnd(_ *am.Event) {
 // ///// CONNECTION
 
 func (d *Debugger) ConnectEventEnter(e *am.Event) bool {
-	msg, ok1 := e.Args["msg_struct"].(*telemetry.DbgMsgStruct)
+	msg, ok1 := e.Args["msg_struct"].(*dbg.DbgMsgStruct)
 	_, ok2 := e.Args["conn_id"].(string)
 	if !ok1 || !ok2 || msg.ID == "" {
 		d.Mach.Log("Error: msg_struct malformed\n")
@@ -538,7 +545,7 @@ func (d *Debugger) ConnectEventEnter(e *am.Event) bool {
 
 func (d *Debugger) ConnectEventState(e *am.Event) {
 	// initial structure data
-	msg := e.Args["msg_struct"].(*telemetry.DbgMsgStruct)
+	msg := e.Args["msg_struct"].(*dbg.DbgMsgStruct)
 	connId := e.Args["conn_id"].(string)
 	var c *Client
 
@@ -691,7 +698,7 @@ func (d *Debugger) DisconnectEventState(e *am.Event) {
 // ///// CLIENTS
 
 func (d *Debugger) ClientMsgEnter(e *am.Event) bool {
-	_, ok1 := e.Args["msgs_tx"].([]*telemetry.DbgMsgTx)
+	_, ok1 := e.Args["msgs_tx"].([]*dbg.DbgMsgTx)
 	_, ok2 := e.Args["conn_ids"].([]string)
 	return ok1 && ok2
 }
@@ -702,7 +709,7 @@ func (d *Debugger) ClientMsgState(e *am.Event) {
 	// TODO make it async via a dedicated goroutine, pushing results to
 	//  async multi state ClientMsgDone (if possible)
 
-	msgs := e.Args["msgs_tx"].([]*telemetry.DbgMsgTx)
+	msgs := e.Args["msgs_tx"].([]*dbg.DbgMsgTx)
 	connIds := e.Args["conn_ids"].([]string)
 	mach := d.Mach
 
@@ -1289,6 +1296,14 @@ func (d *Debugger) ToggleToolState(e *am.Event) {
 
 	case toolTail:
 		d.Mach.EvToggle1(e, ss.TailMode, nil)
+
+	case toolWeb:
+		go func() {
+			err := openURL("http://" + d.Opts.AddrHttp)
+			if err != nil {
+				d.Mach.EvAddErr(e, err, nil)
+			}
+		}()
 
 	case toolPrev:
 		d.Mach.EvAdd1(e, ss.UserBack, nil)
@@ -2083,12 +2098,15 @@ func (d *Debugger) WebReqState(e *am.Event) {
 		if err != nil {
 			return
 		}
+
+		// send
+		w.Header().Set("Content-Type", "image/svg+xml")
 		_, err = w.Write(b)
 		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
 	}
 }
 
-func (d *Debugger) WebSocketState(e *am.Event) {
+func (d *Debugger) WebSocketDiagState(e *am.Event) {
 	// TODO TYPED PARAMS
 	ws := e.Args["*websocket.Conn"].(*websocket.Conn)
 	r := e.Args["*http.Request"].(*http.Request)
@@ -2227,4 +2245,71 @@ func (d *Debugger) ResizedState(e *am.Event) {
 		// force a redraw TODO bug?
 		d.draw()
 	}()
+}
+
+func (d *Debugger) SshServerEnter(e *am.Event) bool {
+	return d.Opts.UiSsh && d.Opts.AddrSsh != ""
+}
+
+func (d *Debugger) SshServerState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.SshServer)
+	// TODO SshClientState
+	busy := atomic.Bool{}
+	handler := func(sess ssh.Session) {
+		d.Mach.Log("new SSH session " + sess.RemoteAddr().String())
+		if busy.Load() {
+			_, _ = sess.Write([]byte("am-dbg server busy...\n"))
+			_ = sess.Close()
+			return
+		}
+		// TODO prevent double conns via SshServerConnectedState
+
+		_, _, isPty := sess.Pty()
+		if !isPty {
+			return
+		}
+		screen, err := NewSessionScreen(sess)
+		if err != nil {
+			d.Mach.AddErr(err, nil)
+			return
+		}
+		d.App.SetScreen(screen)
+		busy.Store(true)
+
+		// wait till end
+		select {
+		// TODO SshClientState
+		case <-d.Mach.WhenTicks(ss.SshDisconn, 1, nil):
+		case <-ctx.Done():
+		}
+
+		// restore sim screen
+		busy.Store(false)
+		d.App.SetScreen(tcell.NewSimulationScreen("UTF-8"))
+	}
+
+	go func() {
+		if ctx.Err() != nil {
+			return // expired
+		}
+		optSrv := func(s *ssh.Server) error {
+			d.sshSrv = s
+			return nil
+		}
+
+		// show banner TODO optional
+		host, port, _ := net.SplitHostPort(d.Opts.AddrSsh)
+		p := d.Opts.Print
+		p("SSH: listening on %s\n", d.Opts.AddrSsh)
+		p("\n")
+		p("Connect via:\n")
+		p("$ ssh %s -p %s -o UserKnownHostsFile=/dev/null "+
+			"-o StrictHostKeyChecking=no\n", host, port)
+		d.Mach.AddErr(
+			ssh.ListenAndServe(d.Opts.AddrSsh, handler, optSrv), nil)
+	}()
+}
+
+func (d *Debugger) SshServerEnd(e *am.Event) {
+	d.sshSrv.Close()
 }

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -23,26 +23,27 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/andybalholm/brotli"
-	"github.com/gdamore/tcell/v2"
+	"github.com/charmbracelet/ssh"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
 	"github.com/zyedidia/clipper"
 	"golang.org/x/text/message"
-
-	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
-	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amgraph "github.com/pancsta/asyncmachine-go/pkg/graph"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	ssam "github.com/pancsta/asyncmachine-go/pkg/states"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 	amvis "github.com/pancsta/asyncmachine-go/tools/visualizer"
 )
 
@@ -59,7 +60,7 @@ type Debugger struct {
 	Mach *am.Machine
 
 	Clients map[string]*Client
-	// TODO make threadsafe
+	// TODO go-arg and inherit from RWMutex
 	Opts       Opts
 	LayoutRoot *cview.Panels
 	// selected client
@@ -144,10 +145,16 @@ type Debugger struct {
 	logRenderedClient string
 	lastResize        uint64
 	logLastResize     uint64
+	sshSrv            *ssh.Server
+	logFile           *os.File
+	// TODO handle in LogBuiltState
+	logFileMx sync.Mutex
 }
 
 // New creates a new debugger instance and optionally import a data file.
 func New(ctx context.Context, opts Opts) (*Debugger, error) {
+	// TODO default options
+
 	var err error
 	// init the debugger
 	d := &Debugger{
@@ -169,6 +176,11 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 	if d.Opts.Log2Ttl == 0 {
 		d.Opts.Log2Ttl = time.Hour
 	}
+	if d.Opts.Print == nil {
+		d.Opts.Print = func(txt string, args ...any) {
+			fmt.Printf(txt, args...)
+		}
+	}
 
 	gob.Register(server.Exportable{})
 	gob.Register(am.Relation(0))
@@ -185,8 +197,8 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 		return nil, err
 	}
 	d.Mach = mach
-	// mach.AddBreakpoint1(ss.BuildingLog, "", false)
-	// mach.AddBreakpoint1(ss.BuildingLog, "", true)
+	// mach.AddBreakpoint1("", ss.Start, false)
+	// mach.AddBreakpoint1("", ss.Start, true)
 	// TODO update to schemas
 	mach.SetGroupsString(map[string]am.S{
 		"Dialog":           ss.GroupDialog,
@@ -217,12 +229,12 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 	} else {
 		semLog.SetSimple(log.Printf, opts.DbgLogLevel)
 	}
-	semLog.SetArgsMapper(am.NewArgsMapper([]string{
+	semLog.SetArgsMapper(am.NewLogArgsMapper(20, []string{
 		// TODO extract
 		"Client.id", "conn_id", "cursorTx1", "amount", "Client.id",
 		"state", "fwd", "filter", "ToolName", "uri", "addr", "url",
 		"err", "_am_err",
-	}, 20))
+	}))
 
 	d.graph, err = amgraph.New(d.Mach)
 	if err != nil {
@@ -259,12 +271,22 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 		p := path.Join(d.Opts.OutputDir, "am-dbg-clients.txt")
 		clientListFile, err := os.Create(p)
 		if err != nil {
-			mach.AddErr(fmt.Errorf("client list file open: %w", err), nil)
+			mach.AddErr(err, nil)
 		}
 		d.clientListFile = clientListFile
 	}
 
-	// tx file
+	// log file
+	if d.Opts.OutputLog {
+		p := path.Join(d.Opts.OutputDir, "log.txt")
+		logFile, err := os.Create(p)
+		if err != nil {
+			mach.AddErr(err, nil)
+		}
+		d.logFile = logFile
+	}
+
+	// tx files
 	if d.Opts.OutputTx {
 		p := path.Join(d.Opts.OutputDir, "tx.md")
 		txFile, err := os.Create(p)
@@ -294,9 +316,8 @@ func New(ctx context.Context, opts Opts) (*Debugger, error) {
 		txMermaidAsciiFile := path.Join(d.Opts.OutputDir, "tx.mermaid.txt")
 		d.txFileMermaidAscii, err = os.Create(txMermaidAsciiFile)
 		if err != nil {
-			mach.AddErr(fmt.Errorf("tx list file open: %w", err), nil)
+			mach.AddErr(err, nil)
 		}
-		d.txListFile = txListFile
 	}
 
 	return d, nil
@@ -497,7 +518,7 @@ func (d *Debugger) hGetClient(machId string) *Client {
 
 func (d *Debugger) hGetClientTx(
 	machId, txId string,
-) (*Client, *telemetry.DbgMsgTx) {
+) (*Client, *dbg.DbgMsgTx) {
 	c := d.hGetClient(machId)
 	if c == nil {
 		return nil, nil
@@ -531,8 +552,8 @@ func (d *Debugger) Client() *Client {
 }
 
 // NextTx returns the next transition. Thread safe via Eval().
-func (d *Debugger) NextTx() *telemetry.DbgMsgTx {
-	var tx *telemetry.DbgMsgTx
+func (d *Debugger) NextTx() *dbg.DbgMsgTx {
+	var tx *dbg.DbgMsgTx
 
 	// SelectingClient locks d.C
 	<-d.Mach.WhenNot1(ss.SelectingClient, nil)
@@ -546,7 +567,7 @@ func (d *Debugger) NextTx() *telemetry.DbgMsgTx {
 	return tx
 }
 
-func (d *Debugger) hNextTx() *telemetry.DbgMsgTx {
+func (d *Debugger) hNextTx() *dbg.DbgMsgTx {
 	c := d.C
 	if c == nil {
 		return nil
@@ -560,8 +581,8 @@ func (d *Debugger) hNextTx() *telemetry.DbgMsgTx {
 }
 
 // CurrentTx returns the current transition. Thread safe via Eval().
-func (d *Debugger) CurrentTx() *telemetry.DbgMsgTx {
-	var tx *telemetry.DbgMsgTx
+func (d *Debugger) CurrentTx() *dbg.DbgMsgTx {
+	var tx *dbg.DbgMsgTx
 
 	// SelectingClient locks d.C
 	<-d.Mach.WhenNot1(ss.SelectingClient, nil)
@@ -575,7 +596,7 @@ func (d *Debugger) CurrentTx() *telemetry.DbgMsgTx {
 	return tx
 }
 
-func (d *Debugger) hCurrentTx() *telemetry.DbgMsgTx {
+func (d *Debugger) hCurrentTx() *dbg.DbgMsgTx {
 	c := d.C
 	if c == nil {
 		return nil
@@ -589,8 +610,8 @@ func (d *Debugger) hCurrentTx() *telemetry.DbgMsgTx {
 }
 
 // PrevTx returns the previous transition. Thread safe via Eval().
-func (d *Debugger) PrevTx() *telemetry.DbgMsgTx {
-	var tx *telemetry.DbgMsgTx
+func (d *Debugger) PrevTx() *dbg.DbgMsgTx {
+	var tx *dbg.DbgMsgTx
 
 	// SelectingClient locks d.C
 	<-d.Mach.WhenNot1(ss.SelectingClient, nil)
@@ -604,7 +625,7 @@ func (d *Debugger) PrevTx() *telemetry.DbgMsgTx {
 	return tx
 }
 
-func (d *Debugger) hPrevTx() *telemetry.DbgMsgTx {
+func (d *Debugger) hPrevTx() *dbg.DbgMsgTx {
 	c := d.C
 	if c == nil {
 		return nil
@@ -948,7 +969,7 @@ func (d *Debugger) hParseMsg(c *Client, idx int) {
 		sum += v
 	}
 	index := c.MsgStruct.StatesIndex
-	prevTx := &telemetry.DbgMsgTx{}
+	prevTx := &dbg.DbgMsgTx{}
 	prevTxParsed := &types.MsgTxParsed{}
 	if len(c.MsgTxs) > 1 && idx > 0 {
 		prevTx = c.MsgTxs[idx-1]
@@ -988,7 +1009,8 @@ func (d *Debugger) hParseMsg(c *Client, idx int) {
 	if len(msgTx.CalledStates) > 0 {
 		msgTx.CalledStatesIdxs = amhelp.StatesToIndexes(index,
 			msgTx.CalledStates)
-		msgTx.MachineID = ""
+		// TODO optimize: ID registry
+		// msgTx.MachineID = ""
 		msgTx.CalledStates = nil
 	}
 	// TODO refac when dbg@v2 lands
@@ -1225,10 +1247,13 @@ func (d *Debugger) hExportData(filename string, snapshot bool) {
 	data := make([]*server.Exportable, len(d.Clients))
 	i := 0
 	for _, c := range d.Clients {
-		data[i] = c.Exportable
+		data[i] = &server.Exportable{
+			MsgStruct: c.Exportable.MsgStruct,
+			MsgTxs:    c.Exportable.MsgTxs,
+		}
 		// snapshot limits to a single tx
 		if snapshot {
-			data[i].MsgTxs = []*telemetry.DbgMsgTx{c.Tx(c.LastTxTill(now))}
+			data[i].MsgTxs = []*dbg.DbgMsgTx{c.Tx(c.LastTxTill(now))}
 		}
 		i++
 	}
@@ -1246,7 +1271,7 @@ func (d *Debugger) hExportData(filename string, snapshot bool) {
 }
 
 func (d *Debugger) hGetTxInfo(txIndex1 int,
-	tx *telemetry.DbgMsgTx, parsed *types.MsgTxParsed, title string,
+	tx *dbg.DbgMsgTx, parsed *types.MsgTxParsed, title string,
 ) (string, string) {
 	left := title
 	right := " "
@@ -1255,7 +1280,7 @@ func (d *Debugger) hGetTxInfo(txIndex1 int,
 	}
 
 	// left side
-	var prev *telemetry.DbgMsgTx
+	var prev *dbg.DbgMsgTx
 	if txIndex1 > 1 {
 		prev = d.C.MsgTxs[txIndex1-2]
 	}
@@ -1278,7 +1303,11 @@ func (d *Debugger) hGetTxInfo(txIndex1 int,
 	if !tx.Accepted {
 		left += "[grey]"
 	}
-	left += fmt.Sprintf(" %s%s: [::b]%s[::-]", tx.Type, multi,
+	queued := ""
+	if tx.IsQueued {
+		queued = "q"
+	}
+	left += fmt.Sprintf(" %s%s%s: [::b]%s[::-]", queued, tx.Type, multi,
 		strings.Join(calledStates, ", "))
 
 	if !tx.Accepted {
@@ -1293,9 +1322,7 @@ func (d *Debugger) hGetTxInfo(txIndex1 int,
 	if tx.IsCheck {
 		right += "check | "
 	}
-	if tx.IsQueued {
-		right += "[grey]queued[-] | "
-	} else if !tx.Accepted {
+	if !tx.Accepted {
 		right += "[grey]canceled[-] | "
 	}
 
@@ -1373,8 +1400,8 @@ func (d *Debugger) hUpdateMatrixRelations() {
 	if c.SelectedGroup != "" {
 		index = c.MsgSchemaParsed.Groups[c.SelectedGroup]
 	}
-	var tx *telemetry.DbgMsgTx
-	var prevTx *telemetry.DbgMsgTx
+	var tx *dbg.DbgMsgTx
+	var prevTx *dbg.DbgMsgTx
 	if c.CursorStep1 == 0 {
 		tx = d.hCurrentTx()
 		prevTx = d.hPrevTx()
@@ -2011,7 +2038,7 @@ func (d *Debugger) diagramLink(outDir string, svgName string) {
 }
 
 func (d *Debugger) diagramsMemCache(
-	e *am.Event, id string, cache *goquery.Document, tx *telemetry.DbgMsgTx,
+	e *am.Event, id string, cache *goquery.Document, tx *dbg.DbgMsgTx,
 	outDir, svgName string,
 ) {
 	svgPath := path.Join(outDir, svgName+".svg")
@@ -2049,7 +2076,7 @@ func (d *Debugger) diagramsMemCache(
 }
 
 func (d *Debugger) diagramsFileCache(
-	e *am.Event, id string, tx *telemetry.DbgMsgTx, lvl int, outDir,
+	e *am.Event, id string, tx *dbg.DbgMsgTx, lvl int, outDir,
 	svgName string,
 ) {
 	defer d.Mach.PanicToErrState(ss.ErrDiagrams, nil)

--- a/tools/debugger/keyboard.go
+++ b/tools/debugger/keyboard.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"code.rocketnine.space/tslocum/cbind"
-	"github.com/gdamore/tcell/v2"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/cview/cbind"
+	"github.com/pancsta/tcell-v2"
 
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
@@ -227,6 +227,7 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 	// TODO add state deps to the keystrokes structure
 	// TODO use tcell.KeyNames instead of strings as keys
 	// TODO rate limit
+	keys := tcell.KeyNames
 	return map[string]func(ev *tcell.EventKey) *tcell.EventKey{
 		// play/pause
 		"space": func(ev *tcell.EventKey) *tcell.EventKey {
@@ -271,6 +272,7 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 
 		// expand / collapse trees
 		"alt+e": func(ev *tcell.EventKey) *tcell.EventKey {
+			// TODO race
 			d.hToolExpand()
 
 			return nil
@@ -305,6 +307,7 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 
 		// scroll to the first tx
 		"home": func(ev *tcell.EventKey) *tcell.EventKey {
+			// TODO race
 			d.hToolFirstTx(nil)
 
 			return nil
@@ -312,6 +315,7 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 
 		// scroll to the last tx
 		"end": func(ev *tcell.EventKey) *tcell.EventKey {
+			// TODO race
 			d.hToolLastTx(nil)
 
 			return nil
@@ -319,8 +323,14 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 
 		// quit the app
 		"ctrl+q": func(ev *tcell.EventKey) *tcell.EventKey {
-			d.Mach.Remove1(ss.Start, nil)
+			// SSH PTY
+			if d.Mach.Is1(ss.SshServer) {
+				d.Mach.Add1(ss.SshDisconn, nil)
+				return nil
+			}
 
+			// local PTY
+			d.Mach.Remove1(ss.Start, nil)
 			return nil
 		},
 
@@ -371,19 +381,24 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 		},
 
 		// remove client (sidebar)
-		"backspace": func(ev *tcell.EventKey) *tcell.EventKey {
+		keys[tcell.KeyBackspace]: func(ev *tcell.EventKey) *tcell.EventKey {
 			if d.Mach.Not1(ss.ClientListFocused) {
 				return ev
 			}
 
-			sel := d.clientList.GetCurrentItem()
-			if sel == nil || d.Mach.Not1(ss.ClientListFocused) {
-				return nil
+			// TODO race
+			d.hDeleteClient()
+			return nil
+		},
+
+		// remove client (sidebar)
+		"alt+d": func(ev *tcell.EventKey) *tcell.EventKey {
+			if d.Mach.Not1(ss.ClientListFocused) {
+				return ev
 			}
 
-			ref := sel.GetReference().(*sidebarRef)
-			d.Mach.Add1(ss.RemoveClient, am.A{"Client.id": ref.name})
-
+			// TODO race
+			d.hDeleteClient()
 			return nil
 		},
 
@@ -408,6 +423,16 @@ func (d *Debugger) getKeystrokes() map[string]tcellKeyFn {
 			return ev
 		},
 	}
+}
+
+func (d *Debugger) hDeleteClient() {
+	sel := d.clientList.GetCurrentItem()
+	if sel == nil || d.Mach.Not1(ss.ClientListFocused) {
+		return
+	}
+
+	ref := sel.GetReference().(*sidebarRef)
+	d.Mach.Add1(ss.RemoveClient, am.A{"Client.id": ref.name})
 }
 
 func (d *Debugger) focusDefault() {
@@ -534,7 +559,7 @@ func (d *Debugger) hJumpBackKey(ev *tcell.EventKey) *tcell.EventKey {
 		// }
 
 		// state jump TODO dont block
-		amhelp.Add1Block(ctx, d.Mach, state, am.A{
+		amhelp.Add1Sync(ctx, d.Mach, state, am.A{
 			"state": d.C.SelectedState,
 			"fwd":   false,
 		})
@@ -542,7 +567,7 @@ func (d *Debugger) hJumpBackKey(ev *tcell.EventKey) *tcell.EventKey {
 		d.hUpdateClientList()
 	} else {
 		// fast jump TODO dont block
-		amhelp.Add1Block(ctx, d.Mach, ss.Back, am.A{
+		amhelp.Add1Sync(ctx, d.Mach, ss.Back, am.A{
 			"amount": min(fastJumpAmount, d.C.CursorTx1),
 		})
 	}
@@ -569,7 +594,7 @@ func (d *Debugger) hJumpFwdKey(ev *tcell.EventKey) *tcell.EventKey {
 		// }
 
 		// state jump TODO dont block
-		amhelp.Add1Block(ctx, d.Mach, state, am.A{
+		amhelp.Add1Sync(ctx, d.Mach, state, am.A{
 			"state": d.C.SelectedState,
 			"fwd":   true,
 		})
@@ -577,7 +602,7 @@ func (d *Debugger) hJumpFwdKey(ev *tcell.EventKey) *tcell.EventKey {
 		d.hUpdateClientList()
 	} else {
 		// fast jump TODO dont block
-		amhelp.Add1Block(ctx, d.Mach, ss.Fwd, am.A{
+		amhelp.Add1Sync(ctx, d.Mach, ss.Fwd, am.A{
 			"amount": min(fastJumpAmount, len(d.C.MsgTxs)-d.C.CursorTx1),
 		})
 	}

--- a/tools/debugger/log.go
+++ b/tools/debugger/log.go
@@ -12,12 +12,13 @@ import (
 	"github.com/pancsta/cview"
 	"golang.org/x/exp/maps"
 
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+
 	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 )
 
@@ -84,8 +85,16 @@ func (d *Debugger) BuildingLogState(e *am.Event) {
 			return // expired
 		}
 
-		// cview is safe
 		d.log.Clear()
+		if d.Opts.OutputLog {
+			go func() {
+				// TODO handle in LogBuiltState
+				d.logFileMx.Lock()
+				defer d.logFileMx.Unlock()
+				_, _ = d.logFile.Write(cview.StripTags([]byte(buf), true, true))
+			}()
+		}
+		// cview is thread safe
 		_, err := d.log.Write([]byte(buf))
 		// d.Mach.Log("writting %d", len(buf))
 		// d.Mach.Log(buf)
@@ -228,7 +237,7 @@ func (d *Debugger) handleLogScroll() {
 	d.log.ScrollTo(row, 0)
 }
 
-func (d *Debugger) hParseMsgLog(c *Client, msgTx *telemetry.DbgMsgTx, idx int) {
+func (d *Debugger) hParseMsgLog(c *Client, msgTx *dbg.DbgMsgTx, idx int) {
 	logEntries := make([]*am.LogEntry, 0)
 
 	tx := c.MsgTxs[idx]
@@ -295,7 +304,7 @@ func (d *Debugger) hParseMsgLog(c *Client, msgTx *telemetry.DbgMsgTx, idx int) {
 }
 
 func (d *Debugger) hParseMsgLogEntry(
-	c *Client, tx *telemetry.DbgMsgTx, entry *am.LogEntry,
+	c *Client, tx *dbg.DbgMsgTx, entry *am.LogEntry,
 ) *am.LogEntry {
 	lvl := entry.Level
 
@@ -1050,7 +1059,7 @@ func (d *Debugger) hUpdateLogReader(e *am.Event) {
 
 		// queued tx
 		if tx.IsQueued {
-			var executed *telemetry.DbgMsgTx
+			var executed *dbg.DbgMsgTx
 
 			// DEBUG
 			// // look into the future TODO links to the wrong one
@@ -1112,7 +1121,7 @@ func (d *Debugger) hUpdateLogReader(e *am.Event) {
 
 			// executed tx
 		} else {
-			var queued *telemetry.DbgMsgTx
+			var queued *dbg.DbgMsgTx
 
 			// look into the past
 			for iii := c.CursorTx1 - 2; iii >= 0; iii-- {
@@ -1582,7 +1591,7 @@ func (d *Debugger) hUpdateLogReader(e *am.Event) {
 
 func (d *Debugger) parseMsgReader(
 	c *Client, log *am.LogEntry, txEntries []*types.LogReaderEntryPtr,
-	tx *telemetry.DbgMsgTx,
+	tx *dbg.DbgMsgTx,
 ) []*types.LogReaderEntryPtr {
 	// TODO get data from SemLogger
 	// TODO add errs to machine (not log)

--- a/tools/debugger/misc_dbg.go
+++ b/tools/debugger/misc_dbg.go
@@ -1,12 +1,18 @@
 package debugger
 
 import (
+	"errors"
 	"log"
+	"os/exec"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/gdamore/tcell/v2"
+	"github.com/charmbracelet/ssh"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
+	"github.com/pancsta/tcell-v2/terminfo"
 
 	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
 	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
@@ -68,6 +74,7 @@ const (
 	// toolLog4              ToolName = "log-4"
 	toolReader ToolName = "reader"
 	toolRain   ToolName = "rain"
+	toolWeb    ToolName = "web"
 
 	// row 2
 
@@ -96,6 +103,7 @@ type Opts struct {
 	// MachAddress to listen on
 	AddrRpc  string
 	AddrHttp string
+	AddrSsh  string
 	// Log level of the debugger's machine
 	DbgLogLevel am.LogLevel
 	// Go race detector is enabled
@@ -107,7 +115,7 @@ type Opts struct {
 	Timelines int
 	// File path to import (brotli)
 	ImportData string
-	// File to dump client list into.
+	// Dump client list into a txt file.
 	OutputClients bool
 	// Root dir for output files
 	OutputDir string
@@ -127,6 +135,10 @@ type Opts struct {
 	TailMode        bool
 	OutputTx        bool
 	EnableClipboard bool
+	UiSsh           bool
+	UiWeb           bool
+	Print           func(txt string, args ...any)
+	OutputLog       bool
 }
 
 type OptsFilters struct {
@@ -213,4 +225,135 @@ func (c *Client) GetReaderEntry(txId string, idx int) *types.LogReaderEntry {
 	}
 
 	return ptrTx[idx]
+}
+
+// ///// ///// /////
+
+// ///// SSH
+
+// ///// ///// /////
+
+func NewSessionScreen(s ssh.Session) (tcell.Screen, error) {
+	pi, ch, ok := s.Pty()
+	if !ok {
+		return nil, errors.New("no pty requested")
+	}
+	ti, err := terminfo.LookupTerminfo(pi.Term)
+	if err != nil {
+		return nil, err
+	}
+	screen, err := tcell.NewTerminfoScreenFromTtyTerminfo(&tty{
+		Session: s,
+		size:    pi.Window,
+		ch:      ch,
+	}, ti)
+	if err != nil {
+		return nil, err
+	}
+	return screen, nil
+}
+
+type tty struct {
+	ssh.Session
+	size     ssh.Window
+	ch       <-chan ssh.Window
+	resizecb func()
+	mu       sync.Mutex
+}
+
+func (t *tty) Start() error {
+	go func() {
+		for win := range t.ch {
+			t.mu.Lock()
+			t.size = win
+			t.notifyResize()
+			t.mu.Unlock()
+		}
+	}()
+	return nil
+}
+
+func (t *tty) Stop() error {
+	return nil
+}
+
+func (t *tty) Drain() error {
+	return nil
+}
+
+func (t *tty) WindowSize() (window tcell.WindowSize, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return tcell.WindowSize{
+		Width:  t.size.Width,
+		Height: t.size.Height,
+	}, nil
+}
+
+func (t *tty) NotifyResize(cb func()) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.resizecb = cb
+}
+
+func (t *tty) notifyResize() {
+	if t.resizecb != nil {
+		t.resizecb()
+	}
+}
+
+// ///// ///// /////
+
+// ///// MISC
+
+// ///// ///// /////
+
+// openURL opens the specified URL in the default browser of the user.
+// https://gist.github.com/sevkin/9798d67b2cb9d07cb05f89f14ba682f8
+func openURL(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd.exe"
+		args = []string{
+			"/c", "rundll32", "url.dll,FileProtocolHandler",
+			strings.ReplaceAll(url, "&", "^&"),
+		}
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	default:
+		if isWSL() {
+			cmd = "cmd.exe"
+			args = []string{"start", url}
+		} else {
+			cmd = "xdg-open"
+			args = []string{url}
+		}
+	}
+
+	e := exec.Command(cmd, args...)
+	err := e.Start()
+	if err != nil {
+		return err
+	}
+	err = e.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// isWSL checks if the Go program is running inside Windows Subsystem for Linux
+func isWSL() bool {
+	releaseData, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(releaseData)), "microsoft")
 }

--- a/tools/debugger/server/dbg_server.go
+++ b/tools/debugger/server/dbg_server.go
@@ -7,6 +7,7 @@ package server
 import (
 	"encoding/gob"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -21,14 +22,13 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/soheilhy/cmux"
-
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	"github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
+	"github.com/soheilhy/cmux"
 )
 
 // ///// ///// /////
@@ -40,8 +40,8 @@ import (
 type Exportable struct {
 	// TODO refac to MsgSchema
 	// TODO version schemas
-	MsgStruct *telemetry.DbgMsgStruct
-	MsgTxs    []*telemetry.DbgMsgTx
+	MsgStruct *dbg.DbgMsgStruct
+	MsgTxs    []*dbg.DbgMsgTx
 }
 
 type Client struct {
@@ -157,7 +157,7 @@ func (c *Client) TxIndex(id string) int {
 	return -1
 }
 
-func (c *Client) Tx(idx int) *telemetry.DbgMsgTx {
+func (c *Client) Tx(idx int) *dbg.DbgMsgTx {
 	if idx < 0 || idx >= len(c.MsgTxs) {
 		return nil
 	}
@@ -291,8 +291,7 @@ func (c *Client) ParseSchema() {
 // ///// ///// /////
 
 func StartRpc(
-	mach *am.Machine, addr string, mux chan<- cmux.CMux, fwdAdds []string,
-	enableHttp bool,
+	mach *am.Machine, addr string, mux chan<- cmux.CMux, p types.Params,
 ) {
 	// TODO dont listen in WASM
 
@@ -300,7 +299,7 @@ func StartRpc(
 	gob.Register(am.Relation(0))
 	gob.Register(Exportable{})
 	if addr == "" {
-		addr = telemetry.DbgAddr
+		addr = dbg.DbgAddr
 	}
 	_, addrPort, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(addrPort)
@@ -314,9 +313,9 @@ func StartRpc(
 	}
 	mach.Log("dbg server started at %s", addr)
 
-	// connect to another instances
-	fwdTo := make([]*rpc.Client, len(fwdAdds))
-	for i, a := range fwdAdds {
+	// connect to other instances
+	fwdTo := make([]*rpc.Client, len(p.FwdData))
+	for i, a := range p.FwdData {
 		fwdTo[i], err = rpc.Dial("tcp", a)
 		if err != nil {
 			fmt.Printf("Cant fwd to %s: %s\n", a, err)
@@ -329,37 +328,42 @@ func StartRpc(
 	tcpL := mux1.Match(cmux.Any())
 	go tcpAccept(tcpL, mach, fwdTo)
 
-	// second cmux for http/ws on port+1
-	if enableHttp {
+	// HTTP and WS on port+1
+	if p.UiWeb {
 		httpAddr := fmt.Sprintf("%s:%d",
 			addr[:strings.LastIndex(addr, ":")], port+1)
-		httpLis, err := net.Listen("tcp", httpAddr)
-		if err != nil {
-			log.Println(err)
-			mach.AddErr(err, nil)
-			panic(err)
+		httpMux := http.ServeMux{}
+		httpMux.HandleFunc("/{$}", func(w http.ResponseWriter, r *http.Request) {
+			httpHandlerIndex(w, r, mach, p)
+		})
+		httpMux.Handle("/", http.FileServer(http.Dir(p.OutputDir)))
+		httpMux.HandleFunc("/diagrams/mach", func(
+			w http.ResponseWriter, r *http.Request,
+		) {
+
+			httpHandlerDiagMach(w, r, mach)
+		})
+		httpMux.HandleFunc("/diagrams/mach.svg", func(
+			w http.ResponseWriter, r *http.Request,
+		) {
+
+			httpHandlerDiagMach(w, r, mach)
+		})
+		httpMux.HandleFunc("/diagrams/mach.ws",
+			func(w http.ResponseWriter, r *http.Request) {
+				wsDiagHandler(w, r, mach)
+			})
+		httpMux.HandleFunc("/dbg.ws", func(w http.ResponseWriter, r *http.Request) {
+			wsDbgHandler(w, r, mach, fwdTo)
+		})
+		httpSrv := &http.Server{
+			Handler: &httpMux,
+			Addr:    httpAddr,
 		}
-		mux2 := cmux.New(httpLis)
-		httpL := mux2.Match(cmux.HTTP1())
-		httpS := &http.Server{
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-				if r.RequestURI == "/diagrams/mach.ws" {
-					wsHandler(w, r, mach)
-					return
-				}
-				httpHandler(w, r, mach)
-			})}
-
+		// listen
 		go func() {
-			mach.AddErr(httpS.Serve(httpL), nil)
-		}()
-		go func() {
-			if err := mux2.Serve(); err != nil {
-				fmt.Println(err)
-				mach.AddErr(err, nil)
-				os.Exit(1)
-			}
+			mach.AddErr(httpSrv.ListenAndServe(), nil)
 		}()
 	}
 
@@ -378,15 +382,16 @@ func StartRpc(
 	}
 }
 
-// TODO rename to RpcServer (compat break)
+// TODO rename to RPCServer (compat break)
 type RPCServer struct {
-	Mach   *am.Machine
+	Mach *am.Machine
+	// TODO ConnId
 	ConnID string
 	FwdTo  []*rpc.Client
 }
 
 type DbgMsgSchemaFwd struct {
-	MsgStruct *telemetry.DbgMsgStruct
+	MsgStruct *dbg.DbgMsgStruct
 	ConnId    string
 }
 
@@ -406,7 +411,7 @@ func (r *RPCServer) DbgMsgSchemaFwd(
 }
 
 func (r *RPCServer) DbgMsgSchema(
-	msgSchema *telemetry.DbgMsgStruct, _ *string,
+	msgSchema *dbg.DbgMsgStruct, _ *string,
 ) error {
 
 	r.Mach.Add1(ss.ConnectEvent, am.A{
@@ -433,13 +438,13 @@ func (r *RPCServer) DbgMsgSchema(
 }
 
 var (
-	queue       []*telemetry.DbgMsgTx
+	queue       []*dbg.DbgMsgTx
 	queueConnId []string
 	queueMx     sync.Mutex
 	scheduled   bool
 )
 
-func (r *RPCServer) DbgMsgTx(msgTx *telemetry.DbgMsgTx, _ *string) error {
+func (r *RPCServer) DbgMsgTx(msgTx *dbg.DbgMsgTx, _ *string) error {
 	queueMx.Lock()
 	defer queueMx.Unlock()
 
@@ -486,7 +491,7 @@ func (r *RPCServer) DbgMsgTx(msgTx *telemetry.DbgMsgTx, _ *string) error {
 }
 
 type DbgMsgTx struct {
-	MsgTx  *telemetry.DbgMsgTx
+	MsgTx  *dbg.DbgMsgTx
 	ConnId string
 }
 
@@ -552,28 +557,33 @@ func tcpAccept(l net.Listener, mach *am.Machine, fwdTo []*rpc.Client) {
 		}
 
 		// handle the client
-		go func() {
-			server := rpc.NewServer()
-			connID := utils.RandId(8)
-			rcvr := &RPCServer{
-				Mach:   mach,
-				ConnID: connID,
-				FwdTo:  fwdTo,
-			}
-
-			err = server.Register(rcvr)
-			if err != nil {
-				rcvr.Mach.AddErr(err, nil)
-				// TODO err msg
-				fmt.Println(err)
-				os.Exit(1)
-			}
-			server.ServeConn(conn)
-
-			// TODO pass to range fwdTo (dedicated RPC method)
-			rcvr.Mach.Add1(ss.DisconnectEvent, am.A{"conn_id": connID})
-		}()
+		go AcceptConn(conn, mach, fwdTo)
 	}
+}
+
+// AcceptConn accepts a std rpc connection, or alike.
+func AcceptConn(
+	conn io.ReadWriteCloser, mach *am.Machine, fwdTo []*rpc.Client,
+) {
+	server := rpc.NewServer()
+	connId := utils.RandId(8)
+	rcvr := &RPCServer{
+		Mach:   mach,
+		ConnID: connId,
+		FwdTo:  fwdTo,
+	}
+
+	err := server.Register(rcvr)
+	if err != nil {
+		rcvr.Mach.AddErr(err, nil)
+		// TODO err msg
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	server.ServeConn(conn)
+
+	// TODO pass to range fwdTo (dedicated RPC method)
+	rcvr.Mach.Add1(ss.DisconnectEvent, am.A{"conn_id": connId})
 }
 
 // ///// ///// /////
@@ -582,8 +592,54 @@ func tcpAccept(l net.Listener, mach *am.Machine, fwdTo []*rpc.Client) {
 
 // ///// ///// /////
 
-// httpHandler serves plain HTTP requests.
-func httpHandler(w http.ResponseWriter, r *http.Request, mach *am.Machine) {
+// httpHandlerIndex lists --dir
+func httpHandlerIndex(
+	w http.ResponseWriter, r *http.Request, mach *am.Machine, p types.Params,
+) {
+	middleware(w)
+
+	// Read directory contents
+	entries, err := os.ReadDir(p.OutputDir)
+	if err != nil {
+		mach.AddErr(err, nil)
+		http.Error(w, "Failed to read directory", http.StatusInternalServerError)
+		return
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsDir() != entries[j].IsDir() {
+			return entries[i].IsDir()
+		}
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	// Build HTML response
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, "<html><head><title>am-dbg --dir %s</title></head><body>",
+		p.OutputDir)
+	fmt.Fprintf(w, "<h1>am-dbg</h1><hr>")
+
+	fmt.Fprintf(w, "<h2>Pages</h2><hr><ul>")
+	// TODO read from state and hide
+	fmt.Fprintf(w, `<li><a href="/diagrams/mach">/diagrams/mach</a></li>`)
+	fmt.Fprintf(w, `</ul>`)
+
+	fmt.Fprintf(w, "<h2>--dir %s</h2><hr><ul>", p.OutputDir)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			name += "/"
+		}
+		fmt.Fprintf(w, `<li><a href="%s">%s</a></li>`, name, name)
+	}
+
+	fmt.Fprintf(w, "</ul><hr></body></html>")
+}
+
+// httpHandlerDiagMach serve the diagram website.
+func httpHandlerDiagMach(
+	w http.ResponseWriter, r *http.Request, mach *am.Machine,
+) {
 	done := make(chan struct{})
 
 	middleware(w)
@@ -593,6 +649,7 @@ func httpHandler(w http.ResponseWriter, r *http.Request, mach *am.Machine) {
 		return
 	}
 
+	// TODO WebDiagReq
 	mach.Add1(ss.WebReq, am.A{
 		// TODO typed params
 		"uri":                 r.RequestURI,
@@ -605,34 +662,37 @@ func httpHandler(w http.ResponseWriter, r *http.Request, mach *am.Machine) {
 	<-done
 }
 
-// wsHandler handles WebSocket upgrade requests and echoes messages.
-func wsHandler(w http.ResponseWriter, r *http.Request, mach *am.Machine) {
+// wsDiagHandler handles diagram updates.
+func wsDiagHandler(w http.ResponseWriter, r *http.Request, mach *am.Machine) {
 	middleware(w)
 
-	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
 		mach.AddErrState(ss.ErrWeb, err, nil)
 		return
 	}
-	defer c.Close(websocket.StatusInternalError, "internal error")
+	defer conn.Close(websocket.StatusInternalError, "internal error")
+	// TODO remove?
 	done := make(chan struct{})
-	mach.Add1(ss.WebSocket, am.A{
+	mach.Add1(ss.WebSocketDiag, am.A{
 		// TODO typed params
-		"*websocket.Conn":     c,
+		"*websocket.Conn":     conn,
 		"*http.Request":       r,
 		"http.ResponseWriter": w,
 		"doneChan":            done,
 		"addr":                r.RemoteAddr,
 	})
 	// TODO timeout
+	// TODO r.Context()?
 	<-done
 }
 
 func middleware(w http.ResponseWriter) {
+	// TODO add security
 	// CORS
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Origin", "localhost")
 	w.Header().Set("Access-Control-Allow-Methods",
 		"POST, GET, OPTIONS, PUT, DELETE")
 	w.Header().Set("Access-Control-Allow-Headers",
@@ -643,6 +703,22 @@ func middleware(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
+}
+
+// wsDbgHandler handles dbg protocol over WS.
+func wsDbgHandler(
+	w http.ResponseWriter, r *http.Request, mach *am.Machine, fwdTo []*rpc.Client,
+) {
+
+	connWs, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		log.Printf("Upgrade error: %v", err)
+		return
+	}
+	conn := websocket.NetConn(mach.Context(), connWs, websocket.MessageBinary)
+	AcceptConn(conn, mach, fwdTo)
 }
 
 // ///// ///// /////

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -32,10 +32,11 @@ var States = am.Schema{
 		Multi:   true,
 		Require: S{Start},
 	},
-	WebSocket: {
+	WebSocketDiag: {
 		Multi:   true,
 		Require: S{Start},
 	},
+	WebSocketDbg: {Require: S{Start}},
 
 	// user scrolling tx / steps
 	UserFwd: {
@@ -261,6 +262,11 @@ var States = am.Schema{
 	DiagramsReady: {Remove: S{DiagramsRendering}},
 
 	InitClient: {Multi: true},
+	SshServer:  {Require: S{Start}},
+	SshDisconn: {
+		Multi:   true,
+		Require: S{SshServer},
+	},
 }
 
 // Groups of states.
@@ -362,7 +368,8 @@ const (
 	ConnectEvent       = "ConnectEvent"
 	DisconnectEvent    = "DisconnectEvent"
 	WebReq             = "WebReq"
-	WebSocket          = "WebSocket"
+	WebSocketDiag      = "WebSocketDiag"
+	WebSocketDbg       = "WebSocketDbg"
 	RemoveClient       = "RemoveClient"
 	ClientSelected     = "ClientSelected"
 	BuildingLog        = "BuildingLog"
@@ -424,6 +431,8 @@ const (
 	ErrDiagrams        = "ErrDiagrams"
 	ErrWeb             = "ErrWeb"
 	InitClient         = "InitClient"
+	SshServer          = "SshServer"
+	SshDisconn         = "SshDisconn"
 )
 
 // Names of all the states (pkg enum).
@@ -438,7 +447,8 @@ var Names = S{
 	ConnectEvent,
 	DisconnectEvent,
 	WebReq,
-	WebSocket,
+	WebSocketDiag,
+	WebSocketDbg,
 
 	// user scrolling
 	UserFwd,
@@ -541,6 +551,8 @@ var Names = S{
 	ErrWeb,
 
 	InitClient,
+	SshServer,
+	SshDisconn,
 }
 
 // #endregion

--- a/tools/debugger/test/integration_test.go
+++ b/tools/debugger/test/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
 	"github.com/soheilhy/cmux"
 	"github.com/stretchr/testify/assert"
 
@@ -67,7 +68,7 @@ func init() {
 	// init am-dbg telemetry server
 	muxCh := make(chan cmux.CMux, 1)
 	defer close(muxCh)
-	go server.StartRpc(worker.Mach, workerAddr, muxCh, nil, false)
+	go server.StartRpc(worker.Mach, workerAddr, muxCh, types.Params{})
 	// wait for mux
 	<-muxCh
 }

--- a/tools/debugger/test/remote/integration_remote_test.go
+++ b/tools/debugger/test/remote/integration_remote_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	testing2 "github.com/pancsta/asyncmachine-go/pkg/helpers/testing"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
 	"github.com/stretchr/testify/assert"
 
 	amtest "github.com/pancsta/asyncmachine-go/internal/testing"
@@ -18,7 +19,6 @@ import (
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	arpc "github.com/pancsta/asyncmachine-go/pkg/rpc"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	"github.com/pancsta/asyncmachine-go/tools/debugger"
 	"github.com/pancsta/asyncmachine-go/tools/debugger/server"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
@@ -114,7 +114,7 @@ func TestTailModeRemote(t *testing.T) {
 
 	// connect to the worker as a new telemetry client
 	mach.SemLogger().SetLevel(am.LogOps)
-	err := telemetry.TransitionsToDbg(mach, workerTelemetryAddr)
+	err := dbg.TransitionsToDbg(mach, workerTelemetryAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/debugger/tree.go
+++ b/tools/debugger/tree.go
@@ -9,11 +9,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
+
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
 
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 	ss "github.com/pancsta/asyncmachine-go/tools/debugger/states"
 )
 
@@ -116,7 +117,7 @@ func (d *Debugger) hInitSchemaTree() *cview.TreeView {
 func (d *Debugger) hUpdateSchemaTree() {
 	// TODO refac to updateSchema (state)
 
-	var msg telemetry.DbgMsg
+	var msg dbg.DbgMsg
 	c := d.C
 	if c == nil {
 		return
@@ -151,7 +152,7 @@ func (d *Debugger) hUpdateSchemaTree() {
 // returns the length of the longest row
 // TODO refactor
 func (d *Debugger) hUpdateTreeDefaultsHighlights(
-	msg telemetry.DbgMsg, idx int,
+	msg dbg.DbgMsg, idx int,
 ) int {
 	c := d.C
 	if c == nil {
@@ -303,7 +304,7 @@ func (d *Debugger) hUpdateTreeDefaultsHighlights(
 }
 
 func (d *Debugger) hUpdateTreeTxSteps(
-	steps []*am.Step, tx *telemetry.DbgMsgTx,
+	steps []*am.Step, tx *dbg.DbgMsgTx,
 ) int {
 	c := d.C
 	if c == nil {
@@ -486,7 +487,7 @@ func (d *Debugger) hUpdateTreeTxSteps(
 var reTreeStateColorFix = regexp.MustCompile(`\[white\](M?\|\d+)(\.*)`)
 
 func (d *Debugger) hUpdateTreeRelCols(
-	colStartIdx int, steps []*am.Step, msg telemetry.DbgMsg,
+	colStartIdx int, steps []*am.Step, msg dbg.DbgMsg,
 ) {
 	c := d.C
 	if c == nil {

--- a/tools/debugger/types/cli_dbg.go
+++ b/tools/debugger/types/cli_dbg.go
@@ -12,21 +12,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
 	"github.com/spf13/cobra"
 
 	am "github.com/pancsta/asyncmachine-go/pkg/machine"
-	"github.com/pancsta/asyncmachine-go/pkg/telemetry"
 )
 
 // TODO enum
-// TODO cobra groups
+// TODO refac to go-arg
 const (
 	pDbgLogLevel      = "dbg-log-level"
 	pDbgAmDbgAddr     = "dbg-am-dbg-addr"
 	pGoRace           = "dbg-go-race"
 	pId               = "dbg-id"
-	pServerAddr       = "listen-on"
-	pServerAddrShort  = "l"
+	pListenAddr       = "listen-addr"
+	pListenAddrShort  = "l"
 	pEnableMouse      = "enable-mouse"
 	pEnableClipboard  = "enable-clipboard"
 	pCleanOnConnect   = "clean-on-connect"
@@ -42,10 +42,11 @@ const (
 	pStartupTxShort   = "t"
 	pTail             = "tail"
 	// TODO AM_DBG_PROF
-	pProfSrv      = "dbg-prof-srv"
-	pMaxMem       = "max-mem"
-	pLogOpsTtl    = "log-ops-ttl"
-	pReaderShort  = "r"
+	pProfSrv     = "dbg-prof-srv"
+	pMaxMem      = "max-mem"
+	pLogOpsTtl   = "log-ops-ttl"
+	pReaderShort = "r"
+	// TODO refac fwd-addr
 	pFwdData      = "fwd-data"
 	pFwdDataShort = "f"
 	// TODO --filters + loglevel, eg canceled,L1,empty
@@ -57,17 +58,19 @@ const (
 	pOutputDirShort = "d"
 	pOutputClients  = "output-clients"
 	pOutputTx       = "output-tx"
+	pOutputLog      = "output-log"
 	pOutputDiagrams = "output-diagrams"
-	pUiDiagrams     = "ui-diagrams"
 
 	// UI
 
-	pView       = "view"
-	pViewShort  = "v"
-	pViewNarrow = "view-narrow"
-	pViewReader = "view-reader"
-	pTimelines  = "view-timelines"
-	pRain       = "view-rain"
+	pView          = "view"
+	pViewShort     = "v"
+	pViewNarrow    = "view-narrow"
+	pViewReader    = "view-reader"
+	pViewTimelines = "view-timelines"
+	pViewRain      = "view-rain"
+	pUiWeb         = "ui-web"
+	pUiSsh         = "ui-ssh"
 
 	// filters
 
@@ -89,6 +92,7 @@ type Params struct {
 	RaceDetector    bool
 	ImportData      string
 	EnableMouse     bool
+	UiSsh           bool
 	EnableClipboard bool
 	CleanOnConnect  bool
 	SelectConnected bool
@@ -97,7 +101,7 @@ type Params struct {
 	ProfSrv         string
 	MaxMemMb        int
 	LogOpsTtl       time.Duration
-	Reader          bool
+	ViewReader      bool
 	FwdData         []string
 
 	StartupMachine string
@@ -113,13 +117,14 @@ type Params struct {
 
 	OutputDir      string
 	OutputDiagrams int
-	UiDiagrams     bool
+	UiWeb          bool
 	OutputClients  bool
-	Timelines      int
+	ViewTimelines  int
 	Rain           bool
 	TailMode       bool
 	OutputTx       bool
 	MachUrl        string
+	OutputLog      bool
 }
 
 type RootFn func(cmd *cobra.Command, args []string, params Params)
@@ -146,7 +151,7 @@ func AddFlags(rootCmd *cobra.Command) {
 	// TODO understand string names like Changes, Ops
 	f.Int(pDbgLogLevel, int(am.LogNothing),
 		"Log level produced by this instance, 0-5 (silent-everything)")
-	f.StringP(pServerAddr, pServerAddrShort, telemetry.DbgAddr,
+	f.StringP(pListenAddr, pListenAddrShort, dbg.DbgAddr,
 		"Host and port for the debugger to listen on")
 	f.String(pId, "am-dbg", "ID of this instance")
 	f.String(pDbgAmDbgAddr, "", "Debug this instance of am-dbg with another one")
@@ -162,7 +167,9 @@ func AddFlags(rootCmd *cobra.Command) {
 		"Select a transition by _number_ on startup (requires --"+
 			pStartupMach+")")
 	f.String(pStartupGroup, "", "Startup group")
-	f.Bool(pEnableMouse, true, "Enable mouse support (experimental)")
+	f.Bool(pEnableMouse, true, "Enable mouse support")
+	f.Bool(pUiSsh, false,
+		"Enable SSH headless mode on port --listen-addr +2. EXPERIMENTAL")
 	f.Bool(pEnableClipboard, true, "Enable clipboard support")
 	f.Bool(pCleanOnConnect, true,
 		"Clean up disconnected clients on the 1st connection")
@@ -178,8 +185,8 @@ func AddFlags(rootCmd *cobra.Command) {
 	// FILTERS
 
 	f.Bool(pFilterGroup, true, "Filter transitions by a selected group")
-	f.Int(pFilterLogLevel, int(am.LogChanges), "Filter transitions to this log "+
-		"level, 0-5 (silent-everything)")
+	f.Int(pFilterLogLevel, int(am.LogChanges), "Filter transitions up to this"+
+		" log level, 0-5 (silent-everything)")
 
 	// MISC
 
@@ -194,15 +201,19 @@ func AddFlags(rootCmd *cobra.Command) {
 		"Output directory for generated files")
 	f.Bool(pOutputClients, false,
 		"Write a detailed client list into am-dbg-clients.txt inside --dir")
-	f.Bool(pOutputTx, false,
-		"Write the current transition with steps into am-dbg-tx.md inside --dir")
+	f.Bool(pOutputTx, true,
+		"Write the current transition with steps into tx.md / d2 / mermaid"+
+			" / txt inside --dir. EXPERIMENTAL")
+	f.Bool(pOutputLog, false,
+		"Write the current log buffer to log.txt inside --dir.")
 	f.Int(pOutputDiagrams, 0,
-		"Level of details for diagrams (svg, d2, mermaid) in "+
+		"Level of details for machine graph diagrams (svg, d2, mermaid) in "+
 			"--dir (0 off, 1-3 on). EXPERIMENTAL")
-	f.Bool(pUiDiagrams, true,
-		"Start a web diagrams viewer on a +1 port (EXPERIMENTAL)")
-	f.Int(pTimelines, 2, "Number of timelines to show (0-2)")
-	f.Bool(pRain, false, "Show the rain view")
+	f.Bool(pUiWeb, true,
+		"Start a web server for --dir and diagrams on --listen-addr +1 "+
+			"(EXPERIMENTAL)")
+	f.Int(pViewTimelines, 2, "Number of timelines to show (0-2)")
+	f.Bool(pViewRain, false, "Show the rain view")
 	f.Bool(pTail, true, "Start from the lastest tx")
 }
 
@@ -234,7 +245,7 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 	}
 	filterLogLevel := am.LogLevel(min(5, filterLogLevelInt))
 
-	serverAddr := cmd.Flag(pServerAddr).Value.String()
+	serverAddr := cmd.Flag(pListenAddr).Value.String()
 	debugAddr := cmd.Flag(pDbgAmDbgAddr).Value.String()
 	importData := cmd.Flag(pImport).Value.String()
 	startupGroup := cmd.Flag(pStartupGroup).Value.String()
@@ -250,13 +261,13 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 		panic(err)
 	}
 	outputDiagrams = min(3, outputDiagrams)
-	uiDiagrams, err := cmd.Flags().GetBool(pUiDiagrams)
+	uiWeb, err := cmd.Flags().GetBool(pUiWeb)
 	if err != nil {
 		panic(err)
 	}
 
 	// timelines
-	timelines, err := cmd.Flags().GetInt(pTimelines)
+	timelines, err := cmd.Flags().GetInt(pViewTimelines)
 	if err != nil {
 		panic(err)
 	}
@@ -267,6 +278,10 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 		panic(err)
 	}
 	outputTx, err := cmd.Flags().GetBool(pOutputTx)
+	if err != nil {
+		panic(err)
+	}
+	outputLog, err := cmd.Flags().GetBool(pOutputLog)
 	if err != nil {
 		panic(err)
 	}
@@ -287,7 +302,7 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 		panic(err)
 	}
 
-	rain, err := cmd.Flags().GetBool(pRain)
+	rain, err := cmd.Flags().GetBool(pViewRain)
 	if err != nil {
 		panic(err)
 	}
@@ -301,6 +316,11 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 	}
 
 	enableMouse, err := cmd.Flags().GetBool(pEnableMouse)
+	if err != nil {
+		panic(err)
+	}
+
+	uiSsh, err := cmd.Flags().GetBool(pUiSsh)
 	if err != nil {
 		panic(err)
 	}
@@ -358,11 +378,14 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 
 		EnableMouse:     enableMouse,
 		EnableClipboard: enableClipboard,
-		Reader:          reader,
 		StartupView:     startupView,
 		StartupGroup:    startupGroup,
 		ViewNarrow:      viewNarrow,
 		ViewRain:        rain,
+		ViewReader:      reader,
+		ViewTimelines:   timelines,
+		UiWeb:           uiWeb,
+		UiSsh:           uiSsh,
 
 		// filters
 
@@ -373,10 +396,9 @@ func ParseParams(cmd *cobra.Command, args []string) Params {
 
 		OutputClients:  outputClients,
 		OutputTx:       outputTx,
+		OutputLog:      outputLog,
 		OutputDir:      outputDir,
 		OutputDiagrams: outputDiagrams,
-		UiDiagrams:     uiDiagrams,
-		Timelines:      timelines,
 
 		// misc
 

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/lithammer/dedent"
 	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
 	"github.com/zyedidia/clipper"
 
 	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
@@ -316,6 +317,7 @@ func (d *Debugger) hInitToolbar() {
 		d.toolbars[i].SetSelectedStyle(colorActive,
 			cview.Styles.PrimitiveBackgroundColor, tcell.AttrBold)
 		d.toolbars[i].SetSelectable(true, true)
+		// TODO remove empty space
 		d.toolbars[i].SetBorders(false)
 
 		// click effect
@@ -452,6 +454,14 @@ func (d *Debugger) hInitToolbar() {
 				return d.Mach.Any1(ss.MatrixView, ss.TreeMatrixView)
 			}},
 		},
+	}
+
+	if d.Opts.AddrHttp != "" {
+		d.toolbarItems[2] = slices.Insert(d.toolbarItems[2], 3,
+			toolbarItem{id: toolWeb, label: "web", active: func() bool {
+				return false
+			}},
+		)
 	}
 
 	d.hUpdateToolbar()
@@ -638,7 +648,8 @@ func (d *Debugger) hUpdateHelpDialog() {
 		[::b]alt o[::-]              log reader
 		[::b]home/end[::-]           schema / last tx
 		[::b]alt s[::-]              export data
-		[::b]backspace[::-]          remove machine
+		[::b]backspace[::-]          remove client
+		[::b]alt-d[::-]              remove client
 		[::b]esc[::-]                focus mach list
 		[::b]ctrl q[::-]             quit
 		[::b]?[::-]                  show help
@@ -675,11 +686,12 @@ func (d *Debugger) hUpdateHelpDialog() {
 	
 		[::b]### [::u]about am-dbg[::-]
 		%-15s    version
-		%-15s    server DBG addr
-		%-15s    server HTTP addr
+		%-15s    DBG server addr
+		%-15s    HTTP server addr
+		%-15s    SSH server addr
 		%-15s    mem usage
 	`, "\n ")), colorActive, d.Opts.Version, d.Opts.AddrRpc,
-		d.Opts.AddrHttp, strconv.Itoa(mem)+"mb"))
+		d.Opts.AddrHttp, d.Opts.AddrSsh, strconv.Itoa(mem)+"mb"))
 }
 
 func (d *Debugger) hInitLayout() {
@@ -832,7 +844,7 @@ func (d *Debugger) draw(components ...cview.Primitive) {
 
 	go func() {
 		select {
-		case <-d.Mach.Ctx().Done():
+		case <-d.Mach.Context().Done():
 			return
 
 		// debounce every 16msec


### PR DESCRIPTION
- feat: add `--ui-ssh` for SSH access and embedding
- feat: add `--ui-web` for web access to files in `--dir`
- feat: add support for WebSocket clients
- `listen-on` is now `--listen-addr`
- fix: fixed single-frame export
- feat: add `--output-log`

A lot of dev accessibility improvments in `v0.18`:
- SSH allows for embedding the debugger in an app, and connecting the UI on demand (1 simultaneous client only)
- Web UI makes browsing `--dir` assets much easier, also links to pages (for now only `/diagrams/mach`)
- some params changed, some were added

<img width="765" height="835" alt="ss-2026-02-21-13-18-57" src="https://github.com/user-attachments/assets/3c557254-78cf-4efe-b70b-2744dda69708" />
