### PR TITLE
feat(am-gen): add an optional global import

### DIFF
--- a/tools/cmd/am-gen/cmd_gen.go
+++ b/tools/cmd/am-gen/cmd_gen.go
@@ -87,12 +87,14 @@ func genStatesFile(ctx context.Context, params *cli.StatesParams) error {
 		fmt.Printf("Generated %s\n", name)
 
 		// save utils
-		content = []byte(generator.GenUtilsFile())
-		err = os.WriteFile("states_utils.go", content, 0666)
-		if err != nil {
-			return err
+		if !params.Global && params.Utils {
+			content = []byte(generator.GenUtilsFile())
+			err = os.WriteFile("states_utils.go", content, 0666)
+			if err != nil {
+				return err
+			}
+			fmt.Println("Generated states_utils.go")
 		}
-		fmt.Println("Generated states_utils.go")
 
 	} else {
 		return fmt.Errorf("file %s already exists, delete it or use --force", name)

--- a/tools/generator/cli/cli.go
+++ b/tools/generator/cli/cli.go
@@ -16,7 +16,7 @@ import (
 //
 //nolint:lll
 type Args struct {
-	StatesFile *StatesParams  `arg:"subcommand:states-file" help:"Generate state schema files"`
+	StatesFile *StatesParams  `arg:"subcommand:states-file" help:"Generate state schema"`
 	Grafana    *GrafanaParams `arg:"subcommand:grafana" help:"Generate Grafana dashboards"`
 	Version    bool           `arg:"-v,--version" help:"Print version and exit"`
 }
@@ -89,4 +89,6 @@ type StatesParams struct {
 	Force bool `arg:"-f,--force" help:"Override output file (if any)"`
 	// Utils - Generate states_utils.go in CWD. Overrides files.
 	Utils bool `arg:"-u,--utils" default:"true" help:"Generate states_utils.go in CWD. Overrides files."`
+	// Global - Import pkg/states/global and skip generating states_utils.go.
+	Global bool `arg:"--global" help:"Import pkg/states/global and skip generating states_utils.go"`
 }

--- a/tools/generator/schema.go
+++ b/tools/generator/schema.go
@@ -33,6 +33,7 @@ type SchemaGenerator struct {
 	Name string
 	// N is the first letter of Name
 	N           string
+	Global      bool
 	States      []string
 	StatesAuto  []string
 	StatesMulti []string
@@ -117,6 +118,7 @@ func (g *SchemaGenerator) parseParams(p cli.StatesParams) {
 
 	g.Name = capitalizeFirstLetter(p.Name)
 	g.N = string(g.Name[0])
+	g.Global = p.Global
 }
 
 var _ = ssG.Inherit
@@ -135,8 +137,12 @@ func (g *SchemaGenerator) Output() string {
 	// TODO switch to github.com/dave/jennifer
 
 	var impPkgStates string
-	if g.Mach.Any1(ssG.InheritBasic, ssG.InheritConnected) {
-		impPkgStates = "\n\tss \"github.com/pancsta/asyncmachine-go/pkg/states\""
+	if g.Mach.Any1(ssG.InheritBasic, ssG.InheritConnected, ssG.InheritDisposed) {
+		impPkgStates = "\n\tssam \"github.com/pancsta/asyncmachine-go/pkg/states\""
+	}
+	var impGlobal string
+	if g.Global {
+		impGlobal = "\n\t. \"github.com/pancsta/asyncmachine-go/pkg/states/global\""
 	}
 
 	// imports
@@ -146,8 +152,8 @@ func (g *SchemaGenerator) Output() string {
 		import (
 			"context"
 	
-			am "github.com/pancsta/asyncmachine-go/pkg/machine"%s
-	`, impPkgStates)
+			am "github.com/pancsta/asyncmachine-go/pkg/machine"%s%s
+	`, impGlobal, impPkgStates)
 
 	if g.Mach.Is1(ssG.InheritRpcStateSource) {
 		out += "\tssrpc \"github.com/pancsta/asyncmachine-go/pkg/rpc/states\"\n"
@@ -175,11 +181,15 @@ func (g *SchemaGenerator) Output() string {
 
 	// inherits
 	if g.Mach.Is1(ssG.InheritBasic) {
-		out += "\t// inherit from BasicStatesDef\n\t*ss.BasicStatesDef\n"
+		out += "\t// inherit from BasicStatesDef\n\t*ssam.BasicStatesDef\n"
 	}
 	if g.Mach.Is1(ssG.InheritConnected) {
 		out += "\t// inherit from ConnectedStatesDef\n" +
-			"\t*ss.ConnectedStatesDef\n"
+			"\t*ssam.ConnectedStatesDef\n"
+	}
+	if g.Mach.Is1(ssG.InheritDisposed) {
+		out += "\t// inherit from DisposedStatesDef\n" +
+			"\t*ssam.DisposedStatesDef\n"
 	}
 	if g.Mach.Is1(ssG.InheritRpcStateSource) {
 		out += "\t// inherit from rpc/StateSourceStatesDef\n" +
@@ -198,7 +208,7 @@ func (g *SchemaGenerator) Output() string {
 			type %sGroupsDef struct {
 		`, g.Name, g.Name, g.Name)
 	if g.Mach.Is1(ssG.InheritConnected) {
-		out += "\t*ss.ConnectedGroupsDef\n"
+		out += "\t*ssam.ConnectedGroupsDef\n"
 	}
 	if g.Mach.Is1(ssG.InheritNodeWorker) {
 		out += "\t*ssnode.WorkerGroupsDef\n"
@@ -223,11 +233,15 @@ func (g *SchemaGenerator) Output() string {
 
 	// struct inherit
 	if g.Mach.Is1(ssG.InheritBasic) {
-		out += "\t// inherit from BasicSchema\n\tss.BasicSchema,\n"
+		out += "\t// inherit from BasicSchema\n\tssam.BasicSchema,\n"
 	}
 	if g.Mach.Is1(ssG.InheritConnected) {
 		out += fmt.Sprintf("\t// inherit from ConnectedSchema\n" +
-			"\tss.ConnectedSchema,\n")
+			"\tssam.ConnectedSchema,\n")
+	}
+	if g.Mach.Is1(ssG.InheritDisposed) {
+		out += fmt.Sprintf("\t// inherit from DisposedSchema\n" +
+			"\tssam.DisposedSchema,\n")
 	}
 	if g.Mach.Is1(ssG.InheritRpcStateSource) {
 		out += fmt.Sprintf("\t// inherit from rpc/StateSourceSchema\n" +
@@ -338,7 +352,7 @@ func (g *SchemaGenerator) Output() string {
 	out += "}"
 
 	if g.Mach.Is1(ssG.InheritConnected) {
-		out += ", ss.ConnectedGroups"
+		out += ", ssam.ConnectedGroups"
 	}
 	if g.Mach.Is1(ssG.InheritNodeWorker) {
 		out += ", ssnode.WorkerGroups"

--- a/tools/generator/schema_test.go
+++ b/tools/generator/schema_test.go
@@ -28,7 +28,7 @@ func TestAll(t *testing.T) {
 	params := cli.StatesParams{
 		Version: false,
 		States:  "State1,State2:multi",
-		Inherit: "basic,connected,node/worker,rpc/statesrc",
+		Inherit: "basic,connected,disposed,node/worker,rpc/statesrc",
 		Groups:  "Group1,Group2",
 		Name:    "MyMach",
 	}
@@ -46,7 +46,7 @@ func TestAll(t *testing.T) {
 			"context"
 	
 			am "github.com/pancsta/asyncmachine-go/pkg/machine"
-			ss "github.com/pancsta/asyncmachine-go/pkg/states"
+			ssam "github.com/pancsta/asyncmachine-go/pkg/states"
 			ssnode "github.com/pancsta/asyncmachine-go/pkg/node/states"
 		)
 		
@@ -58,16 +58,18 @@ func TestAll(t *testing.T) {
 			State2 string
 		
 			// inherit from BasicStatesDef
-			*ss.BasicStatesDef
+			*ssam.BasicStatesDef
 			// inherit from ConnectedStatesDef
-			*ss.ConnectedStatesDef
+			*ssam.ConnectedStatesDef
+			// inherit from DisposedStatesDef
+			*ssam.DisposedStatesDef
 			// inherit from node/StateSourceStatesDef
 			*ssnode.StateSourceStatesDef
 		}
 		
 		// MyMachGroupsDef contains all the state groups [MyMach] state-machine.
 		type MyMachGroupsDef struct {
-			*ss.ConnectedGroupsDef
+			*ssam.ConnectedGroupsDef
 			*ssnode.WorkerGroupsDef
 			Group1 S
 			Group2 S
@@ -76,9 +78,11 @@ func TestAll(t *testing.T) {
 		// MyMachSchema represents all relations and properties of [MyMachStates].
 		var MyMachSchema = SchemaMerge(
 			// inherit from BasicSchema
-			ss.BasicSchema,
+			ssam.BasicSchema,
 			// inherit from ConnectedSchema
-			ss.ConnectedSchema,
+			ssam.ConnectedSchema,
+			// inherit from DisposedSchema
+			ssam.DisposedSchema,
 			// inherit from node/WorkerSchema
 			ssnode.WorkerSchema,
 			am.Schema{
@@ -96,7 +100,7 @@ func TestAll(t *testing.T) {
 			sgM = am.NewStateGroups(MyMachGroupsDef{
 				Group1: S{},
 				Group2: S{},
-			}, ss.ConnectedGroups, ssnode.WorkerGroups)
+			}, ssam.ConnectedGroups, ssnode.WorkerGroups)
 		
 			// MyMachStates contains all the states for the [MyMach] state-machine.
 			MyMachStates = ssM
@@ -141,7 +145,7 @@ func TestBasicConnected(t *testing.T) {
 			"context"
 	
 			am "github.com/pancsta/asyncmachine-go/pkg/machine"
-			ss "github.com/pancsta/asyncmachine-go/pkg/states"
+			ssam "github.com/pancsta/asyncmachine-go/pkg/states"
 		)
 		
 		// MyMachStatesDef contains all the states of the [MyMach] state-machine.
@@ -152,14 +156,14 @@ func TestBasicConnected(t *testing.T) {
 			State2 string
 		
 			// inherit from BasicStatesDef
-			*ss.BasicStatesDef
+			*ssam.BasicStatesDef
 			// inherit from ConnectedStatesDef
-			*ss.ConnectedStatesDef
+			*ssam.ConnectedStatesDef
 		}
 		
 		// MyMachGroupsDef contains all the state groups [MyMach] state-machine.
 		type MyMachGroupsDef struct {
-			*ss.ConnectedGroupsDef
+			*ssam.ConnectedGroupsDef
 			Group1 S
 			Group2 S
 		}
@@ -167,9 +171,9 @@ func TestBasicConnected(t *testing.T) {
 		// MyMachSchema represents all relations and properties of [MyMachStates].
 		var MyMachSchema = SchemaMerge(
 			// inherit from BasicSchema
-			ss.BasicSchema,
+			ssam.BasicSchema,
 			// inherit from ConnectedSchema
-			ss.ConnectedSchema,
+			ssam.ConnectedSchema,
 			am.Schema{
 		
 				ssM.State1: {},
@@ -185,7 +189,7 @@ func TestBasicConnected(t *testing.T) {
 			sgM = am.NewStateGroups(MyMachGroupsDef{
 				Group1: S{},
 				Group2: S{},
-			}, ss.ConnectedGroups)
+			}, ssam.ConnectedGroups)
 		
 			// MyMachStates contains all the states for the [MyMach] state-machine.
 			MyMachStates = ssM
@@ -482,6 +486,75 @@ func TestGroupsStates(t *testing.T) {
 			MyMachGroups = sgM
 		)
 		
+		// NewMyMach creates a new [MyMach] state-machine in the most basic form.
+		func NewMyMach(ctx context.Context) *am.Machine {
+			return am.New(ctx, MyMachSchema, nil)
+		}
+	`), "\n")
+
+	assert.Equal(t, expected, removeEmptyLines(generated))
+}
+
+func TestGlobal(t *testing.T) {
+	ctx := context.Background()
+	// --states State1,State2
+	//				--name MyMach
+
+	params := cli.StatesParams{
+		Version: false,
+		States:  "State1,State2",
+		Name:    "MyMach",
+		Global:  true,
+	}
+
+	gen, err := NewSchemaGenerator(ctx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	generated := gen.Output()
+	expected := strings.TrimLeft(dedent.Dedent(`
+		package states
+		
+		import (
+			"context"
+	
+			am "github.com/pancsta/asyncmachine-go/pkg/machine"
+			. "github.com/pancsta/asyncmachine-go/pkg/states/global"
+		)
+		
+		// MyMachStatesDef contains all the states of the [MyMach] state-machine.
+		type MyMachStatesDef struct {
+			*am.StatesBase
+		
+			State1 string
+			State2 string
+		
+		}
+		
+		// MyMachGroupsDef contains all the state groups [MyMach] state-machine.
+		type MyMachGroupsDef struct {
+		}
+		
+		// MyMachSchema represents all relations and properties of [MyMachStates].
+		var MyMachSchema = am.Schema{
+		
+			ssM.State1: {},
+			ssM.State2: {},
+		}
+		
+		// EXPORTS AND GROUPS
+		
+		var (
+			ssM = am.NewStates(MyMachStatesDef{})
+			sgM = am.NewStateGroups(MyMachGroupsDef{})
+		
+			// MyMachStates contains all the states for the [MyMach] state-machine.
+			MyMachStates = ssM
+			// MyMachGroups contains all the state groups for the [MyMach] state-machine.
+			MyMachGroups = sgM
+		)
+	
 		// NewMyMach creates a new [MyMach] state-machine in the most basic form.
 		func NewMyMach(ctx context.Context) *am.Machine {
 			return am.New(ctx, MyMachSchema, nil)


### PR DESCRIPTION
- add `--global`
- fix `--inherit disposed`
- fix `--utils=false`

Skips generating `states_utils.go` for those who dont mind global imports.