### PR TITLE
refac(rpc): improve Mux APIs

### DIFF
--- a/pkg/rpc/mux.go
+++ b/pkg/rpc/mux.go
@@ -2,11 +2,13 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
 	"sync/atomic"
 
+	ampipe "github.com/pancsta/asyncmachine-go/pkg/states/pipes"
 	"github.com/soheilhy/cmux"
 
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
@@ -16,7 +18,7 @@ import (
 
 // MuxNewServerFn is a function to create a new RPC server for each incoming
 // connection.
-type MuxNewServerFn func(num int, conn net.Conn) (*Server, error)
+type MuxNewServerFn func(mux *Mux, id string, conn net.Conn) (*Server, error)
 
 var ssM = states.MuxStates
 
@@ -28,43 +30,44 @@ type Mux struct {
 	// Source is the state source to expose via RPC. Required if NewServerFn
 	// isnt provided.
 	Source am.Api
-	// NewServerFn creates a new instance of Server and is called for every new
-	// connection.
-	NewServerFn MuxNewServerFn
 	// Typed arguments struct value
 	Args any
 
 	Name string
 	Addr string
-	// The listener used by this Mux, can be set manually before Start().
+	// Listener used by this [Mux], can be set manually before Start().
 	Listener   net.Listener
 	LogEnabled bool
 	// The last error returned by NewServerFn.
 	NewServerErr error
 	Opts         MuxOpts
 
-	clients   []net.Conn
-	cmux      cmux.CMux
-	connCount atomic.Int64
+	cmux          cmux.CMux
+	countConns    atomic.Int64
+	countDisconns atomic.Int64
 }
 
 // NewMux initializes a Mux instance to handle RPC server creation for incoming
 // connections with the given parameters.
 //
-// newServerFn: when nil, [Mux.Source] needs to be set manually before calling
-// [Mux.Start].
+// addr: can be empty if [Mux.Listener] is set later.
+// stateSource: optional, can be replaced with [opts.NewServerFn].
 func NewMux(
-	ctx context.Context, name string, newServerFn MuxNewServerFn, opts *MuxOpts,
+	ctx context.Context, addr string, name string, stateSource am.Api,
+	opts *MuxOpts,
 ) (*Mux, error) {
+	// TODO allow muxers without listening on a port (for relay matchers)
+
 	if opts == nil {
 		opts = &MuxOpts{}
 	}
 	d := &Mux{
-		Name:        name,
-		LogEnabled:  os.Getenv(EnvAmRpcLogMux) != "",
-		NewServerFn: newServerFn,
-		Args:        opts.Args,
-		Opts:        *opts,
+		Name:       name,
+		LogEnabled: os.Getenv(EnvAmRpcLogMux) != "",
+		Source:     stateSource,
+		Addr:       addr,
+		Args:       opts.Args,
+		Opts:       *opts,
 	}
 
 	mach, err := am.NewCommon(ctx, "rm-"+name, states.MuxSchema, ssM.Names(),
@@ -107,7 +110,8 @@ func (m *Mux) NewServerErrState(e *am.Event) {
 }
 
 func (m *Mux) StartEnter(e *am.Event) bool {
-	return m.NewServerFn != nil || m.Source != nil
+	// require either a source or factory
+	return m.Opts.NewServerFn != nil || m.Source != nil
 }
 
 func (m *Mux) StartState(e *am.Event) {
@@ -173,7 +177,7 @@ func (m *Mux) ClientConnectedState(e *am.Event) {
 }
 
 func (m *Mux) HasClientsEnd(e *am.Event) bool {
-	return len(m.clients) == 0
+	return m.countConns.Load() == m.countDisconns.Load()
 }
 
 func (m *Mux) HealthcheckState(e *am.Event) {
@@ -199,7 +203,6 @@ func (m *Mux) accept(e *am.Event, l net.Listener) {
 		// TODO handle ErrListenerClosed and ErrServerClosed
 		conn, err := l.Accept()
 		if err != nil {
-
 			mach.AddErr(err, nil)
 			continue
 		}
@@ -208,36 +211,18 @@ func (m *Mux) accept(e *am.Event, l net.Listener) {
 		}))
 
 		// get a new conn number
-		var num int64 = -1
-		for {
-			num = m.connCount.Load()
-			if m.connCount.CompareAndSwap(num, num+1) {
-				break
-			}
-		}
+		nextId := m.countConns.Add(1)
 
 		// new instance
-		var server *Server
-		if m.NewServerFn == nil {
-			server, err = NewServer(m.Mach.Context(), ":0",
-				m.Name+"-"+strconv.Itoa(int(num)), m.Source, &ServerOpts{
-					Parent:   m.Mach,
-					Args:     m.Args,
-					ParseRpc: m.Opts.ParseRpc,
-				})
-		} else {
-			server, err = m.NewServerFn(int(num), conn)
-		}
+		server, err := m.NewServer(e, strconv.Itoa(int(nextId)), conn)
 		// TODO return this err to the RPC client
 		if err != nil {
 			_ = conn.Close()
 			mach.Log("failed to create a new server: %s", err)
+			m.countDisconns.Add(1)
 			continue
 		}
-
-		// inject net.Conn
-		server.Conn = conn
-		server.Start(e)
+		mach.EvAdd1(e, ssM.HasClients, nil)
 
 		// TODO optimize: re-use old instances?
 		// TODO handle with a state, not a goroutine
@@ -247,8 +232,40 @@ func (m *Mux) accept(e *am.Event, l net.Listener) {
 			<-server.Mach.When1(ssS.ClientConnected, muxCtx)
 			<-server.Mach.WhenNot1(ssS.ClientConnected, muxCtx)
 			server.Stop(e, true)
+			m.countDisconns.Add(1)
+			mach.EvRemove1(e, ssM.HasClients, nil)
 		}()
 	}
+}
+
+// NewServer creates a new server instance for this muxer.
+func (m *Mux) NewServer(
+	e *am.Event, id string, conn net.Conn,
+) (*Server, error) {
+	var srv *Server
+	var err error
+	if m.Opts.NewServerFn == nil {
+		srv, err = m.NewDefaultServer(id)
+	} else {
+		srv, err = m.Opts.NewServerFn(m, id, conn)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	srv.Conn = conn
+	srv.Start(e)
+
+	return srv, nil
+}
+
+func (m *Mux) NewDefaultServer(id string) (*Server, error) {
+	return NewServer(m.Mach.Context(), "",
+		m.Name+"-"+id, m.Source, &ServerOpts{
+			Parent:   m.Mach,
+			Args:     m.Args,
+			ParseRpc: m.Opts.ParseRpc,
+		})
 }
 
 func (m *Mux) Start(e *am.Event) am.Result {
@@ -278,6 +295,9 @@ func (m *Mux) log(msg string, args ...any) {
 // ///// ///// /////
 
 type MuxOpts struct {
+	// NewServerFn is a function to create a new RPC server for each incoming
+	// connection. Optional.
+	NewServerFn MuxNewServerFn
 	// Parent is a parent state machine for a new Mux state machine. See
 	// [am.Opts].
 	Parent am.Api
@@ -285,16 +305,23 @@ type MuxOpts struct {
 	Args any
 	// optional RPC args parser
 	ParseRpc func(args am.A) am.A
-
-	// Listen on a WebSocket connection instead of TCP.
-	// WebSocket bool
-	// // HTTP URL without proto to tunnel the TCP listen over a WebSocket conn.
-	// // See WsListenPath.
-	// WebSocketTunnel string
 }
 
-// WEBSOCKET
+// BindMux binds the HasClients state with Add/Remove to custom states.
+func BindMux(
+	source, target *am.Machine, activeState, inactiveState string,
+) error {
+	if activeState == "" {
+		return fmt.Errorf("active state must be set")
+	}
+	if inactiveState == "" {
+		inactiveState = activeState
+	}
 
+	return ampipe.Bind(source, target, ssM.HasClients, activeState, inactiveState)
+}
+
+// TODO
 // type wsHandlerMux struct {
 // 	m     *Mux
 // 	event *am.Event

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -52,6 +52,7 @@ const (
 
 	PrefixNetMach = "rnm-"
 	WsPathListen  = "/listen/"
+	WsPathDial    = "/dial/"
 )
 
 var ss = states.SharedStates
@@ -1053,7 +1054,7 @@ func MachRepl(mach am.Api, addr string, opts *ReplOpts) error {
 		}
 	}
 
-	mux, err := NewMux(mach.Context(), "repl-"+mach.Id(), nil, &MuxOpts{
+	mux, err := NewMux(mach.Context(), addr, "repl-"+mach.Id(), mach, &MuxOpts{
 		Parent:   mach,
 		Args:     opts.Args,
 		ParseRpc: opts.ParseRpc,
@@ -1061,8 +1062,6 @@ func MachRepl(mach am.Api, addr string, opts *ReplOpts) error {
 	if err != nil {
 		return err
 	}
-	mux.Addr = addr
-	mux.Source = mach
 	mux.Start(nil)
 
 	if addrCh == nil && addrDir == "" {
@@ -1303,4 +1302,10 @@ func newClosedChan() chan struct{} {
 // Eg /listen/MyMach/localhost:1234
 func WsListenPath(machId, addr string) string {
 	return WsPathListen + machId + "/" + addr
+}
+
+// WsDialPath creates a WebSocket dial listen URL path.
+// Eg /dial/MyMach/localhost:1234
+func WsDialPath(machId, addr string) string {
+	return WsPathDial + machId + "/" + addr
 }

--- a/pkg/rpc/rpc_client.go
+++ b/pkg/rpc/rpc_client.go
@@ -139,9 +139,11 @@ var (
 // takes a consumer, which is a state machine with a ServerPayload state. See
 // states.ConsumerStates.
 func NewClient(
-	ctx context.Context, netSrcAddr string, name string, netSrcSchema am.Schema,
+	ctx context.Context, addr string, name string, netSrcSchema am.Schema,
 	opts *ClientOpts,
 ) (*Client, error) {
+	//
+
 	// defaults
 	if name == "" {
 		name = "rpc"
@@ -152,20 +154,15 @@ func NewClient(
 	if !opts.NoSchema && netSrcSchema == nil {
 		netSrcSchema = am.Schema{}
 	}
-	if amhelp.IsWasm() {
+	if amhelp.IsWasm() && opts.WebSocket == "" {
 		opts.WebSocket = "/"
-	}
-
-	// validate
-	if netSrcAddr == "" {
-		return nil, errors.New("rpcc: netSrcAddr required")
 	}
 
 	c := &Client{
 		Name:               name,
 		ExceptionHandler:   &ExceptionHandler{},
 		LogEnabled:         os.Getenv(EnvAmRpcLogClient) != "",
-		Addr:               netSrcAddr,
+		Addr:               addr,
 		CallTimeout:        3 * time.Second,
 		ConnTimeout:        3 * time.Second,
 		DisconnTimeout:     3 * time.Second,
@@ -197,7 +194,7 @@ func NewClient(
 	mach, err := am.NewCommon(ctx, GetClientId(name), states.ClientSchema,
 		ssC.Names(), c, opts.Parent, &am.Opts{Tags: []string{
 			TagRpcClient,
-			"addr:" + netSrcAddr,
+			"addr:" + addr,
 		}})
 	if err != nil {
 		return nil, err
@@ -277,6 +274,11 @@ func (c *Client) StartEnd(e *am.Event) {
 	if wasConn {
 		c.Mach.EvAdd1(e, ssC.Disconnecting, nil)
 	}
+}
+
+func (c *Client) ConnectingEnter(e *am.Event) bool {
+	// require either the addr or a conn
+	return c.Addr != "" || c.Conn.Load() != nil
 }
 
 func (c *Client) ConnectingState(e *am.Event) {

--- a/pkg/rpc/rpc_server.go
+++ b/pkg/rpc/rpc_server.go
@@ -124,8 +124,10 @@ var (
 
 // NewServer creates a new RPC server, bound to a worker machine.
 // The source machine has to implement [states.StateSourceStatesDef] interface.
+//
+// addr: can be empty if [Server.Listener] or [Server.Conn] is set later.
 func NewServer(
-	ctx context.Context, addr string, name string, netSrcMach am.Api,
+	ctx context.Context, addr string, name string, stateSource am.Api,
 	opts *ServerOpts,
 ) (*Server, error) {
 	// TODO SPLIT
@@ -142,15 +144,15 @@ func NewServer(
 	}
 
 	// check the source
-	if netSrcMach == nil {
+	if stateSource == nil {
 		return nil, fmt.Errorf("netSrcMach required")
 	}
-	if !netSrcMach.StatesVerified() {
+	if !stateSource.StatesVerified() {
 		return nil, fmt.Errorf(
 			"net source states not verified, call VerifyStates()")
 	}
-	hasHandlers := netSrcMach.HasHandlers()
-	if hasHandlers && !netSrcMach.Has(ssW.Names()) {
+	hasHandlers := stateSource.HasHandlers()
+	if hasHandlers && !stateSource.Has(ssW.Names()) {
 		// error only when some handlers bound, skip deterministic machines
 		err := fmt.Errorf(
 			"%w: NetSourceMach with handlers has to implement "+
@@ -167,7 +169,7 @@ func NewServer(
 		Addr:             addr,
 		DeliveryTimeout:  5 * time.Second,
 		LogEnabled:       os.Getenv(EnvAmRpcLogServer) != "",
-		Source:           netSrcMach,
+		Source:           stateSource,
 		Args:             opts.Args,
 		Opts:             *opts,
 
@@ -223,7 +225,7 @@ func NewServer(
 	}
 	// queue ticks start at 1
 	s.tracer.dataLatest.queueTick = 1
-	if err = netSrcMach.BindTracer(s.tracer); err != nil {
+	if err = stateSource.BindTracer(s.tracer); err != nil {
 		return nil, err
 	}
 
@@ -247,7 +249,7 @@ func NewServer(
 			// dynamic handlers TODO use ampipe.Bind
 			h = createSendPayloadHandlers(s, payloadState)
 		}
-		err = netSrcMach.BindHandlers(h)
+		err = stateSource.BindHandlers(h)
 		if err != nil {
 			return nil, err
 		}
@@ -610,7 +612,7 @@ func (s *Server) Start(e *am.Event) am.Result {
 
 // Stop stops the server, and optionally disposes resources.
 func (s *Server) Stop(e *am.Event, dispose bool) am.Result {
-	// TODO waitTillCtx?
+	// TODO waitTillCtx
 	if s.Mach == nil {
 		return am.Canceled
 	}
@@ -1153,7 +1155,7 @@ func (s *Server) RemoteBye(
 
 // ///// ///// /////
 
-// ///// BINDINGS
+// ///// MISC
 
 // ///// ///// /////
 
@@ -1162,6 +1164,7 @@ func (s *Server) RemoteBye(
 func BindServer(
 	source, target *am.Machine, rpcReady, clientReady string,
 ) error {
+	// TODO use ampipe.BindMany
 	if rpcReady == "" || clientReady == "" {
 		return fmt.Errorf("rpcReady and clientConn must be set")
 	}
@@ -1193,6 +1196,7 @@ func BindServerMulti(
 	if rpcReady == "" || clientConn == "" || clientDisconn == "" {
 		return fmt.Errorf("rpcReady, clientConn, and clientDisconn must be set")
 	}
+	// TODO use ampipe.BindMany
 
 	h := &struct {
 		RpcReadyState am.HandlerFinal
@@ -1215,6 +1219,7 @@ func BindServerMulti(
 
 // BindServerRpcReady bind RpcReady using Add to a custom multi state.
 func BindServerRpcReady(source, target *am.Machine, rpcReady string) error {
+	// TODO use ampipe.Bind
 	h := &struct {
 		RpcReadyState am.HandlerFinal
 	}{
@@ -1223,12 +1228,6 @@ func BindServerRpcReady(source, target *am.Machine, rpcReady string) error {
 
 	return source.BindHandlers(h)
 }
-
-// ///// ///// /////
-
-// ///// MISC
-
-// ///// ///// /////
 
 type ServerOpts struct {
 	// PayloadState is a state for the server to listen on, to deliver payloads

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -720,8 +720,20 @@ func TestMux(t *testing.T) {
 	// init source & mux
 	netSrc := utils.NewRelsNetSrc(t, nil)
 	amhelpt.MachDebugEnv(t, netSrc)
-	mux, err := NewMux(ctx, t.Name(), nil, &MuxOpts{
-		Parent: netSrc,
+	newServerFn := func(mux *Mux, id string, _ net.Conn) (*Server, error) {
+		s, err := NewServer(ctx, serverAddr, t.Name()+"-"+id, netSrc, &ServerOpts{
+			Parent: mux.Mach,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		amhelpt.MachDebugEnv(t, s.Mach)
+
+		return s, nil
+	}
+	mux, err := NewMux(ctx, "", t.Name(), nil, &MuxOpts{
+		Parent:      netSrc,
+		NewServerFn: newServerFn,
 	})
 
 	// client fac
@@ -735,20 +747,6 @@ func TestMux(t *testing.T) {
 		amhelpt.MachDebugEnv(t, c.Mach)
 
 		return c
-	}
-
-	// server fac
-	mux.NewServerFn = func(num int, _ net.Conn) (*Server, error) {
-		name := fmt.Sprintf("%s-%d", t.Name(), num)
-		s, err := NewServer(ctx, serverAddr, name, netSrc, &ServerOpts{
-			Parent: mux.Mach,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		amhelpt.MachDebugEnv(t, s.Mach)
-
-		return s, nil
 	}
 
 	// start cmux

--- a/pkg/rpc/states/ss_rpc.go
+++ b/pkg/rpc/states/ss_rpc.go
@@ -168,7 +168,7 @@ type ServerStatesDef struct {
 
 	// RPC client connected (technically)
 	ClientConnected string
-	// RPC client fully ysable
+	// RPC client fully usable
 	HandshakeDone string
 
 	// How many times the client requested a full sync.
@@ -402,9 +402,11 @@ type MuxStatesDef struct {
 	// Ready - mux is ready to accept new clients.
 	Ready string
 
+	// stateless event
 	ClientConnected string
 	HasClients      string
 	// NewServerErr - new server returned an error. The mux is still running.
+	// TODO refac
 	NewServerErr string
 
 	// inherit from BasicStatesDef


### PR DESCRIPTION
Changes for relay injections and a unified signature of `NewMux` and `NewServer`.