### PR TITLE
feat(am-dbg): add diagram filtering (group, called, changed, touched, relations, selected)

### DIFF
--- a/tools/debugger/dbg_handlers.go
+++ b/tools/debugger/dbg_handlers.go
@@ -218,14 +218,21 @@ func (d *Debugger) StateNameSelectedState(e *am.Event) {
 	}
 
 	d.hUpdateStatusBar()
+	d.Mach.Fork(ctx, e, func() {
+		amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
+	})
 }
 
-func (d *Debugger) StateNameSelectedEnd(_ *am.Event) {
+func (d *Debugger) StateNameSelectedEnd(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.Start)
 	if d.C != nil {
 		d.C.SelectedState = ""
 	}
 	d.hUpdateSchemaTree()
 	d.hUpdateStatusBar()
+	d.Mach.Fork(ctx, e, func() {
+		amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
+	})
 }
 
 func (d *Debugger) PlayingState(_ *am.Event) {
@@ -842,11 +849,10 @@ func (d *Debugger) SetGroupState(e *am.Event) {
 	d.hBuildSchemaTree()
 	d.hUpdateSchemaTree()
 	go amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
-	d.Mach.EvAdd(e, am.S{ss.ToolToggled, ss.BuildingLog}, am.A{
-		// TODO typed args
-		"filterTxs":     true,
-		"logRebuildEnd": len(c.MsgTxs),
-	})
+	d.Mach.EvAdd(e, am.S{ss.ToolToggled, ss.UpdateLogScheduled}, Pass(&A{
+		FilterTxs:     true,
+		LogRebuildEnd: len(c.MsgTxs),
+	}))
 }
 
 // TODO SelectingClientSelectingClient (for?)
@@ -1736,7 +1742,7 @@ func (d *Debugger) hSetCursor1(e *am.Event, args am.A) {
 
 func (d *Debugger) DiagramsScheduledEnter(e *am.Event) bool {
 	// TODO refuse on too many ErrDiagrams, remove ErrDiagrams in ErrDiagramsState
-	return d.C != nil && d.Params.OutputDiagrams > 0
+	return d.C != nil && d.Params.OutputDiagrams.Value > 0
 }
 
 func (d *Debugger) DiagramsScheduledState(e *am.Event) {
@@ -1748,43 +1754,92 @@ func (d *Debugger) DiagramsScheduledState(e *am.Event) {
 }
 
 func (d *Debugger) DiagramsRenderingEnter(e *am.Event) bool {
-	return d.Params.OutputDiagrams > 0 && d.C != nil
+	return d.Params.OutputDiagrams.Value > 0 && d.C != nil
 }
 
 func (d *Debugger) DiagramsRenderingState(e *am.Event) {
-	lvl := d.Params.OutputDiagrams
-	dir := path.Join(d.Params.OutputDir, "diagrams")
+	lvl := d.Params.OutputDiagrams.Value
+	diagDir := path.Join(d.Params.OutputDir, "diagrams")
 	c := d.C
 	tx := d.hCurrentTx()
 	svgName := fmt.Sprintf("%s-%d-%s", c.Id, lvl, c.SchemaHash)
 
 	// state groups
 	var states S
-	if g := c.SelectedGroup; g != "" {
+	if g := c.SelectedGroup; g != "" &&
+		d.Params.OutputDiagGroup == types.ParamsOutDiagGroupSkip {
+
 		states = c.MsgSchemaParsed.Groups[g]
 		gg := strings.ReplaceAll(strings.ReplaceAll(g, "-", ""), " ", "")
 		svgName = fmt.Sprintf("%s-%s-%d-%s",
 			c.Id, strings.ToLower(gg), lvl, c.SchemaHash)
 	}
-	svgPath := filepath.Join(dir, svgName+".svg")
+	svgPath := filepath.Join(diagDir, svgName+".svg")
 
 	// output dir
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(diagDir, 0o755); err != nil {
 		d.Mach.EvAddErrState(e, ss.ErrDiagrams,
 			fmt.Errorf("create output dir: %w", err), nil)
 	}
 
 	// cached?
 
+	// build update fragment
+	index := c.MsgStruct.StatesIndex
+	diagFilters := &amvis.Filters{
+		MachId:   c.Id,
+		Index:    index,
+		Selected: am.S{d.C.SelectedState},
+	}
+	if tx != nil {
+		diagFilters.Active = tx.ActiveStates(index)
+
+		// dim
+		if d.Params.OutputDiagTx != types.ParamsOutDiagTxNone {
+			parsed := c.MsgTxsParsed[c.CursorTx1-1]
+			showIdxs := tx.CalledStatesIdxs
+			switch d.Params.OutputDiagTx {
+			case types.ParamsOutDiagTxMutated:
+				showIdxs = slices.Concat(parsed.StatesAdded, parsed.StatesRemoved)
+			case types.ParamsOutDiagTxTouched:
+				fallthrough
+			case types.ParamsOutDiagTxRelations:
+				showIdxs = parsed.StatesTouched
+			}
+			diagFilters.Highlighted = c.IndexesToStates(showIdxs)
+		}
+
+		// collect touched rels TODO add to step timeline 1-by-1
+		if d.Params.OutputDiagTx == types.ParamsOutDiagTxRelations {
+			for _, step := range tx.Steps {
+				if step.Type != am.StepRelation {
+					continue
+				}
+
+				diagFilters.HighlightedRels = append(diagFilters.HighlightedRels,
+					[3]string{
+						step.GetFromState(index),
+						step.GetToState(index),
+						step.RelType.String(),
+					})
+			}
+		}
+	}
+	if d.Params.OutputDiagGroup == types.ParamsOutDiagGroupHide &&
+		c.SelectedGroup != "" {
+
+		diagFilters.Visible = c.MsgSchemaParsed.Groups[c.SelectedGroup]
+	}
+
 	// mem cache
-	if d.cache.diagramId == c.Id && d.cache.diagramLvl == lvl {
+	if d.cache.diagramName == svgName {
 		cache := d.cache.diagramDom
-		go d.diagramsMemCache(e, c.Id, cache, tx, dir, svgName)
+		go d.diagramsMemCache(e, cache, diagFilters, diagDir, svgName)
 		return
 
 		// file cache, move to mem cache
 	} else if _, err := os.Stat(svgPath); err == nil {
-		go d.diagramsFileCache(e, c.Id, tx, d.cache.diagramLvl, dir, svgName)
+		go d.diagramsFileCache(e, diagFilters, lvl, diagDir, svgName)
 		return
 	}
 
@@ -1798,19 +1853,19 @@ func (d *Debugger) DiagramsRenderingState(e *am.Event) {
 	}
 
 	// unblock
-	go d.diagramsRender(e, shot, c.Id, lvl, len(d.Clients), dir, svgName, states)
+	d.Mach.EvAdd1(e, ss.DiagramsNoCache, nil)
+	go d.diagramsRender(e, shot, c.Id, diagFilters, lvl, len(d.Clients), diagDir,
+		svgName, states)
 }
 
 func (d *Debugger) DiagramsReadyState(e *am.Event) {
 	defer d.Mach.EvRemove1(e, ss.DiagramsReady, nil)
 
 	// update cache
-	// TODO typed args
-	cache, ok := e.Args["Diagram.cache"].(*goquery.Document)
-	if ok {
-		d.cache.diagramDom = cache
-		d.cache.diagramLvl = e.Args["Diagram.lvl"].(int)
-		d.cache.diagramId = e.Args["Diagram.id"].(string)
+	args := ParseArgs(e.Args)
+	if args.DiagramCache != nil {
+		d.cache.diagramDom = args.DiagramCache
+		d.cache.diagramName = args.DiagramName
 	}
 
 	// render a fresher one, if scheduled
@@ -2080,15 +2135,22 @@ func (d *Debugger) WebReqState(e *am.Event) {
 	}
 }
 
+type WsDiagMsg struct {
+	Type  string
+	Addr  *types.MachAddress
+	Group string
+}
+
 func (d *Debugger) WebSocketDiagState(e *am.Event) {
-	// TODO TYPED PARAMS
-	ws := e.Args["*websocket.Conn"].(*websocket.Conn)
-	r := e.Args["*http.Request"].(*http.Request)
-	done := e.Args["doneChan"].(chan struct{})
+	ctx := d.Mach.NewStateCtx(ss.WebSocketDiag)
+	wsdArgs := ParseArgs(e.Args)
+	ws := wsdArgs.WebSocketConn
+	r := wsdArgs.HttpRequest
+	done := wsdArgs.DoneChan
 	clientDone := make(chan struct{})
 
 	// unblock
-	go func() {
+	d.Mach.Fork(ctx, e, func() {
 		for {
 			// wait for diagrams start
 			select {
@@ -2098,18 +2160,63 @@ func (d *Debugger) WebSocketDiagState(e *am.Event) {
 			case <-d.Mach.When1(ss.DiagramsScheduled, nil):
 			}
 
-			// wait for diagrams ready
+			// show progress
 			select {
+
 			case <-clientDone:
 				close(done)
 				return
+
+			case <-d.Mach.When1(ss.DiagramsNoCache, nil):
+				// msg
+				msg, err := json.Marshal(WsDiagMsg{
+					Type: "loading",
+				})
+				if err != nil {
+					d.Mach.Log(err.Error())
+					continue
+				}
+
+				// send
+				err = ws.Write(r.Context(), websocket.MessageText, msg)
+				if err != nil {
+					d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+					return
+				}
+
+			case <-d.Mach.When1(ss.DiagramsReady, nil):
+				// next
+			}
+
+			// wait for diagrams ready
+			select {
+
+			case <-clientDone:
+				close(done)
+				return
+
 			// TODO loop over WSs in DiagramsReady. no goroutine per each
 			case <-d.Mach.When1(ss.DiagramsReady, nil):
 				// msg
-				err := ws.Write(r.Context(), websocket.MessageText,
-					[]byte("refresh"))
-				d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+				msg := WsDiagMsg{
+					Type: "refresh",
+					Addr: d.MachAddr(),
+				}
+				d.Mach.Eval("WebSocketDiagState", func() {
+					if d.Params.OutputDiagGroup == types.ParamsOutDiagGroupHide {
+						msg.Group = d.C.SelectedGroup
+					}
+				}, r.Context())
+				msgB, err := json.Marshal(msg)
 				if err != nil {
+					d.Mach.Log(err.Error())
+					continue
+				}
+
+				// send
+				err = ws.Write(r.Context(), websocket.MessageText, msgB)
+				if err != nil {
+					d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
 					return
 				}
 			}

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -51,9 +51,8 @@ import (
 type S = am.S
 
 type cache struct {
-	diagramId  string
-	diagramLvl int
-	diagramDom *goquery.Document
+	diagramName string
+	diagramDom  *goquery.Document
 }
 
 type Debugger struct {
@@ -328,12 +327,8 @@ func (d *Debugger) setParams(p types.Params) error {
 	if p.FilterLogLevel > am.LogEverything {
 		p.FilterLogLevel = am.LogEverything
 	}
-	if p.OutputDiagrams > 3 {
-		p.OutputDiagrams = 3
-	}
-	if p.ViewTimelines > 2 {
-		p.ViewTimelines = 2
-	}
+	p.OutputDiagrams.Value = max(p.OutputDiagrams.Value, p.OutputDiagrams.Value)
+	p.ViewTimelines.Value = max(p.ViewTimelines.Value, p.ViewTimelines.Value)
 
 	// rain adjusts the default view
 	if p.ViewRain && p.StartupView == "tree-log" {
@@ -2053,7 +2048,7 @@ func (d *Debugger) initGraphGen(
 
 	// machine diagram
 	vis.RenderMachs = []string{id}
-	vis.OutputFilename = path.Join(outDir, svgName)
+	vis.OutputFilename = path.Join(diagDir, svgName)
 	if len(statesAllowlist) > 0 {
 		vis.RenderAllowlist = statesAllowlist
 	}
@@ -2117,9 +2112,11 @@ func (d *Debugger) hSyncOptsTimelines() {
 }
 
 func (d *Debugger) diagramsRender(
-	e *am.Event, shot *amgraph.Graph, id string, details, clients int,
-	outDir string, svgName string, states S,
+	e *am.Event, shot *amgraph.Graph, id string, diagFilters *amvis.Filters,
+	details, clients int, diagDir string, svgName string, states S,
 ) {
+	//
+
 	ctx := d.Mach.NewStateCtx(ss.DiagramsRendering)
 	if ctx.Err() != nil {
 		return // expired
@@ -2128,7 +2125,7 @@ func (d *Debugger) diagramsRender(
 	d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
 
 	// create the visualizer
-	vizs := d.initGraphGen(shot, id, details, clients, outDir, svgName, states)
+	vizs := d.initGraphGen(shot, id, details, clients, diagDir, svgName, states)
 	// TODO config
 	pool := amhelp.Pool(2)
 
@@ -2145,13 +2142,13 @@ func (d *Debugger) diagramsRender(
 	}
 
 	// link
-	d.diagramLink(outDir, svgName)
+	d.diagramLink(diagDir, svgName)
 	if ctx.Err() != nil {
 		return // expired
 	}
 
 	// symlink am-vis-map.svg -> am-vis-map-CLIENTS.svg
-	source := path.Join(outDir, "am-vis-map.svg")
+	source := path.Join(diagDir, "am-vis-map.svg")
 	target := fmt.Sprintf("am-vis-map-%d.svg", clients)
 	_ = os.Remove(source)
 	err = os.Symlink(target, source)
@@ -2161,23 +2158,31 @@ func (d *Debugger) diagramsRender(
 	d.Mach.EvAddErr(e, err, nil)
 
 	// next
-	d.Mach.EvAdd1(e, ss.DiagramsReady, nil)
+	if !diagFilters.Empty() {
+		// apply filters
+		go d.diagramsFileCache(e, diagFilters, details, diagDir, svgName)
+	} else {
+		d.Mach.EvAdd1(e, ss.DiagramsReady, nil)
+	}
 }
 
-func (d *Debugger) diagramLink(outDir string, svgName string) {
+func (d *Debugger) diagramLink(diagDir string, svgName string) {
 	// symlink am-vis.svg -> ID-LVL-HASH.svg
-	source := path.Join(outDir, "am-vis.svg")
-	target := fmt.Sprintf("%s.svg", svgName)
+	source := path.Join(diagDir, "am-vis.svg")
+	target := svgName + ".svg"
 	_ = os.Remove(source)
 	err := os.Symlink(target, source)
 	d.Mach.AddErr(err, nil)
 }
 
+// diagramsMemCache - update diagram from memory cache
 func (d *Debugger) diagramsMemCache(
-	e *am.Event, id string, cache *goquery.Document, tx *dbg.DbgMsgTx,
-	outDir, svgName string,
+	e *am.Event, cache *goquery.Document, diagFilters *amvis.Filters,
+	diagDir, svgName string,
 ) {
-	svgPath := path.Join(outDir, svgName+".svg")
+	//
+
+	svgPath := path.Join(diagDir, svgName+".svg")
 	ctx := d.Mach.NewStateCtx(ss.DiagramsRendering)
 	if ctx.Err() != nil {
 		return // expired
@@ -2186,13 +2191,7 @@ func (d *Debugger) diagramsMemCache(
 	d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
 
 	// update cache DOM
-	states := d.C.MsgStruct.StatesIndex
-	sel := amvis.Fragment{
-		MachId: id,
-		States: states,
-		Active: tx.ActiveStates(states),
-	}
-	err := amvis.UpdateCache(ctx, svgPath, cache, &sel)
+	err := amvis.UpdateCache(ctx, svgPath, cache, diagFilters)
 	if ctx.Err() != nil {
 		return // expired
 	}
@@ -2202,7 +2201,7 @@ func (d *Debugger) diagramsMemCache(
 	}
 
 	// link
-	d.diagramLink(outDir, svgName)
+	d.diagramLink(diagDir, svgName)
 	if ctx.Err() != nil {
 		return // expired
 	}
@@ -2211,13 +2210,14 @@ func (d *Debugger) diagramsMemCache(
 	d.Mach.EvAdd1(e, ss.DiagramsReady, nil)
 }
 
+// diagramsFileCache - update diagram from file cache
 func (d *Debugger) diagramsFileCache(
-	e *am.Event, id string, tx *dbg.DbgMsgTx, lvl int, outDir,
+	e *am.Event, diagFilters *amvis.Filters, lvl int, diagDir,
 	svgName string,
 ) {
 	defer d.Mach.PanicToErrState(ss.ErrDiagrams, nil)
 
-	svgPath := path.Join(outDir, svgName+".svg")
+	svgPath := path.Join(diagDir, svgName+".svg")
 	ctx := d.Mach.NewStateCtx(ss.DiagramsRendering)
 	if ctx.Err() != nil {
 		return // expired
@@ -2238,17 +2238,7 @@ func (d *Debugger) diagramsFileCache(
 	}
 
 	// update cache DOM
-	// TODO support groups
-	states := d.C.MsgStruct.StatesIndex
-	sel := amvis.Fragment{
-		MachId: id,
-		States: states,
-	}
-	if tx != nil {
-		sel.Active = tx.ActiveStates(states)
-	}
-
-	err = amvis.UpdateCache(ctx, svgPath, cache, &sel)
+	err = amvis.UpdateCache(ctx, svgPath, cache, diagFilters)
 	if ctx.Err() != nil {
 		return // expired
 	}
@@ -2258,24 +2248,22 @@ func (d *Debugger) diagramsFileCache(
 	}
 
 	// link
-	d.diagramLink(outDir, svgName)
+	d.diagramLink(diagDir, svgName)
 	if ctx.Err() != nil {
 		return // expired
 	}
 
 	// next
-	d.Mach.EvAdd1(e, ss.DiagramsReady, am.A{
-		// TODO typed args
-		"Diagram.cache": cache,
-		"Diagram.id":    id,
-		"Diagram.lvl":   lvl,
-	})
+	d.Mach.EvAdd1(e, ss.DiagramsReady, Pass(&A{
+		DiagramCache: cache,
+		DiagramName:  svgName,
+	}))
 }
 
 func (d *Debugger) getFocusColor() tcell.Color {
 	color := cview.Styles.MoreContrastBackgroundColor
 	if d.Mach.IsErr() {
-		color = tcell.ColorRed
+		color = tcell.GetColor(theme.Err)
 	}
 
 	return color

--- a/tools/debugger/types/dbg_types.go
+++ b/tools/debugger/types/dbg_types.go
@@ -55,10 +55,12 @@ type Params struct {
 	FilterLogLevel       am.LogLevel `arg:"--filter-log-level" default:"2" help:"Filter transitions up to this log level, 0-5 (silent-everything)"`
 	FilterQueuedTx       bool        `arg:"--filter-queued" help:"Filter queued transitions"`
 
-	OutputClients  bool `arg:"--output-clients" help:"Write a detailed client list into am-dbg-clients.txt inside --dir"`
-	OutputDiagrams int  `arg:"--output-diagrams" help:"Level of details for machine graph diagrams (svg, d2, mermaid) in --dir (0 off, 1-3 on) (EXPERIMENTAL)"`
-	OutputLog      bool `arg:"--output-log" help:"Write the current log buffer to log.txt inside --dir"`
-	OutputTx       bool `arg:"--output-tx" default:"true" help:"Write the current transition with steps into tx.md / d2 / mermaid / txt inside --dir (EXPERIMENTAL)"`
+	OutputClients   bool                 `arg:"--output-clients" help:"Write a detailed client list into am-dbg-clients.txt inside --dir"`
+	OutputDiagrams  ParamsOutputDiagrams `arg:"--output-diagrams" help:"Level of details for machine graph diagrams (svg, d2, mermaid) in --dir (0 off, 1-3 on) (EXPERIMENTAL)"`
+	OutputDiagGroup ParamsOutDiagGroup   `arg:"--output-diag-group" help:"Only show states from the selected group (valid: hide, skip)" default:"hide"`
+	OutputDiagTx    ParamsOutDiagTx      `arg:"--output-diag-tx" help:"Dim states and rels unrelated to a transition (valid: called, changed, touched, relations)" default:"relations"`
+	OutputLog       bool                 `arg:"--output-log" help:"Write the current log buffer to log.txt inside --dir"`
+	OutputTx        bool                 `arg:"--output-tx" default:"true" help:"Write the current transition with steps into tx.md / d2 / mermaid / txt inside --dir (EXPERIMENTAL)"`
 
 	// ui
 
@@ -111,6 +113,120 @@ type Params struct {
 	Screen tcell.Screen `arg:"-"`
 	// Version is the computed build version string.
 	Version string `arg:"-"`
+}
+
+// -----
+
+// ParamsOutputDiagrams is an enum for --output-diagrams
+type ParamsOutputDiagrams enum.Member[int]
+
+// 0, 1, 2, 3
+var (
+	ParamsOutputDiagramsNone  = ParamsOutputDiagrams{0}
+	ParamsOutputDiagramsOne   = ParamsOutputDiagrams{1}
+	ParamsOutputDiagramsTwo   = ParamsOutputDiagrams{2}
+	ParamsOutputDiagramsThree = ParamsOutputDiagrams{3}
+
+	ParamsOutputDiagramsEnum = enum.New(
+		ParamsOutputDiagramsNone,
+		ParamsOutputDiagramsOne,
+		ParamsOutputDiagramsTwo,
+		ParamsOutputDiagramsThree,
+	)
+)
+
+func (p *ParamsOutputDiagrams) UnmarshalText(b []byte) error {
+	value, err := strconv.Atoi(string(b))
+	if err != nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	res := ParamsOutputDiagramsEnum.Parse(value)
+	if res == nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	*p = *res
+	return nil
+}
+
+// -----
+
+// ParamsOutDiagTx is an enum for --output-diagrams-group
+type ParamsOutDiagTx enum.Member[string]
+
+// "", "called", "changed", "touched"
+var (
+	ParamsOutDiagTxNone      = ParamsOutDiagTx{""}
+	ParamsOutDiagTxCalled    = ParamsOutDiagTx{"called"}
+	ParamsOutDiagTxMutated   = ParamsOutDiagTx{"mutated"}
+	ParamsOutDiagTxTouched   = ParamsOutDiagTx{"touched"}
+	ParamsOutDiagTxRelations = ParamsOutDiagTx{"relations"}
+
+	ParamsOutDiagTxEnum = enum.New(ParamsOutDiagTxNone, ParamsOutDiagTxCalled,
+		ParamsOutDiagTxMutated, ParamsOutDiagTxTouched, ParamsOutDiagTxRelations)
+)
+
+func (p *ParamsOutDiagTx) UnmarshalText(b []byte) error {
+	res := ParamsOutDiagTxEnum.Parse(string(b))
+	if res == nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	*p = *res
+	return nil
+}
+
+// -----
+
+// ParamsOutDiagGroup is an enum for --output-diagrams-group
+type ParamsOutDiagGroup enum.Member[string]
+
+// "", "hide", "skip"
+var (
+	ParamsOutDiagGroupNone = ParamsOutDiagGroup{""}
+	ParamsOutDiagGroupHide = ParamsOutDiagGroup{"hide"}
+	ParamsOutDiagGroupSkip = ParamsOutDiagGroup{"skip"}
+
+	ParamsOutDiagGroupEnum = enum.New(ParamsOutDiagGroupNone,
+		ParamsOutDiagGroupHide, ParamsOutDiagGroupSkip)
+)
+
+func (p *ParamsOutDiagGroup) UnmarshalText(b []byte) error {
+	res := ParamsOutDiagGroupEnum.Parse(string(b))
+	if res == nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	*p = *res
+	return nil
+}
+
+// -----
+
+// ParamsViewTimelines is an enum for --view-timelines
+type ParamsViewTimelines enum.Member[int]
+
+// 0, 1, 2
+var (
+	ParamsViewTimelinesNone = ParamsViewTimelines{0}
+	ParamsViewTimelinesOne  = ParamsViewTimelines{1}
+	ParamsViewTimelinesTwo  = ParamsViewTimelines{2}
+
+	ParamsViewTimelinesEnum = enum.New(
+		ParamsViewTimelinesNone,
+		ParamsViewTimelinesOne,
+		ParamsViewTimelinesTwo,
+	)
+)
+
+func (p *ParamsViewTimelines) UnmarshalText(b []byte) error {
+	value, err := strconv.Atoi(string(b))
+	if err != nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	res := ParamsViewTimelinesEnum.Parse(value)
+	if res == nil {
+		return fmt.Errorf("invalid value: %s", b)
+	}
+	*p = *res
+	return nil
 }
 
 // ///// ///// /////

--- a/tools/visualizer/d2.go
+++ b/tools/visualizer/d2.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/lithammer/dedent"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
@@ -116,6 +115,62 @@ var d2Header = utils.Sp(`
 				border-radius: 999
 			}
 		}
+
+		# require relation
+		req: {
+			style.stroke: white
+			target-arrowhead.style.filled: true
+			target-arrowhead.shape: circle
+		}
+		# add relation
+		add: {
+			style.stroke: yellow
+			target-arrowhead.shape: triangle
+			target-arrowhead.style.filled: true
+		}
+		# remove relation
+		rem: {
+			style.stroke: red
+			style.stroke-width: 2
+			target-arrowhead.style.filled: true
+			target-arrowhead.shape: diamond
+			source-arrowhead.style.filled: true
+			source-arrowhead.shape: diamond
+		}
+		# double remove relation
+		rem2: {
+			style.stroke: red
+			style.stroke-width: 4
+			target-arrowhead.style.filled: true
+			target-arrowhead.shape: diamond
+			source-arrowhead.style.filled: true
+			source-arrowhead.shape: diamond
+		}
+		# add pipe
+		pipe_add: {
+			style.stroke: yellow
+			style.stroke-dash: 3
+			target-arrowhead.style.filled: false
+		}
+		# remove pipe
+		pipe_rem: {
+			style.stroke: red
+			target-arrowhead.shape: diamond
+			style.stroke-dash: 3
+		}
+		# pipe (mach -> mach)
+		pipe: {
+			style.stroke: white
+		}
+
+		# parent hierarchy relation
+		parent: {
+			style.stroke: white
+			style.stroke-width: 8
+			target-arrowhead.shape: circle
+		}
+
+	${CLASSES}
 	}
 	direction: right
 
@@ -132,8 +187,22 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 		return fmt.Errorf("failed to get adjacency map: %w", err)
 	}
 
+	// state classes
+	classes := ""
+	for _, c := range r.graph.Clients {
+		if !r.shouldRenderMach(c.Id) {
+			continue
+		}
+		classes += "\tM_" + c.Id + ": {}\n"
+		for _, name := range c.MsgSchema.StatesIndex {
+			// TODO optimize: use short names, save index as *-index.txt
+			classes += "\tF_" + name + ": {}\n"
+			classes += "\tT_" + name + ": {}\n"
+		}
+	}
+
 	// header
-	r.buf.WriteString(dedent.Dedent(d2Header))
+	r.buf.WriteString(strings.ReplaceAll(d2Header, "${CLASSES}", classes))
 
 	// 1st pass - requested machs and neighbours
 	for src := range r.adjMap {
@@ -307,6 +376,7 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 	}
 	r.buf.WriteString(shortMachId + ": " + machId + " {\n" +
 		"\tlabel.near: top-center\n" +
+		"\tclass: [M_" + machId + "; mach]\n" +
 		"\tstyle.font-size: 40\n" +
 		border + tags)
 
@@ -398,6 +468,7 @@ func (r *Renderer) outputD2HalfMach(
 	}
 	r.buf.WriteString(shortMachId + ": " + machId + " {\n" +
 		"\tlabel.near: top-center\n" +
+		"\tclass: [M_" + machId + "; mach]\n" +
 		"\tstyle.font-size: 40\n")
 
 	parent := ""
@@ -450,18 +521,18 @@ func (r *Renderer) renderD2Relations(
 		return
 	}
 
+	classBase := fmt.Sprintf("[M_%s; F_%s; T_", c.Id, stateName)
+
 	// require
 	for _, relState := range state.Require {
 		if !r.shouldRenderState(machId, relState) {
 			continue
 		}
 
-		// TODO class
+		class := classBase + relState + "; " + "req]\n"
 		r.buf.WriteString("\t" + shortStateId + " --> " +
 			r.shortId(relState) + ": require {\n" +
-			"\t\tstyle.stroke: white\n" +
-			"\t\ttarget-arrowhead.style.filled: true\n" +
-			"\t\ttarget-arrowhead.shape: circle\n" +
+			"\t\tclass: " + class +
 			"\t}\n")
 	}
 
@@ -471,14 +542,14 @@ func (r *Renderer) renderD2Relations(
 			continue
 		}
 
-		// TODO class
+		class := classBase + relState + "; " + "add]\n"
 		r.buf.WriteString("\t" + shortStateId + " --> " +
 			r.shortId(relState) + ": add {\n" +
-			"\t\tstyle.stroke: yellow\n" +
-			"\t\ttarget-arrowhead.shape: triangle\n" +
-			"\t\ttarget-arrowhead.style.filled: true\n" +
+			"\t\tclass: " + class +
 			"\t}\n")
 	}
+
+	// TODO "after" relation
 
 	// remove
 	for _, relState := range state.Remove {
@@ -494,7 +565,7 @@ func (r *Renderer) renderD2Relations(
 		// merge double remove
 		edgeType := " --> "
 		label := "remove"
-		width := "2"
+		relClass := "rem"
 		if slices.Contains(c.MsgSchema.States[relState].Remove, stateName) {
 			_, ok1 := renderedRemoves[stateName+":"+relState]
 			_, ok2 := renderedRemoves[relState+":"+stateName]
@@ -503,21 +574,17 @@ func (r *Renderer) renderD2Relations(
 			}
 			edgeType = " <--> "
 			label = "double remove"
-			width = "4"
+			relClass = "rem2"
 
 			// mark
 			renderedRemoves[relState+":"+stateName] = struct{}{}
 			renderedRemoves[relState+":"+stateName] = struct{}{}
 		}
+		class := classBase + relState + "; " + relClass + "]\n"
 
-		// TODO class
 		r.buf.WriteString("\t" + shortStateId + edgeType +
-			r.shortId(relState) + ": " + label + " {\n\t\tstyle.stroke: red\n" +
-			"\t\tstyle.stroke-width: " + width + "\n" +
-			"\t\ttarget-arrowhead.style.filled: true\n" +
-			"\t\ttarget-arrowhead.shape: diamond\n" +
-			"\t\tsource-arrowhead.style.filled: true\n" +
-			"\t\tsource-arrowhead.shape: diamond\n" +
+			r.shortId(relState) + ": " + label + " {\n" +
+			"\t\tclass: " + class +
 			"\t}\n")
 	}
 }
@@ -554,12 +621,10 @@ func (r *Renderer) renderD2Parent(
 	r.adjsMachsToRender = append(r.adjsMachsToRender, target.MachId)
 
 	return shortMachId + " -> " + shortTargetMachId +
-		": parent {\n" +
-		"\tstyle.stroke: white\n" +
-		"\tstyle.stroke-width: 8\n" +
-		"\ttarget-arrowhead.shape: circle\n}\n"
+		": parent { class: parent }\n"
 }
 
+// RPC conns
 func (r *Renderer) renderD2Conns(
 	data *amgraph.EdgeData, machId string, target *amgraph.Vertex, renderHalfs,
 	isHalfMach bool,
@@ -660,19 +725,14 @@ func (r *Renderer) renderD2Pipes(
 				continue
 			}
 
-			// TODO class
-			style := "\tstyle.stroke: yellow\n" +
-				"\tstyle.stroke-dash: 3\n" +
-				"\ttarget-arrowhead.style.filled: false\n"
 			label := "add"
+			pipeClass := "pipe_add"
 			if mp.MutType == am.MutationRemove {
-				style = "\tstyle.stroke: red\n" +
-					"\ttarget-arrowhead.shape: diamond\n" +
-					"\tstyle.stroke-dash: 3\n"
 				label = "remove"
+				pipeClass = "pipe_rem"
 			}
 			ret += sourceId + " -> " + targetId + ":" + label + " {\n" +
-				style + "}\n"
+				"\tclass: " + pipeClass + "\n}\n"
 
 			// remember
 			r.renderedPipes[sourceId+":"+targetId] = struct{}{}
@@ -691,9 +751,7 @@ func (r *Renderer) renderD2Pipes(
 				continue
 			}
 
-			// TODO class, number of pipes
-			ret += shortMachId + " -> " + targetId + ": pipes { " +
-				"style.stroke: white }\n"
+			ret += shortMachId + " -> " + targetId + ": pipes { class: pipe }\n"
 
 			// remember
 			r.renderedPipes[shortMachId+":"+targetId] = struct{}{}

--- a/tools/visualizer/diagram.html
+++ b/tools/visualizer/diagram.html
@@ -1,36 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>am-vis machine diagram</title>
     <style>
         /* Make the body and container fullscreen */
-        html, body {
+        html,
+        body {
             height: 100%;
             width: 100%;
             margin: 0;
             padding: 0;
-            overflow: hidden; /* Prevent scrollbars */
+            overflow: hidden;
+            /* Prevent scrollbars */
             background: black;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
         }
+
         #svg-container {
             width: 100%;
             height: 100%;
             border: none;
-            background-color: #fff;
+            background-color: black;
             cursor: grab;
         }
+
         #svg-container:active {
             cursor: grabbing;
         }
+
         svg {
             width: 100%;
             height: 100%;
             display: block;
             background: black;
         }
+
         /* Status bar for user feedback */
         #status-bar {
             position: fixed;
@@ -43,14 +50,17 @@
             padding: 8px;
             font-size: 14px;
             z-index: 1000;
-            display: none; /* Hidden by default */
+            display: none;
+            /* Hidden by default */
         }
+
         #status-bar.error {
             background-color: #dc3545;
             color: white;
         }
     </style>
 </head>
+
 <body>
 
     <div id="status-bar">Connecting...</div>
@@ -63,7 +73,7 @@
             // --- Configuration ---
             const SVG_URL = 'http://localhost:6831/diagrams/mach.svg';
             const WEBSOCKET_URL = 'ws://localhost:6831/diagrams/mach.ws';
-            const STORAGE_KEY = 'svg-viewbox-state';
+            let currentMemKey = 'svg-viewbox-state';
 
             const svgContainer = document.getElementById('svg-container');
             const statusBar = document.getElementById('status-bar');
@@ -82,7 +92,7 @@
              * Saves the current viewBox state to localStorage.
              */
             function saveViewBoxState() {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(viewBox));
+                localStorage.setItem(currentMemKey, JSON.stringify(viewBox));
             }
 
             /**
@@ -90,7 +100,7 @@
              * @returns {object|null} The saved viewBox object or null if not found.
              */
             function loadViewBoxState() {
-                const savedState = localStorage.getItem(STORAGE_KEY);
+                const savedState = localStorage.getItem(currentMemKey);
                 try {
                     if (savedState) {
                         return JSON.parse(savedState);
@@ -106,7 +116,7 @@
              * Fetches and displays the SVG from the URL.
              * @param {boolean} restoreState - If true, tries to load the view from localStorage.
              */
-            async function loadSVG(restoreState = false) {
+            async function loadSVG(restoreState = false, filename = "") {
                 console.log('Fetching SVG from:', SVG_URL);
                 try {
                     // Add a cache-busting parameter to ensure the latest version is always requested
@@ -177,11 +187,15 @@
                 };
 
                 socket.onmessage = (event) => {
-                    if (event.data === 'refresh') {
+                    msg = JSON.parse(event.data);
+                    if (msg.Type === 'refresh') {
                         console.log('Received "refresh" event, reloading SVG and restoring view.');
+                        currentMemKey = "svg-viewbox-state-" + msg.Addr.MachId + "-" + msg.Group;
                         loadSVG(true); // Pass true to restore state
+                    } else if (msg.Type == "loading") {
+                      svgContainer.innerHTML = `<p style="color: white; padding: 1rem;">Rendering...</p>`;
                     } else {
-                        console.log('Received message:', event.data);
+                        console.log('Received message:', msg);
                     }
                 };
 
@@ -191,6 +205,7 @@
                     const delay = Math.min(maxReconnectDelay, 1000 * Math.pow(2, reconnectAttempts));
                     reconnectAttempts++;
                     updateStatus(`Connection lost. Reconnecting in ${Math.round(delay / 1000)}s...`, true);
+                    svgContainer.innerHTML = ""
                     setTimeout(connectWebSocket, delay);
                 };
 
@@ -257,10 +272,11 @@
 
             // --- Initial Load ---
             // On initial load, don't restore state. This will use the SVG's default view.
-            loadSVG();
+            loadSVG(false, "");
             connectWebSocket();
         });
     </script>
 
 </body>
+
 </html>

--- a/tools/visualizer/visualizer.go
+++ b/tools/visualizer/visualizer.go
@@ -465,8 +465,8 @@ func (r *Renderer) outputMermaidMach(
 		return nil
 	}
 
-	// whitelist
-	if !r.isMachWhitelisted(machId) && !r.isMachCloseEnough(machId) {
+	// allowlist
+	if !r.isMachAllowed(machId) && !r.isMachCloseEnough(machId) {
 		return nil
 	}
 
@@ -649,7 +649,7 @@ func (r *Renderer) fullIdPath(machId string, shorten bool) []string {
 }
 
 func (r *Renderer) shouldRenderMach(machId string) bool {
-	if r.isMachWhitelisted(machId) {
+	if r.isMachAllowed(machId) {
 		return true
 	}
 
@@ -772,8 +772,8 @@ func (r *Renderer) isMachShallowEnough(machId string) bool {
 	return depth <= r.RenderDepth
 }
 
-// isMachWhitelisted checks if mach ID is in the whitelist.
-func (r *Renderer) isMachWhitelisted(id string) bool {
+// isMachAllowed checks if mach ID is in the allowlist.
+func (r *Renderer) isMachAllowed(id string) bool {
 	if slices.Contains(r.renderMachIds(), id) {
 		return true
 	}
@@ -861,69 +861,212 @@ func genId(lastId string) string {
 	}
 }
 
-type Fragment struct {
+// Filters filter a rendered graph for the desired output.
+type Filters struct {
+	// Machine to filter TODO inline as map[string] to other fields
 	MachId string
-	States am.S
+	// list of states to process
+	Index am.S
+	// currently active states (inactive = states - active)
 	Active am.S
+	// currently highlighted states (dimmed = states - highlighted)
+	Highlighted am.S
+	// currently visible states (hidden = states - visible)
+	Visible am.S
+	// currently selected states
+	Selected am.S
+	// {StateFrom, StateTo, [am.Relation.String()]}
+	HighlightedRels [][3]string
+}
+
+func (f *Filters) Empty() bool {
+	return f.Active == nil && f.Highlighted == nil &&
+		f.Visible == nil && f.Selected == nil && f.HighlightedRels == nil
 }
 
 // UpdateCache updates [dom] according to [fragments], and saves to [filepath].
+// Only single-machine diagrams are supported.
 func UpdateCache(
-	ctx context.Context, filepath string, dom *goquery.Document,
-	fragments ...*Fragment,
+	ctx context.Context, filepath string, dom *goquery.Document, filters *Filters,
 ) error {
-	for _, sel := range fragments {
-		for _, state := range sel.States {
-			if ctx.Err() != nil {
-				return nil
+	// TODO extract colors and join with D2 classes
+
+	for _, state := range filters.Index {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		isActive := slices.Contains(filters.Active, state)
+		isStart := state == ssam.BasicStates.Start
+		isReady := state == ssam.BasicStates.Ready
+		isErr := state == am.StateException ||
+			strings.HasPrefix(state, am.PrefixErr)
+		isSelected := slices.Contains(filters.Selected, state)
+
+		fillTxt := "#CDD6F4"
+		classTxt := "text-bold fill-N1"
+
+		strokeInner := "white"
+		fillInner := "#45475A"
+		classInner := "fill-B5"
+
+		if isActive {
+			fillTxt = "black"
+			classTxt = "text-bold"
+
+			strokeInner = "#5F5C5C"
+			fillInner = "yellow"
+			classInner = "stroke-B1"
+
+			if isReady {
+				fillInner = "deepskyblue"
+			} else if isStart {
+				fillInner = "#329241"
+			} else if isErr {
+				fillInner = "red"
 			}
+		}
 
-			isActive := slices.Contains(sel.Active, state)
-			isStart := state == ssam.BasicStates.Start
-			isReady := state == ssam.BasicStates.Ready
-			isErr := state == am.StateException ||
-				strings.HasPrefix(state, am.PrefixErr)
+		cssTxt := "text-anchor: middle; font-size: 16px;"
+		cssInner := ""
+		if isSelected {
+			cssTxt += "fill: black;"
+			cssInner += "fill: limegreen;"
+		}
 
-			fillOuter := "#CDD6F4"
-			classOuter := "text-bold fill-N1"
+		// update
 
-			strokeInner := "white"
-			fillInner := "#45475A"
-			classInner := "fill-B5"
+		// query
+		txt := dom.Find("g > text:contains(" + state + ")").
+			// exact text match
+			FilterFunction(func(i int, s *goquery.Selection) bool {
+				return s.Text() == state
+			})
+		inner := txt.Prev()
+		root := txt.Parent()
 
-			if isActive {
-				fillOuter = "black"
-				classOuter = "text-bold"
+		// colors
+		txt.SetAttr("fill", fillTxt).
+			SetAttr("class", classTxt).
+			SetAttr("style", cssTxt)
+		inner.Children().
+			SetAttr("stroke", strokeInner).
+			SetAttr("class", classInner).
+			SetAttr("style", cssInner).
+			First().
+			SetAttr("fill", fillInner)
 
-				strokeInner = "#5F5C5C"
-				fillInner = "yellow"
-				classInner = "stroke-B1"
+		// CSS TODO use attrs
+		css := ""
+		if filters.Highlighted != nil &&
+			!slices.Contains(filters.Highlighted, state) {
+			css += "opacity: 0.4;"
+		}
+		if filters.Visible != nil && !slices.Contains(filters.Visible, state) {
+			css += "display: none;"
+		}
 
-				if isReady {
-					fillInner = "deepskyblue"
-				} else if isStart {
-					fillInner = "#329241"
-				} else if isErr {
-					fillInner = "red"
+		root.SetAttr("style", css)
+
+		// TODO apply fragments to relation lines
+		//  g > path.connection - attr "d" - start/end
+	}
+
+	// relations
+	qAllRels := "g.add, g.rem, g.rem2, g.req"
+
+	// highlight rels for highlited states
+	if filters.HighlightedRels != nil {
+		// dim all
+		dom.Find(qAllRels).SetAttr("opacity", "0.2")
+
+		// undim highlighted
+		for _, rel := range filters.HighlightedRels {
+			from := rel[0]
+			to := rel[1]
+			q := fmt.Sprintf("g.M_%s.F_%s.T_%s.", filters.MachId, from, to)
+			switch rel[2] {
+			case am.RelationAdd.String():
+				dom.Find(q + "add").RemoveAttr("opacity")
+			case am.RelationRemove.String():
+				dom.Find(q + "rem, " + q + "rem2").RemoveAttr("opacity")
+			case am.RelationRequire.String():
+				dom.Find(q + "req").RemoveAttr("opacity")
+			}
+		}
+	} else if filters.Highlighted != nil {
+		// dim all
+		dom.Find(qAllRels).SetAttr("opacity", "0.2")
+
+		// undim highlighted
+		for _, state := range filters.Highlighted {
+			q := fmt.Sprintf("g.M_%s.F_%s, g.M_%s.T_%s",
+				filters.MachId, state, filters.MachId, state)
+			dom.Find(q).Each(func(i int, selection *goquery.Selection) {
+				for _, state2 := range filters.Highlighted {
+					if state == state2 {
+						continue
+					}
+
+					if selection.HasClass("F_"+state2) ||
+						selection.HasClass("T_"+state2) {
+
+						selection.RemoveAttr("opacity")
+						break
+					}
 				}
-			}
+			})
+		}
+	} else {
+		// reset
+		dom.Find(qAllRels).RemoveAttr("opacity")
+	}
 
-			// update
+	// hide rels for non-visible states
+	if filters.Visible != nil {
+		// hide all
+		dom.Find(qAllRels).SetAttr("visibility", "hidden")
 
-			root := dom.Find("g > text:contains(" + state + ")").
-				// exact text match
-				FilterFunction(func(i int, s *goquery.Selection) bool {
-					return s.Text() == state
-				})
+		// show visible
+		for _, state := range filters.Visible {
+			q := fmt.Sprintf("g.M_%s.F_%s, g.M_%s.T_%s",
+				filters.MachId, state, filters.MachId, state)
+			dom.Find(q).Each(func(i int, selection *goquery.Selection) {
+				for _, state2 := range filters.Visible {
+					if state == state2 {
+						continue
+					}
 
-			root.
-				// outer
-				SetAttr("fill", fillOuter).
-				SetAttr("class", classOuter).
-				// inner
-				Prev().Children().SetAttr("stroke", strokeInner).
-				SetAttr("class", classInner).
-				First().SetAttr("fill", fillInner)
+					if selection.HasClass("F_"+state2) ||
+						selection.HasClass("T_"+state2) {
+
+						selection.RemoveAttr("visibility")
+						break
+					}
+				}
+			})
+		}
+	} else {
+		// reset
+		dom.Find(qAllRels).RemoveAttr("visibility")
+	}
+
+	// mark rels for selected states
+	// reset
+	dom.Find("g.rem2 > path").SetAttr("stroke", "red").
+		SetAttr("style", "stroke-width: 4")
+	dom.Find("g.rem > path").SetAttr("stroke", "red").
+		SetAttr("style", "stroke-width: 2")
+	dom.Find("g.req > path").SetAttr("stroke", "white").
+		SetAttr("style", "stroke-width: 2")
+	dom.Find("g.add > path").SetAttr("stroke", "yellow").
+		SetAttr("style", "stroke-width: 2")
+	if filters.Selected != nil {
+		for _, state := range filters.Selected {
+			q := fmt.Sprintf("g.M_%s.F_%s > path, g.M_%s.T_%s > path",
+				filters.MachId, state, filters.MachId, state)
+			dom.Find(q).SetAttr("stroke", "limegreen").
+				SetAttr("style", "stroke-width: 5")
 		}
 	}
 

--- a/tools/visualizer/visualizer_test.go
+++ b/tools/visualizer/visualizer_test.go
@@ -1,7 +1,7 @@
 package visualizer
 
 // func TestUpdates(t *testing.T) {
-// 	sel := &Fragment{
+// 	sel := &Filters{
 // 		MachId: "cook",
 // 		States: am.S{"Exception", "StoryCookingStarted", "StoryJoke", "Ready",
 // 			"Requesting", "StoryStartAgain", "Start", "BaseDBStarting",


### PR DESCRIPTION
The new diagram filter options are `--output-diag-tx` and `--output-diag-group` (also on the toolbar). The former one highlights the diagram based on the current transition, while the latter one skips or completely re-renders the graph for states from the selected group. State selection will also highlight the diagram (distinctively). The diagram viewer now also has better UX.

<img width="1391" height="1063" alt="ss-2026-04-23-17-15-14" src="https://github.com/user-attachments/assets/b7e81b55-0933-480f-a36a-663584b9926e" />
