### PR TITLE
feat(am-dbg): standardize machine URLs, add selection and query strings

### DIFF
--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -435,15 +435,22 @@ func (d *Debugger) hGetMachAddress() *types.MachAddress {
 		return nil
 	}
 	a := &types.MachAddress{
-		MachId:   c.Id,
-		MachTime: c.MTimeSum,
+		MachId: c.Id,
 	}
+	// TODO getter
 	if c.CursorTx1 > 0 {
-		a.TxId = c.MsgTxs[c.CursorTx1-1].ID
+		tx := c.MsgTxs[c.CursorTx1-1]
+		a.TxId = tx.ID
+		a.MachTime = tx.TimeSum()
+		// TODO queue tick
 	}
 	if c.CursorStep1 > 0 {
 		a.Step = c.CursorStep1
 	}
+
+	// GET params
+	a.State = c.SelectedState
+	a.Group = c.SelectedGroup
 
 	return a
 }
@@ -468,6 +475,7 @@ func (d *Debugger) GoToMachAddress(
 	if d.C == nil || d.C.Id != addr.MachId {
 		// TODO extract as amhelp.WhenNextActive
 		if mach.Is1(ss.ClientSelected) {
+			// TODO next active in ()
 			wait = mach.WhenTicks(ss.ClientSelected, 2, ctx)
 		} else {
 			wait = mach.When1(ss.ClientSelected, ctx)
@@ -482,32 +490,73 @@ func (d *Debugger) GoToMachAddress(
 		wait = mach.When1(ss.ClientSelected, ctx)
 	}
 
+	// TODO timeout
 	<-wait
 	if addr.TxId != "" {
-		scrollArgs := &A{TxId: addr.TxId}
-		if addr.Step != 0 {
-			scrollArgs.CursorStep1 = addr.Step
-			mach.Add1(ss.ScrollToStep, Pass(scrollArgs))
+		scrollArgs := &A{
+			TxId:        addr.TxId,
+			CursorStep1: addr.Step,
 		}
 		mach.Add1(ss.ScrollToTx, Pass(scrollArgs))
+
 	} else if addr.MachTime != 0 {
-		tx := d.C.Tx(d.C.TxByMachTime(addr.MachTime))
+		tx := d.C.Tx(d.C.TxAtMachTime(addr.MachTime))
 		mach.Add1(ss.ScrollToTx, Pass(&A{
 			TxId: tx.ID,
 		}))
+
 	} else if !addr.HumanTime.IsZero() {
-		tx := d.C.Tx(d.C.LastTxTill(addr.HumanTime))
+		tx := d.C.Tx(d.C.TxAtHTime(addr.HumanTime))
+		mach.Add1(ss.ScrollToTx, Pass(&A{
+			TxId: tx.ID,
+		}))
+
+	} else if addr.QueueTick != 0 {
+		tx := d.C.Tx(d.C.TxAtQueueTick(addr.QueueTick))
 		mach.Add1(ss.ScrollToTx, Pass(&A{
 			TxId: tx.ID,
 		}))
 	}
-	if !skipHistory {
-		mach.Eval("GoToMachAddress", func() {
-			d.hPrependHistory(addr)
-			d.hUpdateAddressBar()
-		}, ctx)
-		// TODO only if main panel visible
-		d.draw(d.addressBar)
+	d.hUpdateAddressBar()
+
+	// GET params
+	if addr.State != "" {
+		d.Mach.Add1(ss.StateNameSelected, Pass(&A{
+			State: addr.State,
+		}))
+	}
+	if addr.Group != "" {
+		// TODO fix group IDs, merge with SetGroupState
+		d.Mach.Eval("GoToMachAddress", func() {
+			label := ""
+			for l := range d.C.MsgStruct.Groups {
+				if types.NormalizeGroupName(l) == types.NormalizeGroupName(addr.Group) {
+					label = l
+					break
+				}
+			}
+			d.lastSelectedGroup = label
+			d.C.SelectedGroup = label
+			d.hBuildSchemaTree()
+			d.hUpdateSchemaTree()
+			d.hUpdateTreeGroups()
+			go amhelp.AskAdd1(d.Mach, ss.DiagramsScheduled, nil)
+			d.Mach.Add(am.S{ss.ToolToggled, ss.UpdateLogScheduled}, Pass(&A{
+				FilterTxs:     true,
+				LogRebuildEnd: len(d.C.MsgTxs),
+			}))
+		}, nil)
+	} else {
+		d.Mach.Add1(ss.SetGroup, Pass(&A{
+			Group: "all",
+		}))
+	}
+
+	// TODO remove
+	if addr.Step != 0 {
+		mach.Add1(ss.ScrollToStep, Pass(&A{
+			CursorStep1: addr.Step,
+		}))
 	}
 
 	return true

--- a/tools/debugger/types/dbg_types.go
+++ b/tools/debugger/types/dbg_types.go
@@ -358,21 +358,21 @@ func StartCpuProfileSrv(ctx context.Context, logger *log.Logger, p *Params) {
 }
 
 type MachAddress struct {
-	MachId    string
-	TxId      string
+	MachId string
+	TxId   string
+	// TODO remove
+	Step int
+
+	// GET param
+
 	MachTime  uint64
-	HumanTime time.Time
-	Step      int
-
-	// TODO
 	QueueTick uint64
+	HumanTime time.Time
 
-	// TODO support as GET param
-
-	Group    string
-	State    string
-	Relation string
-	RelState string
+	// selected group
+	Group string
+	// selected state
+	State string
 }
 
 type MachTime struct {
@@ -389,47 +389,74 @@ func (a *MachAddress) Clone() *MachAddress {
 	}
 }
 
-func (a *MachAddress) String() string {
-	if a == nil {
+// StringBase returns a mach URL without GET params (unless no tx ID). Empty
+// string ret if no link.
+func (a *MachAddress) StringBase() string {
+	if a == nil || a.MachId == "" {
+		return ""
+	}
+	ret := "mach://" + a.MachId
+
+	if a.TxId != "" {
+		ret += "/" + a.TxId
+		if a.Step != 0 {
+			ret += fmt.Sprintf("/%d", a.Step)
+		}
+	} else if a.MachTime != 0 {
+		return ret + fmt.Sprintf("/?t=%d", a.MachTime)
+	} else if a.QueueTick != 0 {
+		return ret + fmt.Sprintf("/?q=%d", a.QueueTick)
+	} else if !a.HumanTime.IsZero() {
+		return ret + fmt.Sprintf("/?q=%s", a.HumanTime)
+	} else {
 		return ""
 	}
 
-	if a.TxId != "" {
-		u := fmt.Sprintf("mach://%s/%s", a.MachId, a.TxId)
-		if a.Step != 0 {
-			u += fmt.Sprintf("/%d", a.Step)
-		}
-		if a.MachTime != 0 {
-			u += fmt.Sprintf("/t%d", a.MachTime)
-		}
-		// TODO queue tick as q123
+	return ret
+}
 
-		return u
-	}
+// String returns a full mach URL.
+func (a *MachAddress) String() string {
+	ret := a.StringBase()
+	get := []string{}
 	if a.MachTime != 0 {
-		return fmt.Sprintf("mach://%s/t%d", a.MachId, a.MachTime)
+		get = append(get, fmt.Sprintf("t=%d", a.MachTime))
+	}
+	if a.QueueTick != 0 {
+		get = append(get, fmt.Sprintf("q=%d", a.QueueTick))
 	}
 	if !a.HumanTime.IsZero() {
-		return fmt.Sprintf("mach://%s/%s", a.MachId, a.HumanTime)
+		get = append(get, fmt.Sprintf("ht=%s", a.HumanTime))
+	}
+	if a.Group != "" {
+		get = append(get, fmt.Sprintf("group=%s", NormalizeGroupName(a.Group)))
+	}
+	if a.State != "" {
+		get = append(get, fmt.Sprintf("state=%s", a.State))
 	}
 
-	return fmt.Sprintf("mach://%s", a.MachId)
+	if len(get) == 0 {
+		return ret
+	}
+
+	slices.Sort(get)
+	return ret + "?" + strings.Join(get, "&")
 }
 
 func ParseMachUrl(u string) (*MachAddress, error) {
 	// TODO merge parsing with addr bar
 
-	up, err := url.Parse(u)
+	parsed, err := url.Parse(u)
 	if err != nil {
 		return nil, err
-	} else if up.Host == "" {
-		return nil, fmt.Errorf("host missing in: %s", u)
+	} else if parsed.Host == "" {
+		return nil, fmt.Errorf("mach ID missing in: %s", u)
 	}
 
 	addr := &MachAddress{
-		MachId: up.Host,
+		MachId: parsed.Host,
 	}
-	p := strings.Split(up.Path, "/")
+	p := strings.Split(parsed.Path, "/")
 	if len(p) > 1 {
 		addr.TxId = p[1]
 	}
@@ -438,6 +465,29 @@ func ParseMachUrl(u string) (*MachAddress, error) {
 			addr.Step = s
 		}
 	}
+
+	// get params
+	q, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return nil, err
+	}
+	if v := q.Get("t"); v != "" {
+		if s, err := strconv.ParseUint(v, 10, 64); err == nil {
+			addr.MachTime = s
+		}
+	}
+	if v := q.Get("q"); v != "" {
+		if s, err := strconv.ParseUint(v, 10, 64); err == nil {
+			addr.QueueTick = s
+		}
+	}
+	if v := q.Get("ht"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			addr.HumanTime = t
+		}
+	}
+	addr.State = q.Get("state")
+	addr.Group = q.Get("group")
 
 	return addr, nil
 }


### PR DESCRIPTION
Examples:
 - `mach://cook/5b0e0574309ab28f36a2cd91249545d2-5/26?group=AgentBase&state=BaseDBSaving&t=76`
 - `mach://cook/?t=76`

Better support for mach time (`?t`), queue ticks (`?qt`), human time (`?ht`). Support for steps has been removed, docs are coming.