### PR TITLE
feat(machine): add `Next*Active*` tick helpers

### DIFF
--- a/pkg/machine/mach_utils.go
+++ b/pkg/machine/mach_utils.go
@@ -85,6 +85,42 @@ func IsActiveTick(tick uint64) bool {
 	return tick%2 == 1
 }
 
+// NextActive returns the absolute tick when the state will be active again
+// (excluding the currently active tick).
+func NextActive(tick uint64) uint64 {
+	if IsActiveTick(tick) {
+		return tick + 2
+	}
+	return tick + 1
+}
+
+// NextInactive returns the absolute tick when the state will be inactive again
+// (excluding the currently inactive tick).
+func NextInactive(tick uint64) uint64 {
+	if !IsActiveTick(tick) {
+		return tick + 2
+	}
+	return tick + 1
+}
+
+// NextActiveIn returns the number of ticks until the state will be active again
+// (excluding the currently active tick).
+func NextActiveIn(tick uint64) int {
+	if IsActiveTick(tick) {
+		return 2
+	}
+	return 1
+}
+
+// NextInactiveIn returns the number of ticks until the state will be inactive
+// again (excluding the currently inactive tick).
+func NextInactiveIn(tick uint64) int {
+	if !IsActiveTick(tick) {
+		return 2
+	}
+	return 1
+}
+
 // IsQueued returns true if the mutation has been queued, and the result
 // represents the queue time it will be processed.
 func IsQueued(result Result) bool {


### PR DESCRIPTION
`WhenQueue` combined with tick couting effectively allows using a sync state as an async one, and the new tick helpers make it easier. Example:

```go
// click more and wait for unclick
err = amhelp.WaitForErrAll(ctx, time.Second, mach,
    mach.WhenQueue(mach.EvAdd1(e, ss.ClickingMore, nil)),
    mach.WhenTicks(ss.ClickingMore, am.NextInactiveIn(mach.Tick(ss.ClickingMore)), ctx))
```