### PR TITLE
feat(am-dbg): add full transition history navigation

### DIFF
--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -582,7 +582,16 @@ func (d *Debugger) hRemoveHistory(clientId string) {
 }
 
 func (d *Debugger) hPrependHistory(addr *types.MachAddress) {
+	// add hist if URL changes (excl GET params)
+	if len(d.History) > 0 && d.History[0].StringBase() == addr.StringBase() {
+		return
+	}
 	d.History = slices.Concat([]*types.MachAddress{addr}, d.History)
+	// dbg := make([]string, len(d.History))
+	// for i := range d.History {
+	// 	dbg[i] = d.History[i].String()
+	// }
+	// dump.Println(dbg)
 	d.hTrimHistory()
 }
 
@@ -963,7 +972,7 @@ func (d *Debugger) hUpdateAddressBar() {
 	}
 
 	// copy
-	copyCell := d.addressBar.GetCell(0, 6)
+	copyCell := d.addressBar.GetCell(0, colCopy)
 	copyCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
 	copyCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
 	if machId == "" {
@@ -972,14 +981,18 @@ func (d *Debugger) hUpdateAddressBar() {
 	} else {
 		copyCell.SetSelectable(true)
 	}
-	pasteCell := d.addressBar.GetCell(0, 8)
+	pasteCell := d.addressBar.GetCell(0, colPaste)
 	pasteCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
 	pasteCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
 
-	// history
-	fwdCell := d.addressBar.GetCell(0, 2)
+	// history fwd
+	fwdCell := d.addressBar.GetCell(0, colNext)
 	fwdCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
 	fwdCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
+	fwdMachCell := d.addressBar.GetCell(0, colNextMach)
+	fwdMachCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
+	fwdMachCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
+	fwdMachCell.SetSelectable(true)
 	if d.HistoryCursor > 0 {
 		fwdCell.SetSelectable(true)
 	} else {
@@ -987,15 +1000,49 @@ func (d *Debugger) hUpdateAddressBar() {
 		fwdCell.SetTextColor(tcell.GetColor(theme.Grey))
 		fwdCell.SetBackgroundColor(tcell.ColorDefault)
 	}
-	backCell := d.addressBar.GetCell(0, 0)
+
+	// scan until machId changes
+	nextMach := false
+	for i := d.HistoryCursor; i > 0; i-- {
+		if d.History[i].MachId != d.History[i-1].MachId {
+			nextMach = true
+			break
+		}
+	}
+	if !nextMach {
+		fwdMachCell.SetSelectable(false)
+		fwdMachCell.SetTextColor(tcell.GetColor(theme.Grey))
+		fwdMachCell.SetBackgroundColor(tcell.ColorDefault)
+	}
+
+	// history back
+	backCell := d.addressBar.GetCell(0, colPrev)
 	backCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
 	backCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
+	backMachCell := d.addressBar.GetCell(0, colPrevMach)
+	backMachCell.SetBackgroundColor(tcell.GetColor(theme.LightGrey))
+	backMachCell.SetTextColor(tcell.GetColor(theme.BgPrimary))
+	backMachCell.SetSelectable(true)
 	if d.HistoryCursor < len(d.History)-1 {
 		backCell.SetSelectable(true)
 	} else {
 		backCell.SetSelectable(false)
 		backCell.SetTextColor(tcell.GetColor(theme.Grey))
 		backCell.SetBackgroundColor(tcell.ColorDefault)
+	}
+
+	prevMach := false
+	// scan until machId changes
+	for i := d.HistoryCursor; i < len(d.History)-1; i++ {
+		if d.History[i].MachId != d.History[i+1].MachId {
+			prevMach = true
+			break
+		}
+	}
+	if !prevMach {
+		backMachCell.SetSelectable(false)
+		backMachCell.SetTextColor(tcell.GetColor(theme.Grey))
+		backMachCell.SetBackgroundColor(tcell.ColorDefault)
 	}
 
 	// detect clipboard
@@ -1013,7 +1060,7 @@ func (d *Debugger) hUpdateAddressBar() {
 	if machConn {
 		machColor = "[" + theme.Active + "]"
 	}
-	addrCell := d.addressBar.GetCell(0, 4)
+	addrCell := d.addressBar.GetCell(0, colAddr)
 	if machId != "" && txId != "" {
 		s := ""
 		if stepId != "" {

--- a/tools/debugger/ui.go
+++ b/tools/debugger/ui.go
@@ -258,60 +258,102 @@ func (d *Debugger) hInitTimelineTx() {
 	})
 }
 
-func (d *Debugger) hInitAddressBar() {
-	// TODO enum for col indexes
+// TODO enum for col indexes
+var (
+	colPrevMach = 0
+	colPrev     = 2
+	colNext     = 4
+	colNextMach = 6
+	colAddr     = 8
+	colCopy     = 10
+	colPaste    = 12
+)
 
+func (d *Debugger) hInitAddressBar() {
 	d.addressBar = cview.NewTable()
 	d.addressBar.SetSelectedStyle(tcell.GetColor(theme.Active),
 		cview.Styles.PrimitiveBackgroundColor, tcell.AttrBold)
-	d.addressBar.SetCellSimple(0, 0, "◀ prev mach")
-	d.addressBar.SetCellSimple(0, 1, "")
-	d.addressBar.SetCellSimple(0, 2, " next mach▶ ")
-	d.addressBar.SetCellSimple(0, 3, "")
-	// addr
-	d.addressBar.SetCellSimple(0, 4, "")
-	d.addressBar.SetCellSimple(0, 5, "")
-	d.addressBar.SetCellSimple(0, 6, " copy")
+	d.addressBar.SetCellSimple(0, colPrevMach, "◀ mach")
+	d.addressBar.SetCellSimple(0, 1, " ")
+	d.addressBar.SetCellSimple(0, colPrev, "◀")
+	d.addressBar.SetCellSimple(0, 3, " ")
+	d.addressBar.SetCellSimple(0, colNext, "▶")
+	d.addressBar.SetCellSimple(0, 5, " ")
+	d.addressBar.SetCellSimple(0, colNextMach, " mach▶")
 	d.addressBar.SetCellSimple(0, 7, "")
-	d.addressBar.SetCellSimple(0, 8, " paste")
+	d.addressBar.SetCellSimple(0, colAddr, "") // addr
+	d.addressBar.SetCellSimple(0, 9, " ")
+	d.addressBar.SetCellSimple(0, colCopy, " copy")
+	d.addressBar.SetCellSimple(0, 11, " ")
+	d.addressBar.SetCellSimple(0, colPaste, " paste")
 	d.addressBar.SetSelectable(true, true)
 	d.addressBar.GetCell(0, 1).SetSelectable(false)
 	d.addressBar.GetCell(0, 3).SetSelectable(false)
 	d.addressBar.GetCell(0, 5).SetSelectable(false)
 	d.addressBar.GetCell(0, 7).SetSelectable(false)
+	d.addressBar.GetCell(0, 9).SetSelectable(false)
+	d.addressBar.GetCell(0, 11).SetSelectable(false)
 	d.addressBar.SetSelectedFunc(func(row, column int) {
 		switch column {
-		case 0: // prev mach
+		case colPrevMach:
+			if d.HistoryCursor >= len(d.History)-1 {
+				return
+			}
+			// scan until machId changes
+			for i := d.HistoryCursor; i < len(d.History)-1; i++ {
+				if d.History[i].MachId != d.History[i+1].MachId {
+					d.HistoryCursor = i + 1
+					break
+				}
+			}
+			addr := d.History[d.HistoryCursor]
+			// d.params.Print("go:\n" + addr.String() + "\n")
+			d.GoToMachAddress(addr, true)
+		case colPrev:
 			if d.HistoryCursor >= len(d.History)-1 {
 				return
 			}
 			d.HistoryCursor++
-			d.GoToMachAddress(d.History[d.HistoryCursor], true)
+			addr := d.History[d.HistoryCursor]
+			// d.params.Print("go:\n" + addr.String() + "\n")
+			d.GoToMachAddress(addr, true)
 
-		case 2: // next mach
+		case colNext:
 			if d.HistoryCursor <= 0 {
 				return
 			}
 			d.HistoryCursor--
-			d.GoToMachAddress(d.History[d.HistoryCursor], true)
+			addr := d.History[d.HistoryCursor]
+			// d.params.Print("go:\n" + addr.String() + "\n")
+			d.GoToMachAddress(addr, true)
+		case colNextMach:
+			if d.HistoryCursor <= 0 {
+				return
+			}
+			// scan until machId changes
+			for i := d.HistoryCursor; i > 0; i-- {
+				if d.History[i].MachId != d.History[i-1].MachId {
+					d.HistoryCursor = i - 1
+					break
+				}
+			}
+			addr := d.History[d.HistoryCursor]
+			// d.params.Print("go:\n" + addr.String() + "\n")
+			d.GoToMachAddress(addr, true)
 
-		case 6: // copy
+		case colCopy:
 			if d.clip == nil {
 				return
 			}
 			addr := d.hGetMachAddress().String()
 			_ = d.clip.WriteAll(clipper.RegClipboard, []byte(addr))
 
-		case 8: // paste
+		case colPaste:
 			if d.clip == nil {
 				return
 			}
 			txt, _ := d.clip.ReadAll(clipper.RegClipboard)
-			if u, err := url.Parse(string(txt)); err == nil && u.Scheme == "mach" {
-				addr := &types.MachAddress{MachId: u.Host}
-				if u.Path != "" {
-					addr.TxId = strings.TrimLeft(u.Path, "/")
-				}
+			if addr, err := types.ParseMachUrl(string(txt)); err == nil {
 				d.GoToMachAddress(addr, false)
 			}
 		}
@@ -327,7 +369,7 @@ func (d *Debugger) hInitAddressBar() {
 		}()
 	})
 
-	addr := d.addressBar.GetCell(0, 4)
+	addr := d.addressBar.GetCell(0, colAddr)
 	addr.SetExpansion(1)
 	addr.SetSelectable(false)
 	addr.SetAlign(cview.AlignCenter)


### PR DESCRIPTION
New buttons, full history traversal and by-machine jumps.

<img width="512" height="211" alt="ss-2026-05-10-19-17-56" src="https://github.com/user-attachments/assets/576407db-e8af-4324-a8a7-24dca02fa5df" />
