### PR TITLE
feat(am-dbg): add MCP server and REPL

### DIFF
--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -208,12 +208,25 @@ func New(ctx context.Context, p types.Params) (*Debugger, error) {
 	// mach.AddBreakpoint1(ss.UpdateFocus, "", false)
 	// mach.AddBreakpoint1(ss.UpdateFocus, "", true)
 	mach.SetGroups(states.DebuggerGroups, ss)
-	// start a dedicated aRPC server for the REPL, create an addr file
-	_, _ = arpc.MachReplEnv(mach, &arpc.ReplOpts{
-		AddrDir:  p.OutputDir,
-		Args:     types.ARpc{},
-		ParseRpc: types.ParseRpc,
-	})
+
+	// self debug
+	if p.DebugAddr != "" {
+		_ = amhelp.MachDebug(mach, p.DebugAddr, p.LogLevel, false,
+			amhelp.SemConfigEnv(true))
+	}
+	if p.Repl {
+		// start a dedicated aRPC server for the REPL, create an addr file
+		err = arpc.MachRepl(mach, "", &arpc.ReplOpts{
+			AddrDir:  p.OutputDir,
+			Args:     types.ARpc{},
+			ParseRpc: types.ParseRpc,
+		})
+		mach.AddErr(err, nil)
+	}
+	// mach.AddBreakpoint1(ss.AddressFocused, "", false)
+	// mach.AddBreakpoint1(ss.AddressFocused, "", true)
+	// mach.AddBreakpoint1(ss.UpdateFocus, "", false)
+	// mach.AddBreakpoint1(ss.UpdateFocus, "", true)
 
 	err = d.setParams(p)
 	if err != nil {

--- a/tools/debugger/misc_dbg.go
+++ b/tools/debugger/misc_dbg.go
@@ -232,3 +232,254 @@ func isWSL() bool {
 	}
 	return strings.Contains(strings.ToLower(string(releaseData)), "microsoft")
 }
+
+// ///// ///// /////
+
+// ///// MCP SERVER
+
+// ///// ///// /////
+
+type mcpServer struct {
+	*ammcp.Server
+	d *Debugger
+}
+
+func newMcpServer(d *Debugger) (*mcpServer, error) {
+	srv, err := ammcp.New(d.Mach, ammcp.Opts{
+		Name: "am-dbg",
+		Desc: "MCP to control the asyncmachine-go TUI debugger. " +
+			"The double-line border panel is currently focused. " +
+			"Most features are accessible via ToggleTool.",
+		MutCallback: func(ctx context.Context) error {
+			ok := d.Mach.Eval("MCPTool", func() {
+				d.hRedrawFull(false)
+			}, ctx)
+			if !ok {
+				return am.ErrEvalTimeout
+			}
+			return nil
+		},
+		StatesInclude:  states.DebuggerGroups.Mcp,
+		StatesReadonly: states.DebuggerGroups.McpReadonly,
+		Args:           types.ARpc{},
+		ParseRpc:       types.ParseRpc,
+		StateCalls:     types.StateCalls,
+		Version:        d.params.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// bind keys from keyboard.go
+	keys := slices.Collect(maps.Keys(d.getKeystrokes()))
+	keys = append(keys, "enter", "tab", "shift+tab", "up", "down")
+	pressKey := mcp.NewTool("PressKey",
+		mcp.WithDescription("Press a key combination"),
+		mcp.WithString("key",
+			mcp.Required(),
+			mcp.Description("Name of the state to add"),
+			mcp.Enum(keys...),
+		),
+	)
+
+	// TODO mouse clicks
+
+	// TUI
+
+	textScreen := mcp.NewTool("TextScreen",
+		mcp.WithDescription("Get text content of the TUI screen"),
+	)
+	textReader := mcp.NewTool("TextLogReader",
+		mcp.WithDescription("Get text content of the Log Reader pane"),
+	)
+	textHelp := mcp.NewTool("TextHelp",
+		mcp.WithDescription("Get text content of the Help dialog"),
+	)
+	textLog := mcp.NewTool("TextLog",
+		mcp.WithDescription("Get text content of the current log buffer"),
+	)
+	textClients := mcp.NewTool("TextClients",
+		mcp.WithDescription("Get a full clients list"),
+	)
+	netGraph := mcp.NewTool("NetworkGraph",
+		mcp.WithDescription("Get an XML of the network graph"),
+	)
+	txSteps := mcp.NewTool("Transition Steps",
+		mcp.WithDescription(
+			"Get a markdown sequence diagram of the transition steps"),
+	)
+
+	// methods
+
+	goToMachAddr := mcp.NewTool("GoToMachAddr",
+		mcp.WithDescription("Show a specific machine, transition, or mach time"),
+		mcp.WithString("url",
+			mcp.Required(),
+			mcp.Description("Address to go to"),
+		))
+
+	// server
+	srvDbg := &mcpServer{
+		Server: srv,
+		d:      d,
+	}
+
+	// bind handlers
+	srv.Mcp.AddTool(textScreen, srvDbg.textScreen)
+	srv.Mcp.AddTool(textReader, srvDbg.textReader)
+	srv.Mcp.AddTool(textHelp, srvDbg.textHelp)
+	srv.Mcp.AddTool(textLog, srvDbg.textLog)
+	srv.Mcp.AddTool(textClients, srvDbg.textClients)
+	srv.Mcp.AddTool(netGraph, srvDbg.netGraph)
+	srv.Mcp.AddTool(txSteps, srvDbg.txSteps)
+	srv.Mcp.AddTool(goToMachAddr, srvDbg.goToMachAddr)
+	srv.Mcp.AddTool(pressKey, srvDbg.pressKey)
+
+	return srvDbg, nil
+}
+
+func (m *mcpServer) goToMachAddr(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	url, err := req.RequireString("url")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	machUrl, err := types.ParseMachUrl(url)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	m.d.GoToMachAddress(machUrl, false)
+
+	return mcp.NewToolResultText("ok"), nil
+}
+
+func (m *mcpServer) textReader(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	// check if reader visible
+	if m.d.Mach.Not1(ss.LogReaderVisible) {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"state %s not active", ss.LogReaderVisible)), nil
+	}
+
+	return mcp.NewToolResultText(m.d.LogReaderText()), nil
+}
+
+func (m *mcpServer) textScreen(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText(m.d.App.ScreenText()), nil
+}
+
+func (m *mcpServer) textHelp(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText(textViewToText(m.d.helpDialogLeft) + "\n\n" +
+		textViewToText(m.d.helpDialogRight)), nil
+}
+
+func (m *mcpServer) textLog(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	p := m.d.Params()
+	if !p.OutputLog {
+		return mcp.NewToolResultError("--output-log not set"), nil
+	}
+
+	log, err := os.ReadFile(path.Join(p.OutputDir, logFile))
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(string(log)), nil
+}
+
+func (m *mcpServer) textClients(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	p := m.d.Params()
+	if !p.OutputLog {
+		return mcp.NewToolResultError("--output-clients not set"), nil
+	}
+
+	log, err := os.ReadFile(path.Join(p.OutputDir, "clients.txt"))
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(string(log)), nil
+}
+
+func (m *mcpServer) netGraph(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	p := m.d.Params()
+	if !p.OutputLog {
+		return mcp.NewToolResultError("--output-clients not set"), nil
+	}
+
+	log, err := os.ReadFile(path.Join(p.OutputDir, "graph.xml"))
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(string(log)), nil
+}
+
+func (m *mcpServer) txSteps(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	p := m.d.Params()
+	if !p.OutputLog {
+		return mcp.NewToolResultError("--output-tx not set"), nil
+	}
+
+	log, err := os.ReadFile(path.Join(p.OutputDir, "tx.md"))
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(string(log)), nil
+}
+
+func (m *mcpServer) pressKey(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	key, err := req.RequireString("key")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// split "key" param on + and parse the modifier
+	parts := strings.Split(key, "+")
+	var mod tcell.ModMask = tcell.ModNone
+	keyName := parts[len(parts)-1]
+	for _, part := range parts[:len(parts)-1] {
+		switch strings.ToLower(part) {
+		case "alt":
+			mod |= tcell.ModAlt
+		case "ctrl":
+			mod |= tcell.ModCtrl
+		case "shift":
+			mod |= tcell.ModShift
+		}
+	}
+
+	// create evKey and rune
+	var evKey tcell.Key
+	var rune rune
+	stringToKey := make(map[string]tcell.Key)
+	for key, name := range tcell.KeyNames {
+		stringToKey[strings.ToLower(name)] = key
+	}
+	lowerStr := strings.ToLower(keyName)
+	if key, exists := stringToKey[lowerStr]; exists {
+		evKey = key
+	} else {
+		rune, _ = utf8.DecodeRuneInString(strings.ToLower(keyName))
+		if rune == utf8.RuneError {
+			return mcp.NewToolResultError("key rune err"), nil
+		}
+		evKey = tcell.KeyRune
+	}
+
+	m.d.App.QueueEvent(tcell.NewEventKey(evKey, rune, mod))
+	return mcp.NewToolResultText("ok"), nil
+}

--- a/tools/debugger/types/dbg_types.go
+++ b/tools/debugger/types/dbg_types.go
@@ -81,6 +81,7 @@ type Params struct {
 
 	// ui
 
+	UiMcp bool `arg:"--ui-mcp" help:"Enable MCP server on port --listen-addr +1 (requires --ui-web) (EXPERIMENTAL)" default:"true"`
 	UiSsh bool `arg:"--ui-ssh" help:"Enable SSH headless mode on port --listen-addr +2 (EXPERIMENTAL)"`
 	UiWeb bool `arg:"--ui-web" default:"true" help:"Start a web server for --dir and diagrams on --listen-addr +1 (EXPERIMENTAL)"`
 
@@ -111,6 +112,7 @@ type Params struct {
 	LogLevel am.LogLevel `arg:"--dbg-log-level" default:"0" help:"Log level produced by this instance, 0-5 (silent-everything)"`
 	DbgOtel  bool        `arg:"--dbg-otel" help:"Enable OpenTelemetry tracing for this instance"`
 	ProfSrv  string      `arg:"--dbg-prof-srv" help:"Start pprof server"`
+	Repl     bool        `arg:"--dbg-repl" help:"Start a REPL server in --dir"`
 
 	// internal params
 

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -1161,3 +1161,40 @@ func (d *Debugger) hBoxFromPrimitive(p any) (*cview.Box, string) {
 
 	return box, state
 }
+
+var (
+	trimTailWhitespaceRe = regexp.MustCompile(` +\n`)
+	foldNewlinesRe       = regexp.MustCompile(`\n{3,}`)
+)
+
+// treeToText will get a full render of a tree as text
+func treeToText(tree *cview.TreeView) string {
+	simscreen := tcell.NewSimulationScreen("UTF-8")
+	simscreen.SetSize(1000, 1000)
+	box := cview.NewBox()
+	box.SetRect(0, 0, 1000, 1000)
+	oldBox := tree.Box
+	tree.Box = box
+	tree.Draw(simscreen)
+	text := foldNewlinesRe.ReplaceAllString(
+		trimTailWhitespaceRe.ReplaceAllString(
+			cview.TextFromScreen(simscreen), "\n"), "\n")
+	tree.Box = oldBox
+	return text
+}
+
+// treeToText will get a full render of a tree as text
+func textViewToText(textView *cview.TextView) string {
+	simscreen := tcell.NewSimulationScreen("UTF-8")
+	simscreen.SetSize(1000, 1000)
+	box := cview.NewBox()
+	box.SetRect(0, 0, 1000, 1000)
+	oldBox := textView.Box
+	textView.Box = box
+	textView.Draw(simscreen)
+	text := foldNewlinesRe.ReplaceAllString(
+		trimTailWhitespaceRe.ReplaceAllString(
+			cview.TextFromScreen(simscreen), "\n"), "\n")
+	textView.Box = oldBox
+	return text
+}


### PR DESCRIPTION
These changes allow for automating repetitive tasks within the debugger.
The MCP server, unlike the REPL, returns data and has predefined mutations via `/pkg/machine.CallSignature`.

Accessible via `--ui-mcp` and `--dbg-repl`.

<img width="924" height="794" alt="ss-2026-05-10-19-26-39" src="https://github.com/user-attachments/assets/2c7cd228-b18a-4b9e-8462-43be03768863" />
