### PR TITLE
feat(docs): add editor templates and AI skills

### DIFF
--- a/docs/editors/README.md
+++ b/docs/editors/README.md
@@ -1,0 +1,117 @@
+# <img src="https://pancsta.github.io/assets/asyncmachine-go/logo-25.png" /> /pkg/history
+
+[`cd /`](/README.md)
+
+> [!NOTE]
+> **asyncmachine-go** is a pathless control-flow graph with a consensus (AOP, actor model, state-machine).
+
+## Editor Support
+
+This doc file contains tips on how to handle the bulk of boilerplate needed for **asyncmachine-go**.
+
+## Agent Skills
+
+Using LLMs to generate boilerplate is often faster than using [am-gen](/tools/cmd/am-gen/README.md) or using live
+templates. Dirs with `SKILL.md` files are auto-generated from documentation using the command below. Each skill being a
+single file can easily be copy-pasted and guarantees the highest compatibility.
+
+```bash
+# in repo root
+./scripts/dep-taskfile.sh
+task gen-docs-skills
+cp ./docs/editors/skills/* $DEST
+```
+
+## Token Usage
+
+Skills are divided based on token usage, each fully contained within a single `SKILL.md` file.
+
+- `/am-mini` ~1.3k tokens - compacted version
+- `/am` ~2.9k tokens - basic boilerplate
+- `/am-cook` ~11k tokens - also includes [/docs/cookbook.md](/docs/cookbook.md)
+- `/am-full` ~18k tokens - also includes [/docs/manual.md](/docs/manual.md)
+
+## Live Templates
+
+[Live templates](https://www.jetbrains.com/help/idea/using-live-templates.html#live_templates_configure) expand
+semantically inside **Goland IDE** for fast tab-completion.
+
+### Handler
+
+- `am`
+
+```go
+var _ = $SS$.$STATE$
+func ($N$ *$HANDLERS$) $STATE$$TYPE$(e *am.Event) $RET$ {
+   $END$
+}
+```
+
+| Name       | Expression                           | Default value | Skip if defined |
+|:-----------|:-------------------------------------|:--------------|:----------------|
+| `SS`       | `completeSmart()`                    | ss            |                 |
+| `STATE`    | `completeSmart()`                    | `"Foo"`       |                 |
+| `TYPE`     | `enum("State","Enter","Exit","End")` | `"State"`     |                 |
+| `RET`      | `enum("","bool")`                    |               |                 |
+| `HANDLERS` | `completeSmart()`                    |               |                 |
+| `N`        | `goSuggestVariableName()`            | `"h"`         |                 |
+
+### Handler With Boilerplate
+
+- `am2`
+
+```go
+var _ = $SS$.$STATE$
+func ($N$ *$HANDLERS$) $STATE$$TYPE$(e *am.Event) $RET$ {
+    ctx := $N$.Mach.NewStateCtx($STATE$)
+    mach := $N$.Mach
+
+    mach.Fork(ctx, e, func() {
+        $END$
+    })
+}
+```
+
+| Name       | Expression                           | Default value | Skip if defined |
+|:-----------|:-------------------------------------|:--------------|:----------------|
+| `SS`       | `completeSmart()`                    | ss            |                 |
+| `STATE`    | `completeSmart()`                    | `"Foo"`       |                 |
+| `TYPE`     | `enum("State","Enter","Exit","End")` | `"State"`     |                 |
+| `RET`      | `enum("","bool")`                    |               |                 |
+| `HANDLERS` | `completeSmart()`                    |               |                 |
+| `N`        | `goSuggestVariableName()`            | `"h"`         |                 |
+
+### Error Setter
+
+- `amerr`
+
+```go
+var Err$NAME$ = errors.New("$NAME2$ error")
+
+// AddErr$NAME$ adds [Err$NAME$].
+func AddErr$NAME$(
+    event *am.Event, mach *am.Machine, err error, args ...am.A,
+) am.Result {
+    if err == nil {
+        return am.Executed
+    }
+    err = fmt.Errorf("%w: %w", Err$NAME$, err)
+
+    return mach.EvAddErrState(event, ss.Err$NAME$, err, am.OptArgs(args))
+}
+```
+
+| Name    | Expression           | Default value | Skip if defined |
+|:--------|:---------------------|:--------------|:----------------|
+| `NAME`  | `capitalize(String)` |               |                 |
+| `NAME2` | `camelCase(String)`  | `$NAME$`      |                 |
+
+### Context Expiration Check
+
+- `ctxexp`
+
+```go
+if ctx.Err() != nil {
+    return // expired
+}$END$
+```

--- a/docs/editors/SKILL.md
+++ b/docs/editors/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: am
+description: asyncmachine - generate handlers, schemas, args, telemetry, dbg, RPC, state waiting,
+  state targeting, and more.
+---
+
+# General
+
+- Always check context after a blocking call, before checking `err`. Expired state ctx is `return // expired`.
+- Prefer traced mutations `Ev*(e...)` if `e *am.Event` in the scope.
+- The default ctx in a handler is the handler's state ctx, unless it's a `Multi` state.
+- Always list states from imported schemas (usually `./states/ss_*.go`).
+- Always mimic the example schema (order, naming).
+  - Every schema has to inherit from `*am.StatesBase`
+  - Almost every schema has to inherit from `*ss.BasicStates`, unless specified otherwise or an edge-case.
+  - Schema failes are called `ss_{name}.go`
+- Prefer `am.NewCommon` constructor over `am.New` and always add env-based debugging with `SetArgsMapper(LogArgs)`
+  and groups (if any).
+- Always verify created files using `go build` and the LSP.
+- Use single-state methods (`*1` suffix) for single-state calls, eg `Add1(state)`, instead of `Add(am.S{state})`
+
+# Details

--- a/docs/editors/mini.md
+++ b/docs/editors/mini.md
@@ -1,0 +1,252 @@
+## Handlers
+
+### Activation handler with negotiation
+
+```go
+// negotiation handler
+func (h *Handlers) NameEnter(e *am.Event) bool {}
+// final handler
+func (h *Handlers) NameState(e *am.Event) {}
+```
+
+### De-activation handler with negotiation
+
+```go
+// negotiation handler
+func (h *Handlers) NameExit(e *am.Event) bool {}
+// final handler
+func (h *Handlers) NameEnd(e *am.Event) {}
+```
+
+### State to state handlers
+
+```go
+// with Foo active, can Bar activate? (negotiation)
+func (h *Handlers) FooBar(e *am.Event) {}
+// with Bar active, can Baz activate? (negotiation)
+func (h *Handlers) BarBaz(e *am.Event) {}
+```
+
+## Machine
+
+### Common init
+
+```go
+import (
+    am "github.com/pancsta/asyncmachine-go/pkg/machine"
+    ss "PACKAGE/states"
+)
+// ...
+mach, err := am.NewCommon(ctx, "mach1", ss.States, ss.Names, nil, nil, &am.Opts{
+    LogLevel: am.LogChanges,
+	Parent: machParent,
+})
+```
+
+### Arguments
+
+```go
+// ///// ///// /////
+
+// ///// ARGS
+
+// ///// ///// /////
+
+func init() {
+	gob.Register(ARpc{})
+}
+
+const APrefix = "template"
+
+// A is a struct for node arguments. It's a typesafe alternative to [am.A].
+type A struct {
+	Id   string `log:"id"`
+	Addr string `log:"addr"`
+
+	// non-rpc fields
+
+	ReturnCh chan<- []string
+}
+
+// ARpc is a subset of A, that can be passed over RPC.
+type ARpc struct {
+	Id   string `log:"id"`
+	Addr string `log:"addr"`
+}
+
+// ParseArgs extracts A from [am.Event.Args][APrefix].
+func ParseArgs(args am.A) *A {
+	if r, ok := args[APrefix].(*ARpc); ok {
+		return amhelp.ArgsToArgs(r, &A{})
+	} else if r, ok := args[APrefix].(ARpc); ok {
+		return amhelp.ArgsToArgs(&r, &A{})
+	}
+	if a, _ := args[APrefix].(*A); a != nil {
+		return a
+	}
+	return &A{}
+}
+
+// Pass prepares [am.A] from A to pass to further mutations.
+func Pass(args *A) am.A {
+	return am.A{APrefix: args}
+}
+
+// PassRpc prepares [am.A] from A to pass over RPC.
+func PassRpc(args *A) am.A {
+	return am.A{APrefix: amhelp.ArgsToArgs(args, &ARpc{})}
+}
+
+// LogArgs is an args logger for A.
+func LogArgs(args am.A) map[string]string {
+	a := ParseArgs(args)
+	if a == nil {
+		return nil
+	}
+
+	return amhelp.ArgsToLogMap(a, 0)
+}
+
+// ParseRpc parses [am.A] to *ARpc namespaced in [am.A]. Useful for REPLs.
+func ParseRpc(args am.A) am.A {
+	ret := am.A{APrefix: &ARpc{}}
+	jsonArgs, err := json.Marshal(args)
+	if err == nil {
+		json.Unmarshal(jsonArgs, ret[APrefix])
+	}
+
+	return ret
+}
+```
+
+## Schema
+
+### State definition
+
+```go
+am.Schema{
+    "StateName": {
+
+        // properties
+        Auto:    true,
+        Multi:   true,
+
+        // relations
+        Require: am.S{"AnotherState1"},
+        Add:     am.S{"AnotherState2"},
+        Remove:  am.S{"AnotherState3", "AnotherState4"},
+        After:   am.S{"AnotherState2"},
+    }
+}
+```
+
+### Schema definition
+
+```go
+import (
+    . "github.com/pancsta/asyncmachine-go/pkg/states/global"
+    ss "github.com/pancsta/asyncmachine-go/pkg/states"
+)
+
+// ServerStatesDef contains all the states of the Client state machine.
+type ServerStatesDef struct {
+	*am.StatesBase
+
+	// basics
+
+	// Ready - Client is fully connected to the server.
+	Ready string
+
+	// rpc
+
+	// Starting listening
+	RpcStarting string
+	// setting up RPC accepting
+	RpcAccepting string
+	// RPC is accepting or has accepted connections
+	RpcReady string
+
+	// RPC client connected (technically)
+	ClientConnected string
+	// RPC client fully usable
+	HandshakeDone string
+
+	// How many times the client requested a full sync.
+	MetricSync string
+	// TCP tunneled over websocket
+	WebSocketTunnel string
+
+	// inherit from BasicStatesDef
+	*states.BasicStatesDef
+}
+
+// ServerGroupsDef contains all the state groups of the Client state machine.
+type ServerGroupsDef struct {
+	*SharedGroupsDef
+
+	// Rpc is a group for RPC ready states.
+	Rpc S
+}
+
+// ServerSchema represents all relations and properties of ClientStates.
+var ServerSchema = SchemaMerge(
+	// inherit from SharedStruct
+	SharedSchema,
+	am.Schema{
+
+		ssS.ErrNetwork: {
+			Require: S{am.StateException},
+			Remove:  S{ssS.ClientConnected},
+		},
+
+		// inject Server states into HandshakeDone
+		ssS.HandshakeDone: StateAdd(
+			SharedSchema[ssS.HandshakeDone],
+			am.State{
+				Require: S{ssS.ClientConnected},
+				// TODO why?
+				Remove: S{Exception},
+			}),
+
+		// Server
+
+		ssS.Start: {Add: S{ssS.RpcStarting}},
+		ssS.Ready: {
+			Auto:    true,
+			Require: S{ssS.HandshakeDone, ssS.RpcReady},
+		},
+
+		ssS.RpcStarting: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.RpcAccepting: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.RpcReady: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.ClientConnected: {
+			Require: S{ssS.RpcReady},
+		},
+
+		ssS.MetricSync:      {Multi: true},
+		ssS.WebSocketTunnel: {},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssS = am.NewStates(ServerStatesDef{})
+	sgS = am.NewStateGroups(ServerGroupsDef{
+		Rpc: S{ssS.RpcStarting, ssS.RpcAccepting, ssS.RpcReady},
+	}, SharedGroups)
+
+	// ServerStates contains all the states for the Client machine.
+	ServerStates = ssS
+	// ServerGroups contains all the state groups for the Client machine.
+	ServerGroups = sgS
+)
+```

--- a/docs/editors/schema.go
+++ b/docs/editors/schema.go
@@ -1,0 +1,110 @@
+package states
+
+import (
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	ss "github.com/pancsta/asyncmachine-go/pkg/states"
+	. "github.com/pancsta/asyncmachine-go/pkg/states/global"
+)
+
+// ///// ///// /////
+
+// ///// SERVER
+
+// ///// ///// /////
+
+// ServerStatesDef contains all the states of the Client state machine.
+type ServerStatesDef struct {
+	*am.StatesBase
+
+	// basics
+
+	// Ready - Client is fully connected to the server.
+	Ready string
+
+	// rpc
+
+	// Starting listening
+	RpcStarting string
+	// setting up RPC accepting
+	RpcAccepting string
+	// RPC is accepting or has accepted connections
+	RpcReady string
+
+	// RPC client connected (technically)
+	ClientConnected string
+	// RPC client fully usable
+	HandshakeDone string
+
+	// How many times the client requested a full sync.
+	MetricSync string
+	// TCP tunneled over websocket
+	WebSocketTunnel string
+
+	// inherit from BasicStatesDef
+	*ss.BasicStatesDef
+}
+
+// ServerGroupsDef contains all the state groups of the Client state machine.
+type ServerGroupsDef struct {
+	// Rpc is a group for RPC ready states.
+	Rpc S
+}
+
+// ServerSchema represents all relations and properties of ClientStates.
+var ServerSchema = SchemaMerge(
+	// inherit from BasicStruct
+	ss.BasicSchema,
+	am.Schema{
+
+		ssS.ErrNetwork: {
+			Require: S{am.StateException},
+			Remove:  S{ssS.ClientConnected},
+		},
+
+		// inject Server states into HandshakeDone
+		ssS.HandshakeDone: {
+			Require: S{ssS.ClientConnected},
+			Remove:  S{Exception},
+		},
+
+		// Server
+
+		ssS.Start: {Add: S{ssS.RpcStarting}},
+		ssS.Ready: {
+			Auto:    true,
+			Require: S{ssS.HandshakeDone, ssS.RpcReady},
+		},
+
+		ssS.RpcStarting: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.RpcAccepting: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.RpcReady: {
+			Require: S{ssS.Start},
+			Remove:  sgS.Rpc,
+		},
+		ssS.ClientConnected: {
+			Require: S{ssS.RpcReady},
+		},
+
+		ssS.MetricSync:      {Multi: true},
+		ssS.WebSocketTunnel: {},
+	})
+
+// EXPORTS AND GROUPS
+
+var (
+	ssS = am.NewStates(ServerStatesDef{})
+	sgS = am.NewStateGroups(ServerGroupsDef{
+		Rpc: S{ssS.RpcStarting, ssS.RpcAccepting, ssS.RpcReady},
+	})
+
+	// ServerStates contains all the states for the Client machine.
+	ServerStates = ssS
+	// ServerGroups contains all the state groups for the Client machine.
+	ServerGroups = sgS
+)

--- a/docs/editors/states.md
+++ b/docs/editors/states.md
@@ -1,0 +1,50 @@
+```go
+var BasicSchema = am.Schema{
+    // Errors
+
+    ssB.Exception: {Multi: true},
+    ssB.ErrNetwork: {
+        Multi:   true,
+        Add:     S{Exception},
+        Require: S{Exception},
+    },
+    ssB.ErrHandlerTimeout: {
+        Multi:   true,
+        Add:     S{Exception},
+        Require: S{Exception},
+    },
+
+    // Basics
+
+    ssB.Start:       {},
+    ssB.Ready:       {Require: S{ssB.Start}},
+    ssB.Healthcheck: {Multi: true},
+    ssB.Heartbeat:   {},
+}
+
+// ConnectedSchema represents all relations and properties of ConnectedStates.
+var ConnectedSchema = am.Schema{
+    ssC.ErrConnecting: {Require: S{Exception}},
+
+    ssC.Connecting: {
+        Require: S{Start},
+        Remove:  sgC.Connected,
+    },
+    ssC.Connected: {
+        Require: S{Start},
+        Remove:  sgC.Connected,
+    },
+    ssC.Disconnecting: {Remove: sgC.Connected},
+    ssC.Disconnected: {
+        Auto:   true,
+        Remove: sgC.Connected,
+    },
+}
+
+// DisposedSchema represents all relations and properties of DisposedStates.
+var DisposedSchema = am.Schema{
+    ssD.RegisterDisposal: {Multi: true},
+    ssD.Disposing:        {Remove: S{Start}},
+    ssD.Disposed:         {Remove: S{ssD.Disposing, Start}},
+}
+```


### PR DESCRIPTION
"Skills" are generated from docs, divided by token usage and purpose. Live templates are often faster for everyday coding tho. See `/docs/editors/README.md`.