### PR TITLE
feat(am-vis): add inspect-dump cmd producing a markdown version of th…

### DIFF
--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -438,6 +438,104 @@ func (g *Graph) DumpGv(path string) error {
 	return draw.DOT(g.G, file)
 }
 
+type MachInspect struct {
+	Child  string
+	States []string
+	Conns  []string
+	Pipes  map[string][]string
+}
+
+func (g *Graph) Inspect() (map[string]*MachInspect, error) {
+	adjacencyMap, err := g.G.AdjacencyMap()
+	if err != nil {
+		return nil, err
+	}
+	inspect := make(map[string]*MachInspect)
+	for machId, adjs := range adjacencyMap {
+		if len(strings.Split(machId, ":")) == 2 {
+			continue
+		}
+		fmt.Println(machId)
+
+		// init
+		_, ok := inspect[machId]
+		if !ok {
+			inspect[machId] = &MachInspect{
+				Pipes: make(map[string][]string),
+			}
+		}
+
+		for _, edge := range adjs {
+			conn, _ := g.Connection(machId, edge.Target)
+
+			if conn.Edge.MachChildOf {
+				inspect[machId].Child = edge.Target
+			}
+			if conn.Edge.MachConnectedTo {
+				inspect[machId].Conns = append(inspect[machId].Conns, edge.Target)
+			}
+			if conn.Edge.MachHas != nil {
+				ids := strings.Split(edge.Target, ":")
+				inspect[machId].States = append(inspect[machId].States, ids[1])
+			}
+			if conn.Edge.MachPipesTo != nil {
+				if machId == "orchestrator" {
+					print()
+				}
+				for _, pipe := range conn.Edge.MachPipesTo {
+					inspect[machId].Pipes[edge.Target] = append(
+						inspect[machId].Pipes[edge.Target], fmt.Sprintf(
+							"[%s] %s -> %s", pipe.MutType, pipe.FromState, pipe.ToState,
+						))
+				}
+			}
+		}
+	}
+
+	return inspect, nil
+}
+
+func Markdown(inspect map[string]*MachInspect) string {
+	keys := slices.Collect(maps.Keys(inspect))
+	sort.Strings(keys)
+	ret := "# am-vis inspect-dump\n\n"
+	for _, machId := range keys {
+		data := inspect[machId]
+		ret += "## " + machId + "\n"
+		if data.Child != "" {
+			ret += fmt.Sprintf("Parent: %s\n\n", data.Child)
+		} else {
+			ret += "\n"
+		}
+		if len(data.States) > 0 {
+			sort.Strings(data.States)
+			ret += "### States\n"
+			ret += fmt.Sprintf("- %s\n", strings.Join(data.States, "\n- "))
+			ret += "\n"
+		}
+		if len(data.Conns) > 0 {
+			sort.Strings(data.Conns)
+			ret += "### RPC\n"
+			ret += fmt.Sprintf("- %s\n", strings.Join(data.Conns, "\n- "))
+			ret += "\n"
+		}
+		if len(data.Pipes) > 0 {
+			ret += "### Pipes\n\n"
+			keysPipes := slices.Collect(maps.Keys(data.Pipes))
+			sort.Strings(keysPipes)
+			for _, pipe := range keysPipes {
+				sort.Strings(data.Pipes[pipe])
+				ret += fmt.Sprintf("#### %s\n", pipe)
+				ret += fmt.Sprintf("- %s\n", strings.Join(data.Pipes[pipe], "\n- "))
+				ret += "\n"
+			}
+		}
+		ret += "-----\n\n"
+	}
+
+	return ret
+}
+
 // private
 
 func (g *Graph) parseMsgLog(c *Client, msgTx *dbg.DbgMsgTx) error {

--- a/tools/cmd/am-vis/cmd_vis.go
+++ b/tools/cmd/am-vis/cmd_vis.go
@@ -8,14 +8,15 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/alexflint/go-arg"
 	"github.com/joho/godotenv"
+
 	"github.com/pancsta/asyncmachine-go/internal/utils"
 	amgraph "github.com/pancsta/asyncmachine-go/pkg/graph"
-	am "github.com/pancsta/asyncmachine-go/pkg/machine"
 	dbgtypes "github.com/pancsta/asyncmachine-go/tools/debugger/types"
 	"github.com/pancsta/asyncmachine-go/tools/visualizer"
 	"github.com/pancsta/asyncmachine-go/tools/visualizer/states"
@@ -25,7 +26,8 @@ import (
 
 // nolint:lll
 type Args struct {
-	RenderDump *RenderDumpCmd `arg:"subcommand:render-dump" help:"Render from a debugger dump file"`
+	RenderDump  *RenderDumpCmd  `arg:"subcommand:render-dump" help:"Render from a debugger dump file"`
+	InspectDump *InspectDumpCmd `arg:"subcommand:inspect-dump" help:"Render text form from a debugger dump file"`
 	// DbgServer     *DbgServerCmd     `arg:"subcommand:dbg-server" help:"Render from live connections"`
 
 	// TODO RenderAllowlist
@@ -99,7 +101,16 @@ type RenderDumpCmd struct {
 	MachUrl      string `arg:"positional"`
 }
 
-const CmdRenderDump = "render-dump"
+// nolint:lll
+type InspectDumpCmd struct {
+	DumpFilename string `arg:"-f,--dump-file,positional" help:"Input dbg dump file" default:"am-dbg-dump.gob.br"`
+	MachUrl      string `arg:"positional"`
+}
+
+const (
+	CmdRenderDump  = "render-dump"
+	CmdInspectDump = "inspect-dump"
+)
 
 // TODO DbgServerCmd
 // nolint:lll
@@ -136,6 +147,10 @@ func main() {
 		if err := renderDump(ctx, args, os.Args[1:]); err != nil {
 			_ = p.FailSubcommand(err.Error(), CmdRenderDump)
 		}
+	case args.InspectDump != nil:
+		if err := inspectDump(ctx, args, os.Args[1:]); err != nil {
+			_ = p.FailSubcommand(err.Error(), CmdInspectDump)
+		}
 	}
 }
 
@@ -168,6 +183,17 @@ func renderDump(ctx context.Context, args Args, cliArgs []string) error {
 	clients := slices.Collect(maps.Values(vis.Clients()))
 	fmt.Printf("Imported %d clients\n", len(clients))
 
+	// presets
+	switch {
+	case args.Map:
+		visualizer.PresetMap(vis.R)
+	case args.Bird:
+		visualizer.PresetBird(vis.R)
+	default:
+		visualizer.PresetSingle(vis.R)
+	}
+	applyOverrides(args, cliArgs, vis.R)
+
 	// check target
 	if addr != nil {
 		found := slices.ContainsFunc(clients, func(c amgraph.Client) bool {
@@ -183,17 +209,6 @@ func renderDump(ctx context.Context, args Args, cliArgs []string) error {
 		vis.R.RenderMachs = slices.Collect(maps.Keys(vis.Clients()))
 	}
 
-	// presets
-	switch {
-	case args.Map:
-		visualizer.PresetMap(vis.R)
-	case args.Bird:
-		visualizer.PresetBird(vis.R)
-	default:
-		visualizer.PresetSingle(vis.R)
-	}
-	applyOverrides(args, cliArgs, vis.R)
-
 	// render
 	vis.R.OutputFilename = args.OutputFilename
 	vis.R.OutputMermaid = false
@@ -207,7 +222,58 @@ func renderDump(ctx context.Context, args Args, cliArgs []string) error {
 
 	// push debug
 	if args.Debug {
-		vis.Mach.Add1(am.StateHealthcheck, nil)
+		vis.Mach.Add1(ss.Healthcheck, nil)
+		time.Sleep(time.Second)
+	}
+
+	return nil
+}
+
+func inspectDump(
+	ctx context.Context, args Args, cliArgs []string,
+) error {
+	// go server.StartRpc(mach, p.ServerAddr, nil, p.FwdData)
+
+	vis, err := visualizer.New(ctx, "am-vis")
+	if err != nil {
+		return err
+	}
+
+	// init & import
+	vis.Mach.Add1(ss.Start, nil)
+	// TODO pass to StartState
+	err = vis.HImportData(args.InspectDump.DumpFilename)
+	if err != nil {
+		return err
+	}
+	clients := slices.Collect(maps.Values(vis.Clients()))
+	fmt.Printf("Imported %d clients\n", len(clients))
+
+	// presets
+	switch {
+	case args.Map:
+		visualizer.PresetMap(vis.R)
+	case args.Bird:
+		visualizer.PresetBird(vis.R)
+	default:
+		visualizer.PresetSingle(vis.R)
+	}
+	applyOverrides(args, cliArgs, vis.R)
+
+	// render
+	inspect, err := vis.Graph.Inspect()
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(args.OutputFilename+".md",
+		[]byte(amgraph.Markdown(inspect)), 0644)
+	if err != nil {
+		return err
+	}
+
+	// push debug
+	if args.Debug {
+		vis.Mach.Add1(ss.Healthcheck, nil)
 		time.Sleep(time.Second)
 	}
 
@@ -215,52 +281,69 @@ func renderDump(ctx context.Context, args Args, cliArgs []string) error {
 }
 
 func applyOverrides(args Args, cliArgs []string, vis *visualizer.Renderer) {
-	if slices.Contains(cliArgs, "--render-detailed-pipes") {
+	cliParam := func(param string) bool {
+		for _, n := range cliArgs {
+			if strings.HasPrefix(n, param) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if cliParam("--render-detailed-pipes") {
 		vis.RenderDetailedPipes = args.RenderDetailedPipes
 	}
-	if slices.Contains(cliArgs, "--render-pipes") {
+	if cliParam("--render-pipes") {
 		vis.RenderPipes = args.RenderPipes
 	}
-	if slices.Contains(cliArgs, "--render-exception") {
+	if cliParam("--render-exception") {
 		vis.RenderException = args.RenderException
 	}
-	if slices.Contains(cliArgs, "--render-tags") {
+	if cliParam("--render-tags") {
 		vis.RenderTags = args.RenderTags
 	}
-	if slices.Contains(cliArgs, "--render-inherited") {
+	if cliParam("--render-inherited") {
 		vis.RenderInherited = args.RenderInherited
 	}
-	if slices.Contains(cliArgs, "--render-relations") {
+	if cliParam("--render-relations") {
 		vis.RenderRelations = args.RenderRelations
 	}
-	if slices.Contains(cliArgs, "--render-conns") {
+	if cliParam("--render-conns") {
 		vis.RenderConns = args.RenderConns
 	}
-	if slices.Contains(cliArgs, "--render-parent-rel") {
+	if cliParam("--render-parent-rel") {
 		vis.RenderParentRel = args.RenderParentRel
 	}
-	if slices.Contains(cliArgs, "--render-half-conns") {
+	if cliParam("--render-half-conns") {
 		vis.RenderHalfConns = args.RenderHalfConns
 	}
-	if slices.Contains(cliArgs, "--render-half-pipes") {
+	if cliParam("--render-half-pipes") {
 		vis.RenderHalfPipes = args.RenderHalfPipes
 	}
-	if slices.Contains(cliArgs, "--render-nest-submachines") {
+	if cliParam("--render-nest-submachines") {
 		vis.RenderNestSubmachines = args.RenderNestSubmachines
 	}
-	if slices.Contains(cliArgs, "--render-start") {
+	if cliParam("--render-start") {
 		vis.RenderStart = args.RenderStart
 	}
-	if slices.Contains(cliArgs, "--render-ready") {
+	if cliParam("--render-ready") {
 		vis.RenderReady = args.RenderReady
 	}
-	if slices.Contains(cliArgs, "--render-depth") {
+	if cliParam("--render-depth") {
 		vis.RenderDepth = args.RenderDepth
 	}
-	if slices.Contains(cliArgs, "--render-states") {
+	if cliParam("--render-states") {
 		vis.RenderStates = args.RenderStates
 	}
-	if slices.Contains(cliArgs, "--output-elk") {
+
+	if cliParam("--render-distance") {
+		vis.RenderDistance = args.RenderDistance
+	}
+	if cliParam("--render-depth") {
+		vis.RenderDepth = args.RenderDepth
+	}
+	if cliParam("--output-elk") {
 		vis.OutputElk = args.OutputElk
 	}
 }


### PR DESCRIPTION
- fix: CLI overloads

We can now use `am-vis` to inspect the whole network as text.

```bash
am-vis inspect-dump am-dbg-dump.gob.br
```

```markdown
-----

## rnm-srv-browser2
Parent: rc-srv-browser2

### States
- Browser3Completed
- Browser3Disposed
- Browser3Disposing
- Browser3ErrHandlerTimeout
- Browser3ErrNetwork
- Browser3ErrOnClient
- Browser3Exception
- Browser3Failed
- Browser3Healthcheck
- Browser3Heartbeat
- Browser3Ready
- Browser3RegisterDisposal
- Browser3Retry
- Browser3Retrying
- Browser3RpcReady
- Browser3Start
- Browser3Work
- Browser3Working
- Browser4Completed
- Browser4Disposed
- Browser4Disposing
- Browser4ErrHandlerTimeout
- Browser4ErrNetwork
- Browser4ErrOnClient
- Browser4Exception
- Browser4Failed
- Browser4Healthcheck
- Browser4Heartbeat
- Browser4Ready
- Browser4RegisterDisposal
- Browser4Retry
- Browser4Retrying
- Browser4RpcReady
- Browser4Start
- Browser4Work
- Browser4Working
- Completed
- Disposed
- Disposing
- ErrHandlerTimeout
- ErrNetwork
- ErrOnClient
- Exception
- Failed
- Healthcheck
- Heartbeat
- Ready
- RegisterDisposal
- Retrying
- RpcReady
- ServerPayload
- Start
- Working

### Pipes

#### orchestrator
- [add] Browser3Completed -> Browser3Completed
- [add] Browser3Exception -> ErrBrowser3
- [add] Browser3Failed -> Browser3Failed
- [add] Browser3Ready -> Browser3Ready
- [add] Browser3Working -> Browser3Working
- [add] Browser4Completed -> Browser4Completed
- [add] Browser4Exception -> ErrBrowser4
- [add] Browser4Failed -> Browser4Failed
- [add] Browser4Ready -> Browser4Ready
- [add] Browser4Working -> Browser4Working
- [add] Completed -> Browser2Completed
- [add] Exception -> ErrBrowser2
- [add] Failed -> Browser2Failed
- [add] Ready -> Browser2Ready
- [add] Working -> Browser2Working
- [remove] Browser3Completed -> Browser3Completed
- [remove] Browser3Exception -> ErrBrowser3
- [remove] Browser3Failed -> Browser3Failed
- [remove] Browser3Ready -> Browser3Ready
- [remove] Browser3Working -> Browser3Working
- [remove] Browser4Completed -> Browser4Completed
- [remove] Browser4Exception -> ErrBrowser4
- [remove] Browser4Failed -> Browser4Failed
- [remove] Browser4Ready -> Browser4Ready
- [remove] Browser4Working -> Browser4Working
- [remove] Completed -> Browser2Completed
- [remove] Exception -> ErrBrowser2
- [remove] Failed -> Browser2Failed
- [remove] Ready -> Browser2Ready
- [remove] Working -> Browser2Working

-----

## rs-browser1
Parent: browser1

### States
- ClientConnected
- ErrDelivery
- ErrHandlerTimeout
- ErrNetwork
- ErrNetworkTimeout
- ErrOnClient
- ErrRpc
- Exception
- HandshakeDone
- Handshaking
- Healthcheck
- Heartbeat
- MetricSync
- Ready
- RpcAccepting
- RpcReady
- RpcStarting
- Start
- WebSocketTunnel

### Pipes

#### browser1
- [add] Ready -> RpcReady
- [remove] Ready -> RpcReady

-----
```