### PR TITLE
fix(rpc): remove SendPayload state

### DIFF
--- a/pkg/rpc/netmach_test.go
+++ b/pkg/rpc/netmach_test.go
@@ -1129,15 +1129,6 @@ func TestInspect(t *testing.T) {
 		0 ErrOnClient
 		    |Tick     0
 		    |Require  Exception
-		0 ErrProviding
-		    |Tick     0
-		    |Require  Exception
-		0 ErrSendPayload
-		    |Tick     0
-		    |Require  Exception
-		0 SendPayload
-		    |Tick     0
-		    |Multi    true
 	`
 	assertString(t, w, expected, nil)
 
@@ -1162,8 +1153,7 @@ func TestString(t *testing.T) {
 
 	// test
 	assert.Equal(t, "(A:1 B:1)", w.String())
-	assert.Equal(t, "(A:1 B:1) [Exception:0 C:0 D:0 ErrOnClient:0 "+
-		"ErrProviding:0 ErrSendPayload:0 SendPayload:0]",
+	assert.Equal(t, "(A:1 B:1) [Exception:0 C:0 D:0 ErrOnClient:0]",
 		w.StringAll())
 
 	disposeTest(t, c, s, true)

--- a/pkg/rpc/rpc_client.go
+++ b/pkg/rpc/rpc_client.go
@@ -38,7 +38,8 @@ type Client struct {
 
 	// Addr is the address the Client will connect to.
 	Addr string
-	// NetMach is a remote am.Machine instance
+	// NetMach is a remote am.Machine instance. It's available after the Start
+	// state settles.
 	NetMach *NetworkMachine
 	// Consumer is the optional consumer for deliveries.
 	Consumer   *am.Machine
@@ -246,15 +247,18 @@ func (c *Client) StartState(e *am.Event) {
 	id := PrefixNetMach + utils.RandId(5)
 	// RPC parent or actual parent
 	var parent am.Api = c.Mach
-	if os.Getenv(EnvAmRpcDbg) == "" {
+	if os.Getenv(EnvAmRpcDbg) == "" && c.Opts.Parent != nil {
 		parent = c.Opts.Parent
 	}
 	netMach, nmInternal, err := NewNetworkMachine(ctx, id, nmConn, c.schema,
 		stateNames, parent, nil, c.SyncMutationFiltering)
 	if err != nil {
-		c.Mach.AddErr(err, nil)
+		// TODO handle better
+		c.Mach.EvAddErr(e, err, nil)
+		c.Mach.EvRemove1(e, ss.Start, nil)
 		return
 	}
+	// TODO make it available earlier
 	c.NetMach = netMach
 	c.netMachInt = nmInternal
 }
@@ -419,11 +423,7 @@ func (c *Client) HandshakingState(e *am.Event) {
 	ctx := c.Mach.NewStateCtx(ssC.Connected)
 
 	// unblock
-	go func() {
-		if ctx.Err() != nil {
-			return // expired
-		}
-
+	c.Mach.Fork(ctx, e, func() {
 		// send hello or retry conn
 		resp := &MsgSrvHello{}
 		if c.HelloDelay > 0 {
@@ -509,7 +509,7 @@ func (c *Client) HandshakingState(e *am.Event) {
 			MachTime:  resp.Serialized.Time,
 			QueueTick: resp.Serialized.QueueTick,
 		}))
-	}()
+	})
 }
 
 func (c *Client) HandshakeDoneEnter(e *am.Event) bool {
@@ -962,7 +962,7 @@ func (c *Client) callFailsafe(
 		return false
 	}
 
-	// locks
+	// locks TODO delays exit
 	c.callLock.Lock()
 	defer c.callLock.Unlock()
 
@@ -1028,6 +1028,10 @@ func (c *Client) callFailsafe(
 func (c *Client) call(
 	ctx context.Context, method string, args, resp any, timeout time.Duration,
 ) bool {
+	// debug
+	// c.log("call %s", method)
+
+	// TODO use Fork everywhere
 	defer c.Mach.PanicToErr(nil)
 	mName := ServerMethods.Parse(method).Value
 
@@ -1283,6 +1287,7 @@ type ClientOpts struct {
 	SkippedStates am.S
 	// Sync machine time for every mutation. Disables
 	// [ClientOpts.SyncShallowClocks].
+	// TODO de-activates states for no reason
 	SyncMutations bool
 	// Only activete/deactivate (0-1) clock values will be sent.
 	SyncShallowClocks bool

--- a/pkg/rpc/rpc_server.go
+++ b/pkg/rpc/rpc_server.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"reflect"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -26,8 +25,8 @@ import (
 )
 
 var (
-	ssS = states.ServerStates
-	ssW = states.StateSourceStates
+	ssS  = states.ServerStates
+	ssSs = states.StateSourceStates
 )
 
 // Server is an RPC server that can be bound to a worker machine and provide
@@ -152,7 +151,7 @@ func NewServer(
 			"net source states not verified, call VerifyStates()")
 	}
 	hasHandlers := stateSource.HasHandlers()
-	if hasHandlers && !stateSource.Has(ssW.Names()) {
+	if hasHandlers && !stateSource.Has(ssSs.Names()) {
 		// error only when some handlers bound, skip deterministic machines
 		err := fmt.Errorf(
 			"%w: NetSourceMach with handlers has to implement "+
@@ -227,32 +226,6 @@ func NewServer(
 	s.tracer.dataLatest.queueTick = 1
 	if err = stateSource.BindTracer(s.tracer); err != nil {
 		return nil, err
-	}
-
-	// handle payload
-	if hasHandlers {
-
-		// payload state
-		payloadState := ssW.SendPayload
-		if opts.PayloadState != "" {
-			payloadState = opts.PayloadState
-		}
-
-		// payload handlers
-		var h any
-		if payloadState == ssW.SendPayload {
-			// default handlers
-			h = &SendPayloadHandlers{
-				SendPayloadState: getSendPayloadState(s, ssW.SendPayload),
-			}
-		} else {
-			// dynamic handlers TODO use ampipe.Bind
-			h = createSendPayloadHandlers(s, payloadState)
-		}
-		err = stateSource.BindHandlers(h)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// longer timeouts
@@ -1230,10 +1203,6 @@ func BindServerRpcReady(source, target *am.Machine, rpcReady string) error {
 }
 
 type ServerOpts struct {
-	// PayloadState is a state for the server to listen on, to deliver payloads
-	// to the client. The client activates this state to request a payload from
-	// the worker. Default: am/rpc/states/WorkerStates.SendPayload.
-	PayloadState string
 	// Parent is a parent state machine for a new Server state machine.
 	Parent am.Api // Typed arguments struct pointer
 	// optional typed args struct value
@@ -1245,66 +1214,6 @@ type ServerOpts struct {
 	// HTTP URL without proto to tunnel the TCP listen over a WebSocket conn.
 	// See WsListenPath.
 	WebSocketTunnel string
-}
-
-type SendPayloadHandlers struct {
-	SendPayloadState am.HandlerFinal
-}
-
-// getSendPayloadState returns a handler (usually SendPayloadState) that will
-// deliver a payload to the RPC client. The resulting function can be bound in
-// anon handlers.
-func getSendPayloadState(s *Server, stateName string) am.HandlerFinal {
-	return func(e *am.Event) {
-		// self-remove
-		e.Machine().EvRemove1(e, stateName, nil)
-
-		ctx := s.Mach.NewStateCtx(ssS.Start)
-		args := ParseArgs(e.Args)
-		argsOut := &A{Name: args.Name}
-
-		// side-effect error handling
-		if args.Payload == nil || args.Name == "" {
-			err := fmt.Errorf("invalid payload args [name, payload]")
-			e.Machine().EvAddErrState(e, ssW.ErrSendPayload, err, Pass(argsOut))
-
-			return
-		}
-
-		// unblock and forward to the client
-		go func() {
-			// timeout context
-			ctx, cancel := context.WithTimeout(ctx, s.DeliveryTimeout)
-			defer cancel()
-
-			err := s.SendPayload(ctx, e, args.Payload)
-			if err != nil {
-				e.Machine().EvAddErrState(e, ssW.ErrSendPayload, err, Pass(argsOut))
-			}
-		}()
-	}
-}
-
-// createSendPayloadHandlers creates SendPayload handlers for a custom (dynamic)
-// state name. Useful when binding >1 RPC server into the same state source.
-func createSendPayloadHandlers(s *Server, stateName string) any {
-	// TODO migrate to ampipe.Bind
-	fn := getSendPayloadState(s, stateName)
-
-	// define a struct with the handler
-	structType := reflect.StructOf([]reflect.StructField{
-		{
-			Name: stateName + am.SuffixState,
-			Type: reflect.TypeOf(fn),
-		},
-	})
-
-	// new instance and set handler
-	val := reflect.New(structType).Elem()
-	val.Field(0).Set(reflect.ValueOf(fn))
-	ret := val.Addr().Interface()
-
-	return ret
 }
 
 // calcUpdate calculates a new update based on previously pushed data.

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -153,9 +153,9 @@ func TestWaiting(t *testing.T) {
 	assert.Equal(t, 3, int(c.CallCount),
 		"Client called RemoteHello, RemoteHandshake, RemoteAdd")
 	bytesCount := <-counter
-	assert.LessOrEqual(t, 1_400, int(bytesCount),
+	assert.LessOrEqual(t, 1_300, int(bytesCount),
 		"Bytes transferred (both ways)")
-	assert.GreaterOrEqual(t, 1_500, int(bytesCount),
+	assert.GreaterOrEqual(t, 1_400, int(bytesCount),
 		"Bytes transferred (both ways)")
 
 	disposeTest(t, c, s, true)
@@ -619,19 +619,20 @@ func TestRetryClosedListener(t *testing.T) {
 
 // TestPayload
 
-type TestPayloadHandlers struct{}
+type TestPayloadHandlers struct {
+	srv *Server
+}
 
 // CState will trigger SendPayload
 func (w *TestPayloadHandlers) CState(e *am.Event) {
 	// TODO use v2 state def
 	e.Machine().Remove1(sst.C, nil)
 	args := ParseArgs(e.Args)
-	argsOut := &A{
-		Name:    args.Name,
-		Payload: &MsgSrvPayload{Data: "Hello", Name: args.Name},
-	}
 
-	e.Machine().Add1(ssW.SendPayload, Pass(argsOut))
+	_ = w.srv.SendPayload(context.Background(), e, &MsgSrvPayload{
+		Data: "Hello",
+		Name: args.Name,
+	})
 }
 
 type TestPayloadConsumer struct {
@@ -670,7 +671,8 @@ func TestPayload(t *testing.T) {
 
 	// source mach
 	source := utils.NewNoRelsNetSrc(t, nil, "")
-	err = source.BindHandlers(&TestPayloadHandlers{})
+	handlers := &TestPayloadHandlers{}
+	err = source.BindHandlers(handlers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,6 +681,7 @@ func TestPayload(t *testing.T) {
 	_, _, s, c := NewTest(t, ctx, source, nil, 0, false, &ClientOpts{
 		Consumer: consMach,
 	}, nil)
+	handlers.srv = s
 
 	whenDelivered := consMach.When1(ssCo.ServerPayload, nil)
 	// Consumer requests a payload from the remote worker

--- a/pkg/rpc/states/ss_rpc.go
+++ b/pkg/rpc/states/ss_rpc.go
@@ -29,7 +29,7 @@ type SharedStatesDef struct {
 
 	// inherit from BasicStatesDef
 	*states.BasicStatesDef
-	// inherit from rpc/StateSourceStatesDef
+	// inherit from rpc/StateSourceStatesDef (for REPL)
 	*StateSourceStatesDef
 }
 
@@ -44,7 +44,7 @@ type SharedGroupsDef struct {
 var SharedSchema = SchemaMerge(
 	// inherit from BasicStruct
 	states.BasicSchema,
-	// inherit from rpc/WorkerSchema
+	// inherit from rpc/WorkerSchema (for REPL)
 	StateSourceSchema,
 	am.Schema{
 
@@ -99,17 +99,6 @@ type StateSourceStatesDef struct {
 
 	// ErrOnClient indicates an error added on the Network Machine.
 	ErrOnClient string
-	// ErrProviding - NetMach had issues providing the requested payload.
-	ErrProviding string
-	// ErrSendPayload - RPC server had issues sending the requested payload to
-	// the RPC client.
-	ErrSendPayload string
-
-	// rpc getter
-
-	// SendPayload - Net Source has delivered the requested payload to the RPC
-	// server (not the Consumer) using rpc.Pass, rpc.A, and rpc.MsgSrvPayload.
-	SendPayload string
 }
 
 // StateSourceSchema represents all relations and properties of
@@ -119,13 +108,7 @@ var StateSourceSchema = SchemaMerge(
 
 		// errors
 
-		ssSS.ErrOnClient:    {Require: S{Exception}},
-		ssSS.ErrProviding:   {Require: S{Exception}},
-		ssSS.ErrSendPayload: {Require: S{Exception}},
-
-		// RPC getter
-
-		ssSS.SendPayload: {Multi: true},
+		ssSS.ErrOnClient: {Require: S{Exception}},
 	})
 
 // EXPORTS AND GROUPS
@@ -456,6 +439,7 @@ var (
 // ///// CONSUMER
 
 // ///// ///// /////
+// Consumer is a contract to consumer server payload from an RPC client.
 
 // ConsumerStatesDef contains all the states of the Consumer state machine.
 type ConsumerStatesDef struct {


### PR DESCRIPTION
- use rpc.Server.SendPayload() directly

Sending a payload from server to client via a state has been removed. This simplifies the ambiguous flow and reduces reflection.