### PR TITLE
feat(relay): add WebSocket-to-TCP dial

### DIFF
--- a/examples/wasm/.env
+++ b/examples/wasm/.env
@@ -1,12 +1,13 @@
 # CONFIG
 
-FOO_WS_ADDR=localhost:14000
+FOO_TCP_ADDR=localhost:14000
 FOO_REPL_ADDR=localhost:14010
 
 BAR_TCP_ADDR=localhost:14001
 BAR_REPL_ADDR=localhost:14011
 
 RELAY_HTTP_ADDR=localhost:12733
+REPL_DIR=tmp
 
 # DEBUG
 

--- a/examples/wasm/client/index.html
+++ b/examples/wasm/client/index.html
@@ -11,7 +11,7 @@
       }
 
       const go = new Go();
-      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+      WebAssembly.instantiateStreaming(fetch("main.wasm?"+Date.now()), go.importObject).then((result) => {
           onDomReady(() => {
               go.run(result.instance);
           })

--- a/examples/wasm/client/wasm_client_machs.go
+++ b/examples/wasm/client/wasm_client_machs.go
@@ -92,10 +92,10 @@ func initMachines(
 	// RPC Client (Net Machine)
 
 	// TODO enable
-	foo, err := arpc.NewClient(ctx, example.EnvFooWsAddr, fooHandlerMach.Id(), states.FooSchema, &arpc.ClientOpts{
+	foo, err := arpc.NewClient(ctx, example.EnvRelayHttpAddr, fooHandlerMach.Id(), states.FooSchema, &arpc.ClientOpts{
 		Parent: fooHandlerMach,
-		// automatic in WASM
-		WebSocket: "/",
+		// TODO should be the default for WASM
+		WebSocket: arpc.WsDialPath(fooHandlerMach.Id(), example.EnvFooTcpAddr),
 	})
 	if err != nil {
 		log.Fatal(err.Error())

--- a/examples/wasm/server/wasm_server.go
+++ b/examples/wasm/server/wasm_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	_ "net/http/pprof"
 	"regexp"
 	"sync/atomic"
@@ -36,11 +35,10 @@ func init() {
 func main() {
 	ctx := context.Background()
 
-	// debug
-
-	go func() {
-		http.ListenAndServe("localhost:6060", nil)
-	}()
+	// pprof debug
+	// go func() {
+	// 	http.ListenAndServe("localhost:6060", nil)
+	// }()
 
 	// net source machine
 
@@ -55,31 +53,28 @@ func main() {
 	fooMach.SemLogger().SetArgsMapper(example.LogArgs)
 	handlers.machFoo = fooMach
 	arpc.MachRepl(fooMach, example.EnvFooReplAddr, &arpc.ReplOpts{
-		// TODO config
-		AddrDir:  "tmp",
+		AddrDir:  example.EnvReplDir,
 		Args:     ARpc{},
 		ParseRpc: example.ParseRpc,
 	})
 	fooMach.Add1(ssF.Start, nil)
 
-	// RPC Server
+	// RPC Muxer
 
-	s, err := arpc.NewServer(ctx, example.EnvFooWsAddr, "server-foo", fooMach, &arpc.ServerOpts{
-		// manual web socket, no tcp, not relayed
-		WebSocket: true,
-		Parent:    fooMach,
+	mux, err := arpc.NewMux(ctx, example.EnvFooTcpAddr, "server-foo", fooMach, &arpc.MuxOpts{
+		Parent: fooMach,
 	})
 	if err != nil {
 		panic(err)
 	}
-	s.Start(nil)
-	handlers.s = s
+	mux.Start(nil)
+	handlers.mux = mux
 
 	// websocket relay
 
 	newClient := func(ctx context.Context, id string, conn net.Conn) (*arpc.Client, error) {
 		// RPC Client (Net Machine)
-		bar, err := arpc.NewClient(ctx, "localhost:0", "server-bar", states.BarSchema, &arpc.ClientOpts{
+		bar, err := arpc.NewClient(ctx, "", "server-bar", states.BarSchema, &arpc.ClientOpts{
 			Parent: fooMach,
 		})
 		if err != nil {
@@ -102,13 +97,19 @@ func main() {
 		Debug:  true,
 		Parent: fooMach,
 		Wasm: &amrelayt.ArgsWasm{
-			ListenAddr: example.EnvRelayHttpAddr,
-			StaticDir:  "./client",
-			// TODO config
-			ReplAddrDir: "tmp",
-			ClientMatchers: []amrelayt.ClientMatcher{{
+			ListenAddr:  example.EnvRelayHttpAddr,
+			StaticDir:   "./client",
+			ReplAddrDir: example.EnvReplDir,
+			TunnelMatchers: []amrelayt.TunnelMatcher{{
 				Id:        regexp.MustCompile("^browser-bar-"),
 				NewClient: newClient,
+			}},
+			DialMatchers: []amrelayt.DialMatcher{{
+				Id: regexp.MustCompile("^browser-foo-"),
+				NewServer: func(ctx context.Context, id string, conn net.Conn) (*arpc.Server, error) {
+					// TODO ctx to Event
+					return mux.NewServer(nil, id, conn)
+				},
 			}},
 		},
 	})
@@ -127,7 +128,7 @@ type HandlersFoo struct {
 	machFoo *am.Machine
 	// last connected browser machine
 	rpcBar atomic.Pointer[arpc.Client]
-	s      *arpc.Server
+	mux    *arpc.Mux
 
 	lastMsg   time.Time
 	lastHello time.Time

--- a/examples/wasm/wasm_example.go
+++ b/examples/wasm/wasm_example.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	EnvFooWsAddr   string
+	EnvFooTcpAddr  string
 	EnvFooReplAddr string
 )
 
@@ -23,7 +23,10 @@ var (
 	EnvBarReplAddr string
 )
 
-var EnvRelayHttpAddr string
+var (
+	EnvRelayHttpAddr string
+	EnvReplDir       string
+)
 
 //go:embed .env
 var env string
@@ -37,11 +40,12 @@ func init() {
 		}
 	}
 
-	EnvFooWsAddr = os.Getenv("FOO_WS_ADDR")
+	EnvFooTcpAddr = os.Getenv("FOO_TCP_ADDR")
 	EnvFooReplAddr = os.Getenv("FOO_REPL_ADDR")
 	EnvBarTcpAddr = os.Getenv("BAR_TCP_ADDR")
 	EnvBarReplAddr = os.Getenv("BAR_REPL_ADDR")
 	EnvRelayHttpAddr = os.Getenv("RELAY_HTTP_ADDR")
+	EnvReplDir = os.Getenv("REPL_DIR")
 }
 
 // ///// ///// /////

--- a/tools/relay/relay.go
+++ b/tools/relay/relay.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -171,6 +173,7 @@ func (r *Relay) HttpStartingState(e *am.Event) {
 
 func (r *Relay) HttpReadyState(e *am.Event) {
 	// TODO /dial - RPC clients (WS to TCP dial)
+
 	// ctx := r.Mach.NewStateCtx(ssR.HttpReady)
 
 	r.out("WASM relay listening on http://%s\n", r.Args.Wasm.ListenAddr)
@@ -186,13 +189,124 @@ func (r *Relay) HttpReadyState(e *am.Event) {
 		func(w http.ResponseWriter, req *http.Request) {
 			r.HandleWsTcpListen(e, w, req)
 		})
+
+	// WS->TCP dial
+	r.HttpMux.HandleFunc("/dial/",
+		func(w http.ResponseWriter, req *http.Request) {
+			r.HandleWsTcpDial(e, w, req)
+		})
+}
+
+func (r *Relay) HandleWsTcpDial(
+	e *am.Event, w http.ResponseWriter, req *http.Request,
+) {
+	// TODO state
+	// TODO loop guard to detect flood (fix thread safety)
+
+	// TODO req.Context() needs body to be read to close
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	// metric
+	r.Mach.EvAdd1(e, ssR.WsDialConn, nil)
+
+	// parse "localhost:1234"
+	uri, ok := strings.CutPrefix(req.URL.Path, arpc.WsPathDial)
+	if !ok {
+		r.Mach.EvAddErrState(e, ssR.ErrNetwork, fmt.Errorf(
+			"invalid %s path: %s", arpc.WsPathDial, req.URL.Path), nil)
+		return
+	}
+	id, tcpAddr := path.Split(uri)
+	id = strings.TrimSuffix(id, "/")
+	r.Mach.Log("WS TCP dial from %s to %s", id, tcpAddr)
+
+	// TODO origin security
+	// TODO ID security
+
+	// websocket
+	wsConn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		r.Mach.EvAddErrState(e, ssR.ErrNetwork, err, Pass(&A{
+			Addr: tcpAddr,
+		}))
+		return
+	}
+
+	// check server matchers
+	for _, m := range r.Args.Wasm.DialMatchers {
+		if !m.Id.MatchString(id) {
+			continue
+		}
+		r.Mach.Log("WS dial for %s accepted by dial matcher", id)
+
+		netConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
+		srv, err := m.NewServer(ctx, id, netConn)
+		if err != nil {
+			r.Mach.EvAddErr(e,
+				fmt.Errorf("failed to create RPC server for %s: %s", id, err), nil)
+		} else {
+			// stay alive until disconn
+			<-srv.Mach.When1(ssrpc.ServerStates.ClientConnected, ctx)
+			<-srv.Mach.WhenNot1(ssrpc.ServerStates.ClientConnected, ctx)
+			srv.Stop(e, true)
+			return
+		}
+	}
+
+	// dial
+	tcpConn, err := net.Dial("tcp", tcpAddr)
+	if err != nil {
+		r.Mach.EvAddErrState(e, ssR.ErrNetwork, err, Pass(&A{
+			Addr: tcpAddr,
+			Id:   id,
+		}))
+		wsConn.Close(websocket.StatusInternalError, "dial failed")
+		return
+	}
+	defer tcpConn.Close()
+	defer r.Mach.EvAdd1(e, ssR.WsDialDisconn, nil)
+
+	// start
+	wsNetConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
+
+	// TCP -> WebSocket (WASM)
+	errClient := make(chan error, 1)
+	errServer := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(wsNetConn, tcpConn)
+		if err != nil {
+			errServer <- err
+		}
+	}()
+
+	// WebSocket (WASM) -> TCP
+	go func() {
+		_, err := io.Copy(tcpConn, wsNetConn)
+		if err != nil {
+			errClient <- err
+		}
+	}()
+
+	// wait
+	select {
+	case <-ctx.Done():
+	case <-errClient:
+		r.Mach.Log("WS TCP dial from %s to %s client err: %s",
+			id, tcpAddr, errClient)
+	case <-errServer:
+		r.Mach.Log("WS TCP dial from %s to %s server err: %s",
+			id, tcpAddr, errServer)
+	}
 }
 
 func (r *Relay) HandleWsTcpListen(
 	e *am.Event, w http.ResponseWriter, req *http.Request,
 ) {
+	// TODO state
 	// TODO loop guard to detect flood (fix thread safety)
-	// TODO create a REPL file for repl- machs
 
 	// TODO req.Context() needs body to be read to close
 	ctx, cancel := context.WithCancel(req.Context())
@@ -205,7 +319,7 @@ func (r *Relay) HandleWsTcpListen(
 	uri, ok := strings.CutPrefix(req.URL.Path, arpc.WsPathListen)
 	if !ok {
 		r.Mach.EvAddErrState(e, ssR.ErrNetwork, fmt.Errorf(
-			"invalid /listen path: %s", req.URL.Path), nil)
+			"invalid %s path: %s", arpc.WsPathListen, req.URL.Path), nil)
 		return
 	}
 	id, tcpAddr := path.Split(uri)
@@ -228,11 +342,11 @@ func (r *Relay) HandleWsTcpListen(
 	}
 
 	// check client matchers
-	for _, m := range r.Args.Wasm.ClientMatchers {
+	for _, m := range r.Args.Wasm.TunnelMatchers {
 		if !m.Id.MatchString(id) {
 			continue
 		}
-		r.Mach.Log("WS tunnel for %s accepted by client matcher", id)
+		r.Mach.Log("WS tunnel for %s accepted by tunnel matcher", id)
 
 		netConn := websocket.NetConn(ctx, conn, websocket.MessageBinary)
 		client, err := m.NewClient(ctx, id, netConn)
@@ -260,7 +374,7 @@ func (r *Relay) HandleWsTcpListen(
 		}
 
 		// init mach
-		idTun := fmt.Sprintf("%s-wtt-%d", r.Mach.Id(), r.cWsTcpTuns)
+		idTun := fmt.Sprintf("%s-wt-%d", r.Mach.Id(), r.cWsTcpTuns)
 		r.cWsTcpTuns++
 		tun, err := NewWsTcpTun(ctx, conn, id, tcpAddr, req.RemoteAddr, idTun,
 			r.Mach, r.Args.Debug)

--- a/tools/relay/states/ss_relay.go
+++ b/tools/relay/states/ss_relay.go
@@ -24,6 +24,8 @@ type RelayStatesDef struct {
 	// New WebSocket to TCP-listen tunnel req
 	WsTunListenConn    string
 	WsTunListenDisconn string
+	WsDialConn         string
+	WsDialDisconn      string
 
 	// inherit from BasicStatesDef
 	*ssam.BasicStatesDef
@@ -59,6 +61,14 @@ var RelaySchema = SchemaMerge(
 			Require: S{ss.HttpReady},
 		},
 		ss.WsTunListenDisconn: {
+			Multi:   true,
+			Require: S{ss.HttpReady},
+		},
+		ss.WsDialConn: {
+			Multi:   true,
+			Require: S{ss.HttpReady},
+		},
+		ss.WsDialDisconn: {
 			Multi:   true,
 			Require: S{ss.HttpReady},
 		},

--- a/tools/relay/types/types_relay.go
+++ b/tools/relay/types/types_relay.go
@@ -37,17 +37,28 @@ type ArgsRotateDbg struct {
 	Dir          string        `arg:"-d,--dir" default:"." help:"Output directory"`
 }
 
-// ArgsWasm TODO
+// ArgsWasm
 // nolint:lll
 type ArgsWasm struct {
 	ListenAddr  string `arg:"-l,--listen-addr" default:"localhost:12733" help:"Listen address for HTTP server"`
 	StaticDir   string `arg:"-s,--static-dir" help:"Directory with static files to serve (optional)"`
 	ReplAddrDir string `arg:"-r,--repl-addr-dir" help:"Directory for creating REPL addr files (optional)"`
-	// match incoming tunnels by mach IDs and pass directly to clients
-	ClientMatchers []ClientMatcher `arg:"-"`
+	// Match incoming tunnels by mach IDs and pass directly to new RPC clients
+	TunnelMatchers []TunnelMatcher `arg:"-"`
+	// Match incoming TCP dials by mach IDs and pass directly to new RPC servers
+	DialMatchers []DialMatcher `arg:"-"`
 }
 
-type ClientMatcher struct {
+type DialMatcher struct {
+	Id        *regexp.Regexp
+	NewServer NewServerFunc
+}
+
+type NewServerFunc func(
+	ctx context.Context, id string, conn net.Conn,
+) (*arpc.Server, error)
+
+type TunnelMatcher struct {
 	Id        *regexp.Regexp
 	NewClient NewClientFunc
 }

--- a/tools/relay/ws_tcp_tun.go
+++ b/tools/relay/ws_tcp_tun.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	"github.com/coder/websocket"
-
 	"github.com/pancsta/asyncmachine-go/tools/relay/states"
 
 	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
@@ -33,6 +32,7 @@ func NewWsTcpTun(
 	idTun string, parent am.Api, debug bool,
 ) (*WsTcpTun, error) {
 	// TODO validate wsConn
+	// TODO generate ID
 
 	t := &WsTcpTun{
 		DisposedHandlers: &ssam.DisposedHandlers{},


### PR DESCRIPTION
WASM aRPC clients can now dial TCP over `/tools/relay` and access `pkg/rpc.(*Mux)`, meaning a single server can accept multiple browser on the same port. #377 still to go.

```go
// client
foo, err := arpc.NewClient(ctx, example.EnvRelayHttpAddr, fooHandlerMach.Id(), states.FooSchema, &arpc.ClientOpts{
	Parent: fooHandlerMach,
	WebSocket: arpc.WsDialPath(fooHandlerMach.Id(), example.EnvFooTcpAddr),
})

// server as lib (optional, for in-process matching)
relay, err := amrelay.New(ctx, amrelayt.Args{
    Name:   "wasm-demo",
    Debug:  true,
    Parent: fooMach,
    Wasm: &amrelayt.ArgsWasm{
        ListenAddr: example.EnvRelayHttpAddr,
        StaticDir:  "./client",
        ReplAddrDir: "tmp",
        TunnelMatchers: []amrelayt.TunnelMatcher{{
            Id:        regexp.MustCompile("^browser-bar-"),
            NewClient: newClient,
        }},
        DialMatchers: []amrelayt.DialMatcher{{
            Id: regexp.MustCompile("^browser-foo-"),
            NewServer: func(ctx context.Context, id string, conn net.Conn) (*arpc.Server, error) {
                return mux.NewServer(nil, id, conn)
            },
        }},
    },
})
```