### PR TITLE
feat(machine): add per-state generic typed args

### DIFF
--- a/examples/mach_template/mach_template.go
+++ b/examples/mach_template/mach_template.go
@@ -54,7 +54,7 @@ func main() {
 
 	// getting data back via a channel (needs to be buffered)
 	ch := make(chan []string, 1)
-	mach.Add1(ss.Channel, Pass(&A{
+	mach.Add1(ss.Channel, am.Pass(&AChannel{
 		ReturnCh: ch,
 	}))
 	fmt.Printf("%v\n", <-ch)
@@ -64,7 +64,7 @@ func main() {
 		done := mach.WhenTicks(ss.BazDone, 100, nil)
 
 		for range 100 {
-			mach.Add1(ss.Baz, Pass(&A{
+			mach.Add1(ss.Baz, am.Pass(&ABaz{
 				Addr: "localhost:8090",
 			}))
 		}
@@ -191,7 +191,7 @@ func (h *TemplateHandlers) BarExit(e *am.Event) bool {
 var _ = ss.Baz
 
 func (h *TemplateHandlers) BazState(e *am.Event) {
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[ABaz](e.Args)
 	addr := args.Addr
 
 	// multi states rely on context of other states
@@ -221,7 +221,7 @@ func (h *TemplateHandlers) BazDoneState(e *am.Event) {
 var _ = ss.Channel
 
 func (h *TemplateHandlers) ChannelEnter(e *am.Event) bool {
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[AChannel](e.Args)
 	// only buffered channel can pass
 	return args != nil && cap(args.ReturnCh) > 0
 }
@@ -230,7 +230,7 @@ var _ = ss.Channel
 
 func (h *TemplateHandlers) ChannelState(e *am.Event) {
 	// no validation needed
-	ParseArgs(e.Args).ReturnCh <- []string{"hello", "machines"}
+	am.ParseArgs[AChannel](e.Args).ReturnCh <- []string{"hello", "machines"}
 }
 
 // ///// ///// /////
@@ -239,71 +239,53 @@ func (h *TemplateHandlers) ChannelState(e *am.Event) {
 
 // ///// ///// /////
 
-func init() {
-	gob.Register(ARpc{})
-}
-
 const APrefix = "template"
 
-// A is a struct for node arguments. It's a typesafe alternative to [am.A].
-type A struct {
-	Id   string `log:"id"`
-	Addr string `log:"addr"`
+// Args is shared pkg args for Any state
+type Args struct {
+	am.ArgsBase `json:"-"`
+}
 
-	// non-rpc fields
+func (Args) ArgsPrefix() string {
+	return APrefix
+}
 
+// -----
+
+type AChannel struct {
+	Args `json:"-"`
+
+	// Return chan.
 	ReturnCh chan<- []string
 }
 
-// ARpc is a subset of A, that can be passed over RPC.
-type ARpc struct {
-	Id   string `log:"id"`
+func (AChannel) ArgsState() string {
+	return ss.Channel
+}
+
+// -----
+
+type ABaz struct {
+	Args `json:"-"`
+
+	// Address with logging.
 	Addr string `log:"addr"`
 }
 
-// ParseArgs extracts A from [am.Event.Args][APrefix].
-func ParseArgs(args am.A) *A {
-	if r, ok := args[APrefix].(*ARpc); ok {
-		return amhelp.ArgsToArgs(r, &A{})
-	} else if r, ok := args[APrefix].(ARpc); ok {
-		return amhelp.ArgsToArgs(&r, &A{})
+func (ABaz) ArgsState() string {
+	return ss.Baz
+}
+
+// ----- RPC
+
+func init() {
+	for _, arg := range ArgsRpc {
+		gob.Register(arg)
 	}
-	if a, _ := args[APrefix].(*A); a != nil {
-		return a
-	}
-	return &A{}
 }
 
-// Pass prepares [am.A] from A to pass to further mutations.
-func Pass(args *A) am.A {
-	return am.A{APrefix: args}
-}
-
-// PassRpc prepares [am.A] from A to pass over RPC.
-func PassRpc(args *A) am.A {
-	return am.A{APrefix: amhelp.ArgsToArgs(args, &ARpc{})}
-}
-
-// LogArgs is an args logger for A.
-func LogArgs(args am.A) map[string]string {
-	a := ParseArgs(args)
-	if a == nil {
-		return nil
-	}
-
-	return amhelp.ArgsToLogMap(a, 0)
-}
-
-// ParseRpc parses [am.A] to *ARpc namespaced in [am.A]. Useful for REPLs.
-func ParseRpc(args am.A) am.A {
-	ret := am.A{APrefix: &ARpc{}}
-	jsonArgs, err := json.Marshal(args)
-	if err == nil {
-		json.Unmarshal(jsonArgs, ret[APrefix])
-	}
-
-	return ret
-}
+// ArgsRpc will be available in the REPL.
+var ArgsRpc = []am.ArgsApi{ABaz{}}
 
 // ///// ///// /////
 

--- a/pkg/machine/mach_misc.go
+++ b/pkg/machine/mach_misc.go
@@ -1106,16 +1106,6 @@ func (e *Event) String() string {
 
 // ///// ///// /////
 
-// ExceptionArgsPanic is an optional argument ["panic"] for the StateException
-// state which describes a panic within a Transition handler.
-type ExceptionArgsPanic struct {
-	CalledStates S
-	StatesBefore S
-	Transition   *Transition
-	LastStep     *Step
-	StackTrace   string
-}
-
 // ExceptionHandler provide a basic StateException state support, as should be
 // embedded into handler structs in most of the cases. Because ExceptionState
 // will be called after [Machine.HandlerDeadline], it should handle locks
@@ -1128,57 +1118,14 @@ type recoveryData struct {
 	event *Event
 }
 
-func captureStackTrace() string {
-	buf := make([]byte, 4024)
-	n := runtime.Stack(buf, false)
-	stack := string(buf[:n])
-	lines := strings.Split(stack, "\n")
-	isPanic := strings.Contains(stack, "panic")
-	slices.Reverse(lines)
-
-	heads := []string{
-		"AddErr", "AddErrState", "Remove", "Remove1", "Add", "Add1", "Set",
-	}
-	// TODO trim tails start at reflect.Value.Call({
-	//  with asyncmachine 2 frames down
-
-	// trim the head, remove junk
-	stop := false
-	for i, line := range lines {
-		if isPanic && strings.HasPrefix(line, "panic(") {
-			lines = lines[:i-1]
-			break
-		}
-
-		for _, head := range heads {
-			if strings.Contains("machine.(*Machine)."+line+"(", head) {
-				lines = lines[:i-1]
-				stop = true
-				break
-			}
-		}
-		if stop {
-			break
-		}
-	}
-	slices.Reverse(lines)
-	join := strings.Join(lines, "\n")
-
-	if filter := os.Getenv(EnvAmTraceFilter); filter != "" {
-		join = strings.ReplaceAll(join, filter, "")
-	}
-
-	return join
-}
-
 // ExceptionState is a final entry handler for the StateException state.
-// Args:
+// ArgsBase:
 // - err error: The error that caused the StateException state.
 // - panic *ExceptionArgsPanic: Optional details about the panic.
 func (eh *ExceptionHandler) ExceptionState(e *Event) {
 	// TODO handle ErrHandlerTimeout to ErrHandlerTimeoutState (if present)
 
-	args := ParseArgs(e.Args)
+	args := ParseArgs[AException](e.Args)
 	err := args.Err
 	trace := args.ErrTrace
 	mach := e.Machine()

--- a/pkg/machine/schema.go
+++ b/pkg/machine/schema.go
@@ -188,101 +188,154 @@ func StatesByTag(schema Schema, tag string) S {
 
 // ///// ///// /////
 
-// AT represents typed arguments of pkg/machine, extracted from Event.Args
-// via ParseArgs, or created manually to for Pass.
-type AT struct {
-	Err          error
-	ErrTrace     string
-	Panic        *ExceptionArgsPanic
+const APrefix = "_am"
+
+// ArgsApi is the base interface for typed arguments.
+type ArgsApi interface {
+	// ArgsPrefix returns the argument prefix inside the [A] map. Should be provided by the implementation.
+	ArgsPrefix() string
+	// ArgsState represents the state this argument struct belongs to. Defaults to [StateAny].
+	ArgsState() string
+	// TODO deep clone interface, optional
+	// ArgsClone() G
+}
+
+// ArgsBase is the base implementation of [ArgsApi] interface.
+type ArgsBase struct {
+	ArgsApi
+}
+
+// ArgsPrefix is a fallback to a stack trace hash of the implementation symbol. Each
+// pkg should overwrite this method.
+func (a ArgsBase) ArgsPrefix() string {
+	buf := make([]byte, 4024)
+	n := runtime.Stack(buf, false)
+	stack := string(buf[:n])
+	lines := strings.Split(stack, "\n")
+	hash := Hash(lines[3], 10)
+
+	return hash
+}
+
+// State is the default Any state.
+func (a ArgsBase) ArgsState() string {
+	return StateAny
+}
+
+// Clone for deep cloning.
+func (a ArgsBase) Clone() ArgsApi {
+	// shallow clone
+	return a
+}
+
+// pkg args
+
+// Args for this pkg. Do not reuse.
+type Args struct {
+	ArgsBase
+}
+
+func (Args) ArgsPrefix() string {
+	return APrefix
+}
+
+// -----
+
+// ExceptionArgsPanic is an optional argument ["panic"] for the StateException
+// state which describes a panic within a Transition handler.
+type ExceptionArgsPanic struct {
+	CalledStates S
+	StatesBefore S
+	Transition   *Transition
+	LastStep     *Step
+	StackTrace   string
+}
+
+type AException struct {
+	Args
+	Err      error `log:"err"`
+	ErrTrace string
+	Panic    *ExceptionArgsPanic
+
+	// TODO handle
+	Fn string `log:"fn"`
+
+	// deadline
+
 	TargetStates S
 	CalledStates S
 	TimeBefore   Time
 	TimeAfter    Time
 	Event        *Event
-	// MutDone chan gets closed by the machine once it's processed. Can cause chan
-	// leaks when misused. Only for Can* checks.
-	CheckDone *CheckDone
 }
 
-type ATRpc struct {
-	Err          error
-	ErrTrace     string
-	Panic        *ExceptionArgsPanic
-	TargetStates S
-	CalledStates S
-	TimeBefore   Time
-	TimeAfter    Time
-	Event        *Event
+func (AException) ArgsState() string {
+	return StateException
 }
 
-type CheckDone struct {
+// ACheck with a CheckDone chan which gets closed by the machine once it's
+// processed. Can cause chan leaks when misused. Only for Can* checks.
+type ACheck struct {
+	Args
 	// TODO close these on dispose and deadline
-	Ch chan struct{}
+	CheckDone chan struct{}
 	// Was the mutation canceled?
 	Canceled bool
 }
 
-const (
-	argErr       = "_am_err"
-	argErrTrace  = "_am_errTrace"
-	argPanic     = "_am_panic"
-	argCheckDone = "_am_checkDone"
-)
+// -----
 
-// ParseArgs extracts AT from A.
-func ParseArgs(args A) *AT {
-	ret := &AT{}
-
-	if val, ok := args[argErr]; ok {
-		ret.Err = val.(error)
-	}
-	if val, ok := args[argErrTrace]; ok {
-		ret.ErrTrace = val.(string)
-	}
-	if val, ok := args[argPanic]; ok {
-		ret.Panic = val.(*ExceptionArgsPanic)
-	}
-	if val, ok := args[argCheckDone]; ok {
-		ret.CheckDone = val.(*CheckDone)
+// PassMerge merged one or more [A] into [A]. Technically a `map[string]any`
+// merge.
+func PassMerge(args ...A) A {
+	ret := A{}
+	for _, set := range args {
+		for k, v := range set {
+			ret[k] = v
+		}
 	}
 
 	return ret
 }
 
-// Pass prepares A from AT, to pass to further mutations.
-func Pass(args *AT) A {
-	a := A{}
-
-	if args.Err != nil {
-		a[argErr] = args.Err
-	}
-	if args.ErrTrace != "" {
-		a[argErrTrace] = args.ErrTrace
-	}
-	if args.Panic != nil {
-		a[argPanic] = args.Panic
-	}
-	if args.CheckDone != nil {
-		a[argCheckDone] = args.CheckDone
+// Pass accepts pointers of [ArgsBase] to pass to the machine as [A].
+func Pass(args ...ArgsApi) A {
+	ret := A{}
+	for _, a := range args {
+		ret[ArgIndex(a)] = a
 	}
 
-	return a
+	return ret
 }
 
-// PassMerge prepares A from AT and existing A, to pass to further
-// mutations.
-func PassMerge(existing A, args *AT) A {
-	var a A
-	if existing == nil {
-		a = A{}
-	} else {
-		a = maps.Clone(existing)
+// ParseArgs is [ParseArgsCheck] but without the check.
+func ParseArgs[G ArgsApi](args A) *G {
+	v, _ := ParseArgsCheck[G](args)
+	return v
+}
+
+// ParseArgsCheck parses [A] into typed arguments described by the passed generic
+// type. Returns
+func ParseArgsCheck[G ArgsApi](args A) (*G, bool) {
+	var ret G
+	idx := ArgIndex(ret)
+	v, ok := args[idx].(*G)
+	if !ok {
+		// RPC support
+		v2, ok := args[idx].(G)
+		if !ok {
+			// fallback
+			return &ret, false
+		}
+		v = &v2
 	}
 
-	// unmarshal
-	for k, v := range Pass(args) {
-		a[k] = v
-	}
+	return v, true
+}
 
-	return a
+// ArgIndex return an index of [arg] inside [A].
+func ArgIndex(arg ArgsApi) string {
+	ns := arg.ArgsPrefix()
+	state := arg.ArgsState()
+	return ns + "__" + state
 }

--- a/pkg/node/supervisor.go
+++ b/pkg/node/supervisor.go
@@ -577,14 +577,14 @@ func (s *Supervisor) WorkerConnectedState(e *am.Event) {
 var _ = ssS.WorkerForked
 
 func (s *Supervisor) WorkerForkedEnter(e *am.Event) bool {
-	a := ParseArgs(e.Args)
+	a := am.ParseArgs[A](e.Args)
 	return a != nil && a.LocalAddr != "" && a.WorkerRpc != nil
 }
 
 func (s *Supervisor) WorkerForkedState(e *am.Event) {
 	s.Mach.Remove1(ssS.WorkerForked, nil)
 
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	addr := args.LocalAddr
 	bootAddr := args.BootAddr
 	wrpc := args.WorkerRpc
@@ -637,14 +637,14 @@ func (s *Supervisor) WorkerForkedState(e *am.Event) {
 var _ = ssS.KillingWorker
 
 func (s *Supervisor) KillingWorkerEnter(e *am.Event) bool {
-	a := ParseArgs(e.Args)
+	a := am.ParseArgs[A](e.Args)
 	return a != nil && a.LocalAddr != ""
 }
 
 func (s *Supervisor) KillingWorkerState(e *am.Event) {
 	s.Mach.Remove1(ssS.KillingWorker, nil)
 
-	addr := ParseArgs(e.Args).LocalAddr
+	addr := am.ParseArgs[A](e.Args).LocalAddr
 	argsOut := &A{LocalAddr: addr}
 
 	// fake kill in tests
@@ -676,14 +676,14 @@ func (s *Supervisor) KillingWorkerState(e *am.Event) {
 var _ = ssS.WorkerKilled
 
 func (s *Supervisor) WorkerKilledEnter(e *am.Event) bool {
-	a := ParseArgs(e.Args)
+	a := am.ParseArgs[A](e.Args)
 	return a != nil && a.LocalAddr != ""
 }
 
 func (s *Supervisor) WorkerKilledState(e *am.Event) {
 	s.Mach.Remove1(ssS.WorkerKilled, nil)
 
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	delete(s.workers, args.LocalAddr)
 
 	// re-check the pool status
@@ -879,7 +879,7 @@ func (s *Supervisor) ProvideWorkerEnter(e *am.Event) bool {
 
 func (s *Supervisor) ProvideWorkerState(e *am.Event) {
 	s.Mach.Remove1(ssS.ProvideWorker, nil)
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	ctx := s.Mach.NewStateCtx(ssS.Start)
 	idle := s.idleWorkers()
 
@@ -925,14 +925,14 @@ func (s *Supervisor) ProvideWorkerState(e *am.Event) {
 var _ = ssS.ListWorkers
 
 func (s *Supervisor) ListWorkersEnter(e *am.Event) bool {
-	ch := ParseArgs(e.Args).WorkersCh
+	ch := am.ParseArgs[A](e.Args).WorkersCh
 	// require a buffered channel
 	return ch != nil && cap(ch) > 0
 }
 
 func (s *Supervisor) ListWorkersState(e *am.Event) {
 	s.Mach.Remove1(ssS.ListWorkers, nil)
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 
 	switch args.WorkerState {
 	case StateReady:
@@ -951,12 +951,12 @@ func (s *Supervisor) ListWorkersState(e *am.Event) {
 var _ = ssS.SetWorker
 
 func (s *Supervisor) SetWorkerEnter(e *am.Event) bool {
-	return ParseArgs(e.Args).WorkerAddr != ""
+	return am.ParseArgs[A](e.Args).WorkerAddr != ""
 }
 
 func (s *Supervisor) SetWorkerState(e *am.Event) {
 	s.Mach.Remove1(ssS.SetWorker, nil)
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	addr := args.WorkerAddr
 
 	if args.WorkerInfo != nil {

--- a/pkg/pubsub/topic.go
+++ b/pkg/pubsub/topic.go
@@ -213,7 +213,7 @@ func NewTopic(
 var _ = ss.Exception
 
 func (t *Topic) ExceptionEnter(e *am.Event) bool {
-	err := am.ParseArgs(e.Args).Err
+	err := am.ParseArgs[am.AException](e.Args).Err
 
 	// ignore ErrEvalTimeout
 	return !errors.Is(err, am.ErrEvalTimeout)
@@ -222,7 +222,7 @@ func (t *Topic) ExceptionEnter(e *am.Event) bool {
 func (t *Topic) ExceptionState(e *am.Event) {
 	// super
 	t.ExceptionHandler.ExceptionState(e)
-	args := am.ParseArgs(e.Args)
+	args := am.ParseArgs[am.AException](e.Args)
 	err := args.Err
 	target := args.TargetStates
 

--- a/pkg/rpc/mux.go
+++ b/pkg/rpc/mux.go
@@ -104,14 +104,14 @@ func (m *Mux) ExceptionState(e *am.Event) {
 var _ = ssM.NewServerErr
 
 func (m *Mux) NewServerErrEnter(e *am.Event) bool {
-	a := ParseArgs(e.Args)
+	a := am.ParseArgs[A](e.Args)
 	return a != nil && a.Err != nil
 }
 
 var _ = ssM.NewServerErr
 
 func (m *Mux) NewServerErrState(e *am.Event) {
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	m.NewServerErr = args.Err
 }
 

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -252,70 +252,67 @@ type ReplOpts struct {
 
 const APrefix = "am_rpc"
 
+type Args struct {
+	am.ArgsBase `json:"-"`
+}
+
+func (Args) ArgsPrefix() string {
+	return APrefix
+}
+
+// ----- TODO per-state args
+
 // A represents typed arguments of the RPC package. It's a typesafe alternative
 // to [am.A].
 type A struct {
+	Args `json:"-"`
+
 	Id        string `log:"id"`
 	Name      string `log:"name"`
 	MachTime  am.Time
 	QueueTick uint64
 	MachTick  uint32
-	Payload   *MsgSrvPayload
 	Addr      string `log:"addr"`
 	Err       error
 	Method    string `log:"addr"`
 	StartedAt time.Time
 	Dispose   bool
+}
 
-	// non-rpc fields
+// -----
+
+type AServerPayload struct {
+	Args `json:"-"`
+
+	Name    string `log:"name"`
+	Payload *MsgSrvPayload
+}
+
+func (AServerPayload) ArgsState() string {
+	return ssC.ServerPayload
+}
+
+// -----
+
+type AClientConnected struct {
+	Args `json:"-"`
 
 	Client *rpc2.Client
 }
 
-// ARpc is a subset of A, that can be passed over RPC.
-type ARpc struct {
-	Id        string `log:"id"`
-	Name      string `log:"name"`
-	MachTime  am.Time
-	QueueTick uint64
-	MachTick  uint32
-	Payload   *MsgSrvPayload
-	Addr      string `log:"addr"`
-	Err       error
-	Method    string `log:"addr"`
-	StartedAt time.Time
-	Dispose   bool
+func (AClientConnected) ArgsState() string {
+	return ssS.ClientConnected
 }
 
-// ParseArgs extracts A from [am.Event.Args][APrefix].
-func ParseArgs(args am.A) *A {
-	if r, _ := args[APrefix].(*ARpc); r != nil {
-		return amhelp.ArgsToArgs(r, &A{})
+// ----- RPC boilerplate
+
+// ArgsRpc will be available in the REPL.
+var ArgsRpc = []am.ArgsApi{A{}}
+
+func init() {
+	for _, arg := range ArgsRpc {
+		gob.Register(arg)
 	}
-	if a, _ := args[APrefix].(*A); a != nil {
-		return a
-	}
-	return &A{}
-}
-
-// Pass prepares [am.A] from A to pass to further mutations.
-func Pass(args *A) am.A {
-	return am.A{APrefix: args}
-}
-
-// PassRpc prepares [am.A] from A to pass over RPC.
-func PassRpc(args *A) am.A {
-	return am.A{APrefix: amhelp.ArgsToArgs(args, &ARpc{})}
-}
-
-// LogArgs is an args logger for A.
-func LogArgs(args am.A) map[string]string {
-	a := ParseArgs(args)
-	if a == nil {
-		return nil
-	}
-
-	return amhelp.ArgsToLogMap(a, 0)
 }
 
 // // DEBUG for perf testing TODO tag
@@ -444,7 +441,7 @@ type ExceptionHandler struct {
 var _ = ss.Exception
 
 func (h *ExceptionHandler) ExceptionEnter(e *am.Event) bool {
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 	mach := e.Machine()
 
 	isRpcClient := mach.Has(am.S{ssC.Disconnecting, ssC.Disconnected})

--- a/pkg/rpc/rpc_client.go
+++ b/pkg/rpc/rpc_client.go
@@ -528,12 +528,12 @@ func (c *Client) HandshakingState(e *am.Event) {
 var _ = ssC.HandshakeDone
 
 func (c *Client) HandshakeDoneEnter(e *am.Event) bool {
-	a := ParseArgs(e.Args)
+	a := am.ParseArgs[A](e.Args)
 	return a.Id != "" && a.MachTime != nil && a.QueueTick > 0
 }
 
 func (c *Client) HandshakeDoneState(e *am.Event) {
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[A](e.Args)
 
 	// finalize the worker init
 	netMach := c.NetMach
@@ -635,7 +635,7 @@ func (c *Client) ServerPayloadEnter(e *am.Event) bool {
 	if c.Consumer == nil {
 		return false
 	}
-	args := ParseArgs(e.Args)
+	args := am.ParseArgs[AServerPayload](e.Args)
 	argsOut := &A{Name: args.Name}
 
 	if args.Payload == nil {
@@ -649,8 +649,8 @@ func (c *Client) ServerPayloadEnter(e *am.Event) bool {
 }
 
 func (c *Client) ServerPayloadState(e *am.Event) {
-	args := ParseArgs(e.Args)
-	argsOut := &A{
+	args := am.ParseArgs[AServerPayload](e.Args)
+	argsOut := &AServerPayload{
 		Name:    args.Name,
 		Payload: args.Payload,
 	}
@@ -1260,7 +1260,7 @@ func (c *Client) RemoteSendingPayload(
 ) error {
 	// TODO test
 	c.log("RemoteSendingPayload %s", payload.Name)
-	c.Mach.Add1(ssC.ServerDelivering, Pass(&A{
+	c.Mach.Add1(ssC.ServerDelivering, Pass(&AServerPayload{
 		Payload: payload,
 		Name:    payload.Name,
 	}))
@@ -1275,7 +1275,7 @@ func (c *Client) RemoteSendPayload(
 	_ *rpc2.Client, payload *MsgSrvPayload, _ *MsgEmpty,
 ) error {
 	c.log("RemoteSendPayload %s:%s", payload.Name, payload.Token)
-	c.Mach.Add1(ssC.ServerPayload, Pass(&A{
+	c.Mach.Add1(ssC.ServerPayload, Pass(&AServerPayload{
 		Payload: payload,
 		Name:    payload.Name,
 	}))


### PR DESCRIPTION
The biggest gap of the library is now fixed in a short and generic way. Per-state structs open the doors to generating `CallSignagure`s easily but are especially useful in dealing with schemas extended on multiple levels. The new args are backward compatible with a single `A` struct (which by default belongs to `Any` state).

```go
// common def

const APrefix = "template"

type Args struct {
	am.ArgsBase `json:"-"`
}

func (Args) ArgsPrefix() string {
	return APrefix
}

// ----- per state def

type ABaz struct {
	// shared pkg args
	Args `json:"-"`
	// Address with logging.
	Addr string `log:"addr"`
}

func (ABaz) ArgsState() string {
	return ss.Baz
}
```
