### PR TITLE
refac(machine): move funcs into methods of `S` and `Schema`

### DIFF
--- a/pkg/machine/mach_utils.go
+++ b/pkg/machine/mach_utils.go
@@ -9,9 +9,11 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf8"
 )
 
@@ -20,65 +22,6 @@ import (
 // ///// PUB UTILS
 
 // ///// ///// /////
-
-// StatesDiff returns the states that are in states1 but not in states2.
-func StatesDiff(states1 S, states2 S) S {
-	// TODO optimize
-	return slicesFilter(states1, func(name string, i int) bool {
-		return !slices.Contains(states2, name)
-	})
-}
-
-// StatesShared return states present in both states1 and states2.
-func StatesShared(states1 S, states2 S) S {
-	return slicesFilter(states1, func(name string, i int) bool {
-		return slices.Contains(states2, name)
-	})
-}
-
-// StatesEqual returns true if states1 and states2 are equal, regardless of
-// order.
-func StatesEqual(states1 S, states2 S) bool {
-	return slicesEvery(states1, states2) && slicesEvery(states2, states1)
-}
-
-// SchemaClone deep clones the states struct and returns a copy.
-func SchemaClone(schema Schema) Schema {
-	ret := make(Schema)
-
-	for name, state := range schema {
-		ret[name] = cloneState(state)
-	}
-
-	return ret
-}
-
-func cloneState(state State) State {
-	stateCopy := State{
-		Auto:  state.Auto,
-		Multi: state.Multi,
-	}
-
-	// TODO move to Resolver
-
-	if state.Require != nil {
-		stateCopy.Require = slices.Clone(state.Require)
-	}
-	if state.Add != nil {
-		stateCopy.Add = slices.Clone(state.Add)
-	}
-	if state.Remove != nil {
-		stateCopy.Remove = slices.Clone(state.Remove)
-	}
-	if state.After != nil {
-		stateCopy.After = slices.Clone(state.After)
-	}
-	if state.Tags != nil {
-		stateCopy.Tags = slices.Clone(state.Tags)
-	}
-
-	return stateCopy
-}
 
 // IsActiveTick returns true if the tick represents an active state
 // (odd number).
@@ -128,9 +71,259 @@ func IsQueued(result Result) bool {
 	return result > Canceled
 }
 
-// SAdd concatenates multiple state lists into one, removing duplicates.
+// EnvLogLevel returns a log level from an environment variable, AM_LOG by
+// default.
+func EnvLogLevel(name string) LogLevel {
+	if name == "" {
+		name = EnvAmLog
+	}
+	v, _ := strconv.Atoi(os.Getenv(name))
+
+	return LogLevel(v)
+}
+
+// TODO prevent using these names as state names
+var handlerSuffixes = []string{
+	SuffixEnter, SuffixExit, SuffixState, SuffixEnd, StateAny,
+}
+
+// IsHandler checks if a method name is a handler method, by returning a state
+// name.
+func IsHandler(states S, method string) (string, string) {
+	if method == StateAny+SuffixEnter || method == StateAny+SuffixState {
+		return "", ""
+	}
+
+	// suffixes
+	for _, suffix := range handlerSuffixes {
+		if strings.HasSuffix(method, suffix) && len(method) != len(suffix) &&
+			method != StateAny+suffix {
+			return method[0 : len(method)-len(suffix)], ""
+		}
+	}
+
+	// AnyFoo
+	if strings.HasPrefix(method, StateAny) && len(method) != len(StateAny) &&
+		method != StateAny+SuffixState {
+
+		return method[len(StateAny):], ""
+	}
+
+	// FooBar
+	for _, s := range states {
+		if !strings.HasPrefix(method, s) {
+			continue
+		}
+
+		for _, ss := range states {
+			if s+ss == method {
+				return s, ss
+			}
+		}
+	}
+
+	return "", ""
+}
+
+// TestMockClock mocks the internal clock of the machine. Only for testing.
+func TestMockClock(mach *Machine, clock Clock) {
+	mach.clock = clock
+}
+
+// AMerge merges 2 or more maps into 1. Useful for passing args from many
+// packages.
+func AMerge[K comparable, V any](maps ...map[K]V) map[K]V {
+	out := map[K]V{}
+
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// ///// ///// /////
+
+// ///// STATE LIST
+
+// ///// ///// /////
+
+// S (state names) is a string list of state names.
+type S []string
+
+// FilterIndex returns a subset of S from specified indexes.
+func (s S) FilterIndex(idxs []int) S {
+	return IndexToStates(s, idxs)
+}
+
+// FilterPrefix returns all the states with a prefix.
+func (s S) FilterPrefix(prefix ...string) S {
+	ret := S{}
+	for _, p := range prefix {
+		ret = ret.Add(StatesWithPrefix(p, s))
+	}
+
+	return ret
+}
+
+// FilterMatch returns all the states matching a regexp.
+func (s S) FilterMatch(re *regexp.Regexp) S {
+	ret := S{}
+	for _, name := range s {
+		if re.MatchString(name) {
+			ret = append(ret, name)
+		}
+	}
+
+	return ret
+}
+
+// Prefix lists all states with a prefix.
+func (s S) Prefix(prefix string) S {
+	return StatesPrefix(prefix, s)
+}
+
+// Add concatenates multiple state lists into one, removing duplicates.
 // Useful for merging lists of states, eg a state group with other states
 // involved in a relation.
+func (s S) Add(states ...S) S {
+	if len(states) == 0 {
+		return s
+	}
+
+	states = append([]S{s}, states...)
+	return slicesUniq(slices.Concat(states...))
+}
+
+// Add1 is like [S.Add], but for single state names.
+func (s S) Add1(state ...string) S {
+	clone := slices.Clone(s)
+	states := append(clone, state...)
+	return slicesUniq(states)
+}
+
+// Delete removes states from all passed state groups.
+func (s S) Delete(states ...S) S {
+	return SRem(s, states...)
+}
+
+// Delete1 is like [S.Delete], but for single state names.
+func (s S) Delete1(states ...string) S {
+	return SRem(s, states)
+}
+
+// Sub returns the states from [s] that are missing in [other] (subtract).
+func (s S) Sub(other S) S {
+	return StatesDiff(s, other)
+}
+
+// Shared returns states present in both S and other (overlap).
+func (s S) Shared(other S) S {
+	return StatesShared(s, other)
+}
+
+// Equal returns true if states1 and states2 are equal, regardless of
+// order.
+func (s S) Equal(other S) bool {
+	return StatesEqual(s, other)
+}
+
+// EqualOrder is like [S.Equal], but also checks the order of states.
+func (s S) EqualOrder(other S) bool {
+	if len(s) != len(other) {
+		return false
+	}
+
+	for i := range s {
+		if s[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Index returns an index of passed [states]. Unknown states are
+// represented by -1.
+func (s S) Index(states S) []int {
+	return StatesToIndex(s, states)
+}
+
+func (s S) Hash() string {
+	return Hash(strings.Join(s, ","), 4)
+}
+
+// ----- old
+
+// IndexToStates is deprecated, use [S.FilterIndex].
+func IndexToStates(index S, states []int) S {
+	ret := make(S, len(states))
+	for i := range states {
+		name := "unknown" + strconv.Itoa(states[i])
+		if len(index) > states[i] && states[i] != -1 {
+			name = index[states[i]]
+		}
+		ret[i] = name
+	}
+
+	return ret
+}
+
+// StatesToIndex is deprecated, use [S.Index].
+func StatesToIndex(index S, states S) []int {
+	ret := make([]int, len(states))
+	for i := range states {
+		ret[i] = slices.Index(index, states[i])
+	}
+
+	return ret
+}
+
+// StatesDiff is deprecated, use [S.Sub].
+func StatesDiff(states1 S, states2 S) S {
+	// TODO optimize
+	return slicesFilter(states1, func(name string, i int) bool {
+		return !slices.Contains(states2, name)
+	})
+}
+
+// StatesShared is deprecated, use [S.Shared].
+func StatesShared(states1 S, states2 S) S {
+	return slicesFilter(states1, func(name string, i int) bool {
+		return slices.Contains(states2, name)
+	})
+}
+
+// StatesEqual is deprecated, use [S.Equal].
+func StatesEqual(states1 S, states2 S) bool {
+	return slicesEvery(states1, states2) && slicesEvery(states2, states1)
+}
+
+// StatesPrefix is deprecated, use [S.Prefix].
+func StatesPrefix(prefix string, states S) S {
+	ret := make(S, len(states))
+	for i, name := range states {
+		ret[i] = prefix + name
+	}
+
+	return ret
+}
+
+// StatesWithPrefix is deprecated, use [S.FilterPrefix].
+func StatesWithPrefix(prefix string, states S) S {
+	ret := S{}
+	for _, name := range states {
+		if strings.HasPrefix(name, prefix) {
+			ret = append(ret, name)
+		}
+	}
+
+	return ret
+}
+
+// SAdd is deprecated, use [S.Add].
 func SAdd(states ...S) S {
 	// TODO test
 	// TODO move to resolver
@@ -164,22 +357,92 @@ func SRem(src S, states ...S) S {
 	return s
 }
 
-// StateAdd adds new states to relations of the source state, without
+// ///// ///// /////n
+
+// ///// SCHEMA
+
+// ///// ///// /////
+
+// ----- STATE
+
+// State defines a single state of a machine, its properties, relations, and tags.
+// nolint:lll
+type State struct {
+	Auto    bool     `json:"auto,omitempty" yaml:"auto,omitempty" toml:"auto,omitempty"`
+	Multi   bool     `json:"multi,omitempty" yaml:"multi,omitempty" toml:"multi,omitempty"`
+	Require S        `json:"require,omitempty" yaml:"require,omitempty" toml:"require,omitempty"`
+	Add     S        `json:"add,omitempty" yaml:"add,omitempty" toml:"add,omitempty"`
+	Remove  S        `json:"remove,omitempty" yaml:"remove,omitempty" toml:"remove,omitempty"`
+	After   S        `json:"after,omitempty" yaml:"after,omitempty" toml:"after,omitempty"`
+	Tags    []string `json:"tags,omitempty" yaml:"tags,omitempty" toml:"tags,omitempty"`
+}
+
+// Extend adds new states to relations of the source state, without
 // removing existing ones. Useful for adjusting shared stated to a specific
 // machine. Only "true" values for Auto and Multi are applied from [overlay].
 //
-//	ssS.HandshakeDone: StateAdd(
-//		SharedSchema[ssS.HandshakeDone],
+//	ssS.HandshakeDone: SharedSchema[ssS.HandshakeDone].Extend(
 //		am.State{
 //			Require: S{ssS.ClientConnected},
 //			Remove: S{Exception},
 //		}),
+func (s State) Extend(overlay State) State {
+	return StateAdd(s, overlay)
+}
+
+// Set replaces passed relations and properties of the source state.
+// Only relations in the overlay state are replaced, the rest is preserved.
+// If [overlay] has all fields `nil`, then only [auto] and [multi] get applied.
+//
+//	 ssS.HandshakeDone: s.Set(false, true, State{
+//			Remove: S{"C"},
+//		})
+func (s State) Set(auto, multi bool, overlay State) State {
+	return StateSet(s, auto, multi, overlay)
+}
+
+// SetRels is like [State.Set], but inherits properties (Auto, Multi).
+func (s State) SetRels(overlay State) State {
+	return StateSet(s, s.Auto, s.Multi, overlay)
+}
+
+func (s State) Clone() State {
+	stateCopy := State{
+		Auto:  s.Auto,
+		Multi: s.Multi,
+	}
+
+	if s.Require != nil {
+		stateCopy.Require = slices.Clone(s.Require)
+	}
+	if s.Add != nil {
+		stateCopy.Add = slices.Clone(s.Add)
+	}
+	if s.Remove != nil {
+		stateCopy.Remove = slices.Clone(s.Remove)
+	}
+	if s.After != nil {
+		stateCopy.After = slices.Clone(s.After)
+	}
+	if s.Tags != nil {
+		stateCopy.Tags = slices.Clone(s.Tags)
+	}
+
+	return stateCopy
+}
+
+func (s State) HasTag(tag string) bool {
+	return slices.Contains(s.Tags, tag)
+}
+
+// ----- old
+
+// StateAdd is deprecated, use [State.Extend].
 func StateAdd(source State, overlay State) State {
 	// TODO example
 	// TODO test
-	// TODO move to resolver?
-	s := cloneState(source)
-	o := cloneState(overlay)
+	s := source.Clone()
+	o := overlay.Clone()
 
 	if o.Auto {
 		s.Auto = true
@@ -205,19 +468,12 @@ func StateAdd(source State, overlay State) State {
 	return s
 }
 
-// StateSet replaces passed relations and properties of the source state.
-// Only relations in the overlay state are replaced, the rest is preserved.
-// If [overlay] has all fields `nil`, then only [auto] and [multi] get applied.
-//
-//	 ssS.HandshakeDone: StateSet(s, false, true, State{
-//			Remove: S{"C"},
-//		})
+// StateSet is Deprecated, use [State.Set].
 func StateSet(source State, auto, multi bool, overlay State) State {
 	// TODO example
 	// TODO test
-	// TODO move to resolver?
-	s := cloneState(source)
-	o := cloneState(overlay)
+	s := source.Clone()
+	o := overlay.Clone()
 
 	// properties
 	s.Auto = auto
@@ -240,9 +496,14 @@ func StateSet(source State, auto, multi bool, overlay State) State {
 	return s
 }
 
-// SchemaMerge merges multiple state structs into one, overriding the previous
+// ----- SCHEMA
+
+// Schema is a map of state names to state definitions.
+type Schema map[string]State
+
+// Merge merges multiple state structs into one, overriding the previous
 // state definitions. No relation-level merging takes place.
-func SchemaMerge(schemas ...Schema) Schema {
+func (s Schema) Merge(schemas ...Schema) Schema {
 	// TODO mark all-but-last states as Inherited?
 	// TODO example
 	// TODO test
@@ -250,50 +511,25 @@ func SchemaMerge(schemas ...Schema) Schema {
 	l := len(schemas)
 	switch l {
 	case 0:
-		return Schema{}
-	case 1:
-		return schemas[0]
+		return s
 	}
 
-	ret := make(Schema)
+	ret := s.Clone()
 	for i := 0; i < l; i++ {
-		// TODO clone?
 		maps.Copy(ret, schemas[i])
 	}
 
-	return SchemaClone(ret)
+	return ret.Clone()
 }
 
-// StatesPrefix prefixes all the states with a prefix.
-func StatesPrefix(prefix string, states S) S {
-	ret := make(S, len(states))
-	for i, name := range states {
-		ret[i] = prefix + name
-	}
-
-	return ret
-}
-
-// StatesWithPrefix lists all states with a prefix.
-func StatesWithPrefix(prefix string, states S) S {
-	ret := S{}
-	for _, name := range states {
-		if strings.HasPrefix(name, prefix) {
-			ret = append(ret, name)
-		}
-	}
-
-	return ret
-}
-
-// SchemaPrefix will prefix all state names with [prefix]. removeDups will skip
+// Prefix will prefix all state names with [prefix]. removeDups will skip
 // overlaps eg "FooFooName" will be "Foo".
-func SchemaPrefix(
-	schema Schema, prefix string, removeDups bool, optAllowlist, optSkiplist S,
+func (s Schema) Prefix(
+	prefix string, removeDups bool, optAllowlist, optSkiplist S,
 ) Schema {
-	ret := SchemaClone(schema)
-	for name, s := range schema {
-		s = cloneState(s)
+	ret := Schema{}
+	for name, s := range s {
+		s = s.Clone()
 
 		if len(optAllowlist) > 0 && !slices.Contains(optAllowlist, name) {
 			continue
@@ -342,216 +578,26 @@ func SchemaPrefix(
 	return ret
 }
 
-// EnvLogLevel returns a log level from an environment variable, AM_LOG by
-// default.
-func EnvLogLevel(name string) LogLevel {
-	if name == "" {
-		name = EnvAmLog
-	}
-	v, _ := strconv.Atoi(os.Getenv(name))
+// Clone deep clones the states struct and returns a copy.
+func (s Schema) Clone() Schema {
+	ret := make(Schema)
 
-	return LogLevel(v)
-}
-
-// ListHandlers returns a list of handler method names from a handler struct,
-// limited to [states].
-func ListHandlers(handlers any, states S) ([]string, error) {
-	var methodNames []string
-	var errs []error
-
-	check := func(method string) {
-		s1, s2 := IsHandler(states, method)
-		if s1 != "" && !slices.Contains(states, s1) {
-			errs = append(errs, fmt.Errorf(
-				"%w: %s from handler %s", ErrStateMissing, s1, method))
-		}
-		if s2 != "" && !slices.Contains(states, s2) {
-			errs = append(errs, fmt.Errorf(
-				"%w: %s from handler %s", ErrStateMissing, s2, method))
-		}
-
-		if s1 != "" || method == StateAny+SuffixEnter ||
-			method == StateAny+SuffixState {
-
-			methodNames = append(methodNames, method)
-			// TODO verify method signatures early (returns and params)
-		}
-	}
-
-	// methods
-	t := reflect.TypeOf(handlers)
-	for i := 0; i < t.NumMethod(); i++ {
-		method := t.Method(i).Name
-		check(method)
-	}
-
-	// fields
-	val := reflect.ValueOf(handlers).Elem()
-	typ := val.Type()
-	for i := 0; i < val.NumField(); i++ {
-		kind := typ.Field(i).Type.Kind()
-		if kind != reflect.Func {
-			continue
-		}
-		method := typ.Field(i).Name
-		check(method)
-	}
-
-	return methodNames, errors.Join(errs...)
-}
-
-// TODO prevent using these names as state names
-var handlerSuffixes = []string{
-	SuffixEnter, SuffixExit, SuffixState, SuffixEnd, StateAny,
-}
-
-// IsHandler checks if a method name is a handler method, by returning a state
-// name.
-func IsHandler(states S, method string) (string, string) {
-	if method == StateAny+SuffixEnter || method == StateAny+SuffixState {
-		return "", ""
-	}
-
-	// suffixes
-	for _, suffix := range handlerSuffixes {
-		if strings.HasSuffix(method, suffix) && len(method) != len(suffix) &&
-			method != StateAny+suffix {
-			return method[0 : len(method)-len(suffix)], ""
-		}
-	}
-
-	// AnyFoo
-	if strings.HasPrefix(method, StateAny) && len(method) != len(StateAny) &&
-		method != StateAny+SuffixState {
-
-		return method[len(StateAny):], ""
-	}
-
-	// FooBar
-	for _, s := range states {
-		if !strings.HasPrefix(method, s) {
-			continue
-		}
-
-		for _, ss := range states {
-			if s+ss == method {
-				return s, ss
-			}
-		}
-	}
-
-	return "", ""
-}
-
-// MockClock mocks the internal clock of the machine. Only for testing.
-func MockClock(mach *Machine, clock Clock) {
-	mach.clock = clock
-}
-
-// AMerge merges 2 or more maps into 1. Useful for passing args from many
-// packages.
-func AMerge[K comparable, V any](maps ...map[K]V) map[K]V {
-	out := map[K]V{}
-
-	for _, m := range maps {
-		for k, v := range m {
-			out[k] = v
-		}
-	}
-
-	return out
-}
-
-// IndexToTime returns "virtual time" with selected states active. It's useful
-// to use time methods on a list of states, eg the called ones.
-func IndexToTime(index S, active []int) Time {
-	ret := make(Time, len(index))
-	for _, i := range active {
-		ret[i] = 1
+	for name, state := range s {
+		ret[name] = state.Clone()
 	}
 
 	return ret
 }
 
-// IndexToStates decodes state indexes based on the provided index.
-func IndexToStates(index S, states []int) S {
-	ret := make(S, len(states))
-	for i := range states {
-		name := "unknown" + strconv.Itoa(states[i])
-		if len(index) > states[i] && states[i] != -1 {
-			name = index[states[i]]
-		}
-		ret[i] = name
-	}
-
-	return ret
-}
-
-// StatesToIndex returns a subset of [index] that matches [states]. Unknown
-// states are represented by -1.
-func StatesToIndex(index S, states S) []int {
-	ret := make([]int, len(states))
-	for i := range states {
-		ret[i] = slices.Index(index, states[i])
-	}
-
-	return ret
-}
-
-// ///// ///// /////
-
-// ///// UTILS
-
-// ///// ///// /////
-
-// truncateStr with shorten the string and leave a tripedot suffix.
-func truncateStr(s string, maxLength int) string {
-	if len(s) <= maxLength {
-		return s
-	}
-	if maxLength < 5 {
-		return s[:maxLength]
-	} else {
-		return s[:maxLength-3] + "..."
-	}
-}
-
-// j joins state names into a single string
-func j(states []string) string {
-	return strings.Join(states, " ")
-}
-
-// jw joins state names into a single string with a separator.
-func jw(states []string, sep string) string {
-	return strings.Join(states, sep)
-}
-
-func closeSafe[T any](ch chan T) {
-	select {
-	case <-ch:
-	default:
-		close(ch)
-	}
-}
-
-func padString(str string, length int, pad string) string {
-	for {
-		str += pad
-		if len(str) > length {
-			return str[0:length]
-		}
-	}
-}
-
-func ParseSchema(schema Schema) (Schema, error) {
-	// TODO move to Resolver
+// Parse sanitizes the schema and returns potential errors.
+func (s Schema) Parse() (Schema, error) {
 	// TODO capitalize states
 	// TODO ErrFoo must require Exception
 
-	parsed := SchemaClone(schema)
-	states := slices.Collect(maps.Keys(schema))
+	parsed := s.Clone()
+	states := slices.Collect(maps.Keys(s))
 	var errs error
-	for name, state := range schema {
+	for name, state := range s {
 
 		// avoid self removal
 		if slices.Contains(state.Remove, name) {
@@ -604,6 +650,250 @@ func ParseSchema(schema Schema) (Schema, error) {
 	}
 
 	return parsed, errs
+}
+
+// FilterByTag returns a subset schema with states having the given tag.
+func (s Schema) FilterByTag(tag string) Schema {
+	ret := Schema{}
+	for name, state := range s {
+		if slices.Contains(state.Tags, tag) {
+			ret[name] = state
+		}
+	}
+
+	return ret
+}
+
+// Names is a random-order list of defined state names.
+func (s Schema) Names() S {
+	return slices.Collect(maps.Keys(s))
+}
+
+// ----- old
+
+// SchemaMerge is deprecated, use [Schema.Merge].
+func SchemaMerge(schemas ...Schema) Schema {
+	l := len(schemas)
+	switch l {
+	case 0:
+		return Schema{}
+	case 1:
+		return schemas[0]
+	}
+
+	ret := make(Schema)
+	for i := 0; i < l; i++ {
+		// TODO clone?
+		maps.Copy(ret, schemas[i])
+	}
+
+	return ret.Clone()
+}
+
+// ///// ///// /////
+
+// ///// HANDLERS
+
+// ///// ///// /////
+
+// handler represents a list of transition handler methods.
+type handler struct {
+	id  string
+	num int
+	// map-based handler
+	isMap bool
+	mx    sync.Mutex
+	opts  *BindOpts
+
+	// maps
+	negotiations map[string]HandlerNegotiation
+	finals       map[string]HandlerFinal
+
+	// reflect
+	h            any
+	methods      *reflect.Value
+	methodCache  map[string]reflect.Value
+	missingCache map[string]struct{}
+}
+
+// BindOpts define how the methods are bound to the state machine. Optional.
+type BindOpts struct {
+	// Id of this binding, optional.
+	Id string
+	// method name will have this prefix removed
+	MethodPrefixTrim string
+	// only states with this prefix
+	StatePrefix string
+}
+
+type handlerCall struct {
+	fn *reflect.Value
+	// TODO debug only
+	name        string
+	negotiation HandlerNegotiation
+	final       HandlerFinal
+	event       *Event
+	timeout     bool
+}
+
+func (c *handlerCall) Exec() bool {
+	ret := true
+	if c.fn != nil {
+		callRet := c.fn.Call([]reflect.Value{reflect.ValueOf(c.event)})
+		if len(callRet) > 0 {
+			// TODO log err?
+			ret, _ = callRet[0].Interface().(bool)
+		}
+	} else if c.negotiation != nil {
+		ret = c.negotiation(c.event)
+	} else if c.final != nil {
+		c.final(c.event)
+	} else {
+		panic("invalid handler call " + c.name)
+	}
+
+	return ret
+}
+
+func newHandlerCallStruct(
+	e *Event, h *handler, methodName string, m *Machine,
+) *handlerCall {
+	//
+
+	// cache
+	_, ok := h.missingCache[methodName]
+	if ok {
+		h.mx.Unlock()
+
+		return nil
+	}
+	method, ok := h.methodCache[methodName]
+	if !ok {
+		method = h.methods.MethodByName(methodName)
+
+		// support field handlers
+		if !method.IsValid() {
+			method = h.methods.Elem().FieldByName(methodName)
+		}
+		if !method.IsValid() {
+			h.missingCache[methodName] = struct{}{}
+			h.mx.Unlock()
+
+			return nil
+		}
+		h.methodCache[methodName] = method
+	}
+	h.mx.Unlock()
+
+	// call the handler
+	m.log(LogOps, "[handler:%d] %s", h.num, methodName)
+	m.currentHandler.Store(methodName)
+
+	// tracers
+	m.tracersMx.RLock()
+	for i := range m.tracers {
+		m.tracers[i].HandlerStart(m.t.Load(), h.id, methodName)
+	}
+	m.tracersMx.RUnlock()
+
+	return &handlerCall{
+		fn:      &method,
+		name:    methodName,
+		event:   e,
+		timeout: false,
+	}
+}
+
+func newHandlerCallMap(
+	e *Event, h *handler, methodName string, m *Machine,
+) *handlerCall {
+	//
+
+	isFinal := strings.HasSuffix(methodName, SuffixState) ||
+		strings.HasSuffix(methodName, SuffixEnd)
+
+	if isFinal {
+		if _, ok := h.finals[methodName]; !ok {
+			h.mx.Unlock()
+			return nil
+		}
+	} else {
+		if _, ok := h.negotiations[methodName]; !ok {
+			h.mx.Unlock()
+			return nil
+		}
+	}
+	h.mx.Unlock()
+
+	// call the handler
+	m.log(LogOps, "[handler:%d] %s", h.num, methodName)
+	m.currentHandler.Store(methodName)
+
+	// tracers
+	m.tracersMx.RLock()
+	for i := range m.tracers {
+		m.tracers[i].HandlerStart(m.t.Load(), h.id, methodName)
+	}
+	m.tracersMx.RUnlock()
+
+	call := &handlerCall{
+		name:    methodName,
+		event:   e,
+		timeout: false,
+	}
+
+	if isFinal {
+		call.final = h.finals[methodName]
+	} else {
+		call.negotiation = h.negotiations[methodName]
+	}
+
+	return call
+}
+
+// ///// ///// /////
+
+// ///// UTILS
+
+// ///// ///// /////
+
+// truncateStr with shorten the string and leave a tripedot suffix.
+func truncateStr(s string, maxLength int) string {
+	if len(s) <= maxLength {
+		return s
+	}
+	if maxLength < 5 {
+		return s[:maxLength]
+	} else {
+		return s[:maxLength-3] + "..."
+	}
+}
+
+// j joins state names into a single string
+func j(states []string) string {
+	return strings.Join(states, " ")
+}
+
+// jw joins state names into a single string with a separator.
+func jw(states []string, sep string) string {
+	return strings.Join(states, sep)
+}
+
+func closeSafe[T any](ch chan T) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
+func padString(str string, length int, pad string) string {
+	for {
+		str += pad
+		if len(str) > length {
+			return str[0:length]
+		}
+	}
 }
 
 // compareArgs return true if args2 is a subset of args1.


### PR DESCRIPTION
This should make schema overloads and processing easier. Some new ones were also added, like `schema.FilterByTag("foo")` or

```go
schema1["Foo"] = schema2["Foo"].SetRels(am.State{
  Remove: states,
})
```