### PR TITLE
feat(machine): add Tracer.TransitionFinals for more detailed tracing

### DIFF
--- a/pkg/machine/misc_mach.go
+++ b/pkg/machine/misc_mach.go
@@ -835,6 +835,7 @@ type Tracer interface {
 
 	TransitionInit(transition *Transition)
 	TransitionStart(transition *Transition)
+	TransitionFinals(transition *Transition)
 	TransitionEnd(transition *Transition)
 	MutationQueued(machine Api, mutation *Mutation)
 	HandlerStart(transition *Transition, emitter string, handler string)
@@ -855,6 +856,7 @@ type TracerNoOp struct{}
 
 func (t *TracerNoOp) TransitionInit(transition *Transition)          {}
 func (t *TracerNoOp) TransitionStart(transition *Transition)         {}
+func (t *TracerNoOp) TransitionFinals(transition *Transition)        {}
 func (t *TracerNoOp) TransitionEnd(transition *Transition)           {}
 func (t *TracerNoOp) MutationQueued(machine Api, mutation *Mutation) {}
 func (t *TracerNoOp) HandlerStart(

--- a/pkg/machine/transition.go
+++ b/pkg/machine/transition.go
@@ -746,6 +746,13 @@ func (t *Transition) emitEvents() Result {
 			// always correct TimeAfter
 			t.TimeAfter = m.time(nil)
 
+			// tracers
+			m.tracersMx.RLock()
+			for i := 0; !t.Machine.IsDisposed() && i < len(t.Machine.tracers); i++ {
+				t.Machine.tracers[i].TransitionFinals(t)
+			}
+			m.tracersMx.RUnlock()
+
 			if hasHandlers || logEverything || m.subs.HasWhenArgs() {
 				// FooState
 				// FooEnd


### PR DESCRIPTION
Tracer now splits negotiation and final handlers, for better timing results. 