### PR TITLE
feat(am-dbg): add stack traces to queued mutations

### DIFF
--- a/pkg/telemetry/dbg/dbg.go
+++ b/pkg/telemetry/dbg/dbg.go
@@ -25,6 +25,8 @@ const (
 	// EnvAmDbgAddr is the address of a running am-dbg instance.
 	// "1" expands to "localhost:6831"
 	EnvAmDbgAddr = "AM_DBG_ADDR"
+	// EnvAmDbgNoTrace disables collecting stack traces
+	EnvAmDbgNoTrace = "AM_DBG_NO_TRACE"
 )
 
 // DbgMsg is the interface for the messages to be sent to the am-dbg server.
@@ -121,9 +123,10 @@ type DbgMsgTx struct {
 	// is this a check (Can*) tx or mutation?
 	IsCheck bool
 	// is this a queued mutation?
-	IsQueued  bool
-	Args      map[string]string
-	QueueDump []string
+	IsQueued   bool
+	Args       map[string]string
+	QueueDump  []string
+	StackTrace string
 
 	// TODO add Mutation.Source, only if semLogger.IsGraph() == true
 	// Source *am.MutSource
@@ -510,6 +513,10 @@ func (t *Tracer) MutationQueued(mach am.Api, mut *am.Mutation) {
 		// debug
 		// QueueDump: mach.QueueDump(),
 		// TODO Source
+	}
+
+	if os.Getenv(EnvAmDbgNoTrace) == "" {
+		msg.StackTrace = utils.CaptureStackTrace()
 	}
 
 	// collect args

--- a/tools/debugger/log.go
+++ b/tools/debugger/log.go
@@ -656,6 +656,17 @@ func (d *Debugger) initLogReader() *cview.TreeView {
 	// focus change
 	tree.SetChangedFunc(func(node *cview.TreeNode) {
 		ref, ok := node.GetReference().(*logReaderTreeRef)
+
+		// info overlay
+		if ref != nil && ref.info != "" {
+			d.Mach.Add1(ss.Overlay, Pass(&A{
+				Text: ref.info,
+			}))
+		} else if d.Mach.Is1(ss.Overlay) {
+			d.Mach.Remove1(ss.Overlay, nil)
+		}
+
+		// exit when no ref
 		if !ok || ref == nil {
 			return
 		}
@@ -753,6 +764,27 @@ func (d *Debugger) initLogReader() *cview.TreeView {
 	})
 
 	return tree
+}
+
+func (d *Debugger) OverlayEnter(e *am.Event) bool {
+	return ParseArgs(e.Args).Text != ""
+}
+
+func (d *Debugger) OverlayState(e *am.Event) {
+	txt := ParseArgs(e.Args).Text
+
+	d.overlay.SetText(txt)
+	d.overlay.SetVisible(true)
+	x, y, _, h := d.logReader.GetRect()
+	d.overlay.SetRect(0, y, x, h)
+	d.LayoutRoot.SendToFront("overlay")
+	d.Mach.EvAdd1(e, ss.UpdateFocus, nil)
+}
+
+func (d *Debugger) OverlayEnd(e *am.Event) {
+	d.LayoutRoot.SendToBack("overlay")
+	d.overlay.SetVisible(false)
+	d.Mach.EvAdd1(e, ss.UpdateFocus, nil)
 }
 
 func (d *Debugger) OverlayEnd(e *am.Event) {
@@ -1132,6 +1164,16 @@ func (d *Debugger) hUpdateLogReader(e *am.Event) {
 		parentSource.AddChild(node)
 		node = cview.NewTreeNode("tx unknown")
 		node.SetIndent(1)
+		parentSource.AddChild(node)
+	}
+
+	// stack trace
+	if tx.StackTrace != "" {
+		node := cview.NewTreeNode("stack trace")
+		node.SetIndent(1)
+		node.SetReference(&logReaderTreeRef{
+			info: strings.TrimSpace(highlightStackTrace("\n" + tx.StackTrace)),
+		})
 		parentSource.AddChild(node)
 	}
 

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -190,6 +190,7 @@ var States = am.Schema{
 		Multi:   true,
 		Require: S{Ready},
 	},
+	ssD.Overlay: {Require: S{ssD.LogReaderFocused}},
 	AfterFocus: {
 		Multi:   true,
 		Require: S{Ready},
@@ -201,11 +202,13 @@ var States = am.Schema{
 
 	// tx / steps back / fwd
 
-	Fwd: {
-		Require: S{ClientSelected},
+	ssD.Fwd: {
+		Require: S{ssD.ClientSelected},
+		Remove:  S{ssD.Overlay},
 	},
-	Back: {
-		Require: S{ClientSelected},
+	ssD.Back: {
+		Require: S{ssD.ClientSelected},
+		Remove:  S{ssD.Overlay},
 	},
 	FwdStep: {
 		Require: S{ClientSelected},


### PR DESCRIPTION
Every queued mutation (toolbar button) now has the stack trace attached and accessible from the log reader, with the machine-related entries filtered out.

<img width="1294" height="758" alt="ss-2026-04-12-15-48-20" src="https://github.com/user-attachments/assets/a37bf346-57f5-4309-9263-7aeedfabd97b" />
