### PR TITLE
feat(am-dbg): add light theme via `--view-theme light`

### DIFF
--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -56,6 +56,9 @@ type cache struct {
 	diagramDom *goquery.Document
 }
 
+// TODO avoid globals
+var theme Theme
+
 type Debugger struct {
 	*am.ExceptionHandler
 	Mach *am.Machine
@@ -399,6 +402,20 @@ func (d *Debugger) setParams(p types.Params) error {
 		d.Mach.Remove1(ss.FilterDisconn, nil)
 	}
 	d.lastSelectedGroup = p.SelectGroup
+
+	// TODO avoid globals
+	var err error
+	if p.ViewTheme == "light" {
+		theme, err = mapToTheme(themeLight, false)
+	} else {
+		theme, err = mapToTheme(themeDark, true)
+	}
+	if err != nil {
+		return err
+	}
+
+	// apply theme to defaults
+	theme.Apply()
 
 	d.Params = p
 	return nil

--- a/tools/debugger/misc_dbg.go
+++ b/tools/debugger/misc_dbg.go
@@ -21,14 +21,6 @@ import (
 )
 
 const (
-	// TODO light mode
-	colorActive     = tcell.ColorOlive
-	colorActive2    = tcell.ColorGreenYellow
-	colorInactive   = tcell.ColorLimeGreen
-	colorHighlight  = tcell.ColorDarkSlateGray
-	colorHighlight2 = tcell.ColorDimGray
-	colorHighlight3 = tcell.Color233
-	colorErr        = tcell.ColorRed
 	// TODO customize
 	playInterval = 500 * time.Millisecond
 	// TODO add param --max-clients

--- a/tools/debugger/themes.go
+++ b/tools/debugger/themes.go
@@ -1,0 +1,224 @@
+package debugger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/pancsta/cview"
+	"github.com/pancsta/tcell-v2"
+)
+
+// ///// ///// /////
+
+// ///// THEMES
+
+// ///// ///// /////
+
+var themeDark = map[string]string{
+	"active":     "yellow",
+	"active2":    "greenyellow",
+	"inactive":   "limegreen",
+	"highlight":  "darkslategrey",
+	"highlight2": "dimgrey",
+	"highlight3": tcell.Color233.CSS(),
+	"err":        "red",
+	"errBg":      "indianred",
+	"errRecent":  "#FF5FAF",
+	"grey":       "darkgrey",
+	"white":      "white",
+	"yellow":     "yellow",
+	"darkGrey":   "darkgrey",
+	"green":      "green",
+	"lightGrey":  "darkgrey",
+
+	// defaults
+
+	"title":    tcell.ColorWhite.CSS(),
+	"border":   tcell.ColorGrey.CSS(),
+	"graphics": tcell.ColorWhite.CSS(),
+
+	"fgPrimary":         tcell.ColorWhite.CSS(),
+	"fgSecondary":       tcell.ColorYellow.CSS(),
+	"tertiary":          tcell.ColorLimeGreen.CSS(),
+	"inverse":           tcell.ColorBlack.CSS(),
+	"contrastPrimary":   tcell.ColorBlack.CSS(),
+	"contrastSecondary": tcell.ColorLightSlateGray.CSS(),
+
+	"bgPrimary":      tcell.ColorBlack.CSS(),
+	"bgContrast":     tcell.ColorGreen.CSS(),
+	"bgMoreContrast": tcell.ColorDarkGreen.CSS(),
+
+	"scrollBar": tcell.ColorWhite.CSS(),
+}
+
+// TODO fix scollbars, log colors
+var themeLight = map[string]string{
+	"active":            "#7B6200",
+	"active2":           "#005500",
+	"inactive":          "#007700",
+	"highlight":         "#C8DCE0",
+	"highlight2":        "#B0B8BB",
+	"highlight3":        "#EBEBEB",
+	"err":               "#CC0000",
+	"errBg":             "#B03030",
+	"errRecent":         "#C7006B",
+	"grey":              "#555555",
+	"white":             "#111111",
+	"yellow":            "#8B7500",
+	"darkGrey":          "#888888",
+	"green":             "#006400",
+	"bgPrimary":         tcell.ColorWhite.CSS(),
+	"bgContrast":        tcell.ColorOldLace.CSS(),
+	"bgMoreContrast":    tcell.ColorLightGrey.CSS(),
+	"fgPrimary":         tcell.ColorBlack.CSS(),
+	"fgSecondary":       tcell.ColorDimGrey.CSS(),
+	"border":            tcell.ColorGrey.CSS(),
+	"title":             tcell.ColorBlack.CSS(),
+	"graphics":          tcell.ColorBlack.CSS(),
+	"tertiary":          tcell.ColorDarkGreen.CSS(),
+	"inverse":           tcell.ColorWhite.CSS(),
+	"contrastPrimary":   tcell.ColorWhite.CSS(),
+	"contrastSecondary": tcell.ColorDarkGrey.CSS(),
+	"scrollBar":         tcell.ColorBlack.CSS(),
+
+	// TODO
+	"lightGrey": "darkgrey",
+}
+
+// TODO move to types
+type Theme struct {
+	// primary active/selected state color
+	Active string
+	// secondary active color (changed states)
+	Active2 string
+	// inactive/default state color
+	Inactive string
+	// background highlight (selected items)
+	Highlight string
+	// secondary highlight (scrollbars, selections)
+	Highlight2 string
+	// tertiary highlight (table/matrix cells)
+	Highlight3 string
+	// error color
+	Err string
+	// error background color (accepted tx with exception state)
+	ErrBg string
+	// recent error indicator
+	ErrRecent string
+	// inline tview markup grey text
+	Grey string
+	// inline tview markup white/bright text
+	White string
+	// log prefix brackets
+	Yellow string
+	// faded/extern content
+	DarkGrey string
+	// accepted gutter, relation start
+	Green string
+	// addr button background
+	LightGrey string
+
+	// style overrides (cview.Styles)
+	// title text color
+	Title string
+	// border color
+	Border string
+	// graphics color
+	Graphics string
+
+	// primitive background color
+	BgPrimary string
+	// contrast background color
+	BgContrast string
+	// more contrast background color
+	BgMoreContrast string
+
+	// primary text color
+	FgPrimary string
+	// secondary text color
+	FgSecondary string
+	// tertiary text color
+	Tertiary string
+	// inverse text color
+	Inverse string
+	// contrast primary text color
+	ContrastPrimary string
+	// contrast secondary text color
+	ContrastSecondary string
+
+	// scroll bar color
+	ScrollBar string
+}
+
+// mapToTheme converts a string map into a Theme struct.
+func mapToTheme(theme map[string]string, isDark bool) (Theme, error) {
+	var errs error
+	// AI add safety fallback
+	get := func(name string) string {
+		v, ok := theme[name]
+		if ok {
+			return v
+		}
+
+		errs = errors.Join(errs, fmt.Errorf("missing theme key: %s", name))
+		// fallback TODO log err
+		if isDark {
+			return "white"
+		}
+		return "black"
+	}
+
+	return Theme{
+		Active:     get("active"),
+		Active2:    get("active2"),
+		Inactive:   get("inactive"),
+		Highlight:  get("highlight"),
+		Highlight2: get("highlight2"),
+		Highlight3: get("highlight3"),
+		Err:        get("err"),
+		ErrBg:      get("errBg"),
+		ErrRecent:  get("errRecent"),
+		Grey:       get("grey"),
+		White:      get("white"),
+		Yellow:     get("yellow"),
+		DarkGrey:   get("darkGrey"),
+		Green:      get("green"),
+		LightGrey:  get("lightGrey"),
+
+		// defaults
+
+		Title:             get("title"),
+		Border:            get("border"),
+		Graphics:          get("graphics"),
+		BgPrimary:         get("bgPrimary"),
+		BgContrast:        get("bgContrast"),
+		BgMoreContrast:    get("bgMoreContrast"),
+		FgPrimary:         get("fgPrimary"),
+		FgSecondary:       get("fgSecondary"),
+		Tertiary:          get("tertiary"),
+		Inverse:           get("inverse"),
+		ContrastPrimary:   get("contrastPrimary"),
+		ContrastSecondary: get("contrastSecondary"),
+		ScrollBar:         get("scrollBar"),
+	}, errs
+}
+
+// Apply applies the theme to cview.Styles.
+func (t Theme) Apply() {
+	cview.Styles.TitleColor = tcell.GetColor(t.Title)
+	cview.Styles.BorderColor = tcell.GetColor(t.Border)
+	cview.Styles.GraphicsColor = tcell.GetColor(t.Graphics)
+
+	cview.Styles.PrimaryTextColor = tcell.GetColor(t.FgPrimary)
+	cview.Styles.SecondaryTextColor = tcell.GetColor(t.FgSecondary)
+	cview.Styles.TertiaryTextColor = tcell.GetColor(t.Tertiary)
+	cview.Styles.InverseTextColor = tcell.GetColor(t.Inverse)
+	cview.Styles.ContrastPrimaryTextColor = tcell.GetColor(t.ContrastPrimary)
+	cview.Styles.ContrastSecondaryTextColor = tcell.GetColor(t.ContrastSecondary)
+
+	cview.Styles.PrimitiveBackgroundColor = tcell.GetColor(t.BgPrimary)
+	cview.Styles.ContrastBackgroundColor = tcell.GetColor(t.BgContrast)
+	cview.Styles.MoreContrastBackgroundColor = tcell.GetColor(t.BgMoreContrast)
+
+	cview.Styles.ScrollBarColor = tcell.GetColor(t.ScrollBar)
+}

--- a/tools/debugger/tree.go
+++ b/tools/debugger/tree.go
@@ -58,10 +58,10 @@ func (d *Debugger) hInitSchemaTree() *cview.TreeView {
 	tree := cview.NewTreeView()
 	tree.SetRoot(d.treeRoot)
 	tree.SetCurrentNode(d.treeRoot)
-	tree.SetSelectedBackgroundColor(colorHighlight2)
-	tree.SetSelectedTextColor(tcell.ColorWhite)
-	tree.SetHighlightColor(colorHighlight)
-	tree.SetScrollBarColor(colorHighlight2)
+	tree.SetSelectedBackgroundColor(tcell.GetColor(theme.Highlight2))
+	tree.SetSelectedTextColor(tcell.GetColor(theme.White))
+	tree.SetHighlightColor(tcell.GetColor(theme.Highlight))
+	tree.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 
 	// focus change within the tree
 	tree.SetChangedFunc(func(node *cview.TreeNode) {
@@ -598,30 +598,30 @@ func (d *Debugger) hUpdateTreeRelCols(
 				if t == ' ' {
 					if !secondSpace {
 						secondSpace = true
-						dotted += "[grey]."
+						dotted += "[" + theme.Grey + "]."
 					} else if !thirdSpace {
 						thirdSpace = true
-						dotted += "[grey]."
+						dotted += "[" + theme.Grey + "]."
 					} else {
 						dotted += "."
 					}
 				} else if secondSpace && !white {
 					white = true
-					dotted += "[white]" + string(t)
+					dotted += "[" + theme.White + "]" + string(t)
 				} else {
 					// copy existing rune
 					dotted += string(t)
 				}
 			}
 
-			node.SetText(dotted + "[grey]")
+			node.SetText(dotted + "[" + theme.Grey + "]")
 			nodeCols = strings.Repeat(".", max(0, spaces))
 		} else {
 			nodeCols = strings.Repeat(" ", max(0, spaces))
 		}
 
 		if len(relCols) > 0 {
-			nodeCols += "[grey]"
+			nodeCols += "[" + theme.Grey + "]"
 		}
 
 		// draw columns
@@ -648,9 +648,9 @@ func (d *Debugger) hUpdateTreeRelCols(
 				// }
 
 				if isRelStart {
-					nodeCols += "[green::b]|[grey::-]"
+					nodeCols += "[" + theme.Green + "::b]|[" + theme.Grey + "::-]"
 				} else if isRelEnd {
-					nodeCols += "[red::b]|[grey::-]"
+					nodeCols += "[" + theme.Err + "::b]|[" + theme.Grey + "::-]"
 				} else {
 					nodeCols += "|"
 				}
@@ -677,10 +677,10 @@ func (d *Debugger) hUpdateTreeRelCols(
 		if ref.stateName != "" && !ref.isRef {
 			if !msg.Is(d.C.MsgStruct.StatesIndex, am.S{ref.stateName}) {
 				text = reTreeStateColorFix.ReplaceAllString(text,
-					"["+colorInactive.String()+"]$1[grey]$2")
+					"["+theme.Inactive+"]$1["+theme.Grey+"]$2")
 			} else {
 				text = reTreeStateColorFix.ReplaceAllString(text,
-					"["+colorActive.String()+"]$1[grey]$2")
+					"["+theme.Active+"]$1["+theme.Grey+"]$2")
 			}
 		}
 		node.SetText(text + suffix)
@@ -807,7 +807,7 @@ func (d *Debugger) hAddState(name string) {
 	stateNode := cview.NewTreeNode(name + " " + multi + "|0")
 	stateNode.SetSelectable(true)
 	stateNode.SetReference(&nodeRef{stateName: name})
-	stateNode.SetColor(colorInactive)
+	stateNode.SetColor(tcell.GetColor(theme.Inactive))
 	d.treeRoot.AddChild(stateNode)
 
 	if labels != "" {
@@ -838,7 +838,7 @@ func (d *Debugger) hAddState(name string) {
 
 		for _, tag := range state.Tags {
 			tagNode := cview.NewTreeNode("#" + tag)
-			tagNode.SetColor(tcell.ColorGrey)
+			tagNode.SetColor(tcell.GetColor(theme.Grey))
 			tagNode.SetReference(&nodeRef{
 				isTag: true,
 			})

--- a/tools/debugger/types/dbg_types.go
+++ b/tools/debugger/types/dbg_types.go
@@ -73,6 +73,7 @@ type Params struct {
 	ViewRain      bool   `arg:"--view-rain" help:"Show the rain view"`
 	ViewReader    bool   `arg:"-r,--view-reader" help:"Show the log reader view"`
 	TailMode      bool   `arg:"--view-tail" default:"true" help:"Start from the latest tx"`
+	ViewTheme     string `arg:"--view-theme" default:"dark" help:"Color theme (dark, light)"`
 	ViewTimelines int    `arg:"--view-timelines" default:"2" help:"Number of timelines to show (0-2)"`
 
 	// optimization

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -37,10 +37,10 @@ func (d *Debugger) hInitUiComponents() {
 	// groups dropdown
 	d.treeGroups = cview.NewDropDown()
 	d.treeGroups.SetLabel(" Group ")
-	d.treeGroups.SetFieldBackgroundColor(colorHighlight)
-	d.treeGroups.SetDropDownBackgroundColor(colorHighlight)
-	d.treeGroups.SetDropDownSelectedTextColor(colorDefault)
-	d.treeGroups.SetDropDownTextColor(colorDefault)
+	d.treeGroups.SetFieldBackgroundColor(tcell.GetColor(theme.Highlight))
+	d.treeGroups.SetDropDownBackgroundColor(tcell.GetColor(theme.Highlight))
+	d.treeGroups.SetDropDownSelectedTextColor(cview.Styles.PrimaryTextColor)
+	d.treeGroups.SetDropDownTextColor(cview.Styles.PrimaryTextColor)
 	d.treeGroups.SetSelectedFunc(func(_ int, opt *cview.DropDownOption) {
 		// TODO typed args
 		d.Mach.Add1(ss.SetGroup, am.A{"group": opt.GetText()})
@@ -59,9 +59,9 @@ func (d *Debugger) hInitUiComponents() {
 	d.log.SetWrap(false)
 	d.log.SetDynamicColors(true)
 	d.log.SetTitle(" Log ")
-	d.log.SetHighlightForegroundColor(tcell.ColorWhite)
-	d.log.SetHighlightBackgroundColor(colorHighlight2)
-	d.log.SetScrollBarColor(colorHighlight2)
+	d.log.SetHighlightForegroundColor(tcell.GetColor(theme.White))
+	d.log.SetHighlightBackgroundColor(tcell.GetColor(theme.Highlight2))
+	d.log.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 	// log click
 	statePrefixes := []string{"[state] ", "[state:auto] "}
 	d.log.SetClickedFunc(func(txId string) {
@@ -93,7 +93,7 @@ func (d *Debugger) hInitUiComponents() {
 	d.logReader = d.initLogReader()
 	d.logReader.SetTitle(" Reader ")
 	d.logReader.SetBorder(true)
-	d.logReader.SetScrollBarColor(colorHighlight2)
+	d.logReader.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 
 	// matrix
 	d.matrix = cview.NewTable()
@@ -101,15 +101,16 @@ func (d *Debugger) hInitUiComponents() {
 	d.matrix.SetTitle(" Matrix ")
 	d.matrix.SetScrollBarVisibility(cview.ScrollBarNever)
 	d.matrix.SetPadding(0, 0, 1, 0)
-	d.matrix.SetSelectedStyle(colorDefault, colorHighlight, tcell.AttrNone)
+	d.matrix.SetSelectedStyle(cview.Styles.PrimaryTextColor,
+		tcell.GetColor(theme.Highlight), tcell.AttrNone)
 
 	// current tx bar
 	d.currTxBarLeft = cview.NewTextView()
 	d.currTxBarLeft.SetDynamicColors(true)
-	d.currTxBarLeft.SetScrollBarColor(colorHighlight2)
+	d.currTxBarLeft.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 	d.currTxBarRight = cview.NewTextView()
 	d.currTxBarRight.SetTextAlign(cview.AlignRight)
-	d.currTxBarRight.SetScrollBarColor(colorHighlight2)
+	d.currTxBarRight.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 	d.currTxBarRight.SetDynamicColors(true)
 	d.currTxBarRight.SetClickedFunc(func(regionId string) {
 		d.Mach.Add1(ss.TimelineTxsFocused, nil)
@@ -121,10 +122,10 @@ func (d *Debugger) hInitUiComponents() {
 	// next tx bar
 	d.nextTxBarLeft = cview.NewTextView()
 	d.nextTxBarLeft.SetDynamicColors(true)
-	d.nextTxBarLeft.SetScrollBarColor(colorHighlight2)
+	d.nextTxBarLeft.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 	d.nextTxBarRight = cview.NewTextView()
 	d.nextTxBarRight.SetTextAlign(cview.AlignRight)
-	d.nextTxBarRight.SetScrollBarColor(colorHighlight2)
+	d.nextTxBarRight.SetScrollBarColor(tcell.GetColor(theme.Highlight2))
 	d.nextTxBarRight.SetDynamicColors(true)
 	d.nextTxBarRight.SetClickedFunc(func(regionId string) {
 		d.Mach.Add1(ss.TimelineStepsFocused, nil)


### PR DESCRIPTION
The light theme can be useful for debugging outdoors. Some fade-out colors in the dark theme have been fixed.

<img width="1599" height="1078" alt="ss-2026-04-23-17-10-45" src="https://github.com/user-attachments/assets/26239981-7754-453d-a5fc-feca0d3295a3" />
