### PR TITLE
feat(am-dbg): unify diagram viewer for graph, mach, state, steps

### DIFF
--- a/tools/debugger/dbg_handlers.go
+++ b/tools/debugger/dbg_handlers.go
@@ -197,9 +197,10 @@ func (d *Debugger) ReadyState(e *am.Event) {
 		d.Mach.EvAdd1(e, ss.UserNarrowLayout, nil)
 	}
 	d.hSyncOptsTimelines()
-	if d.params.OutputDiagrams.Value > 0 {
-		d.Mach.EvAdd1(e, ss.DiagramsScheduled, nil)
-	}
+	// TODO merge mut once partial acceptance lands
+	d.Mach.EvAdd1(e, ss.DiagramsGraphRendering, nil)
+	d.Mach.EvAdd1(e, ss.DiagramsMachRendering, nil)
+	d.Mach.EvAdd1(e, ss.DiagramsStatesRendering, nil)
 	if d.params.ViewRain {
 		d.Mach.EvAdd1(e, ss.MatrixRain, nil)
 	}
@@ -265,9 +266,12 @@ func (d *Debugger) StateNameSelectedEnter(e *am.Event) bool {
 }
 
 func (d *Debugger) StateNameSelectedState(e *am.Event) {
+	state := am.ParseArgs[A](e.Args).State
 	ctx := d.Mach.NewStateCtx(ss.StateNameSelected)
-	d.C.SelectedState = am.ParseArgs[A](e.Args).State
-	d.lastSelectedState = d.C.SelectedState
+	c := d.C
+
+	c.SelectedState = state
+	d.selectedState.Store(&c.SelectedState)
 
 	switch d.Mach.Switch(states.DebuggerGroups.Views) {
 
@@ -283,21 +287,32 @@ func (d *Debugger) StateNameSelectedState(e *am.Event) {
 	}
 
 	d.hUpdateStatusBar()
-	d.Mach.Fork(ctx, e, func() {
-		amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
+
+	// diagrams TODO merged mutation once partial negotiation lands
+	d.Mach.GoAfter(ctx, time.Second, func() {
+		if err := d.diagramsMachUpdating(ctx); err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+	})
+	d.Mach.GoAfter(ctx, time.Second, func() {
+		if err := d.diagramsStateUpdating(ctx); err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
 	})
 }
 
 func (d *Debugger) StateNameSelectedEnd(e *am.Event) {
-	ctx := d.Mach.NewStateCtx(ss.Start)
 	if d.C != nil {
 		d.C.SelectedState = ""
+		// diagrams
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams,
+			d.diagramsMachUpdating(d.Mach.NewStateCtx(ss.StateNameSelected)), nil)
 	}
+	d.selectedState.Store(new(string))
 	d.hUpdateSchemaTree()
 	d.hUpdateStatusBar()
-	d.Mach.Fork(ctx, e, func() {
-		amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
-	})
 }
 
 var _ = ss.Playing
@@ -672,7 +687,7 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 	}
 
 	// re-select the last group
-	if g := d.lastSelectedGroup; g != "" {
+	if g := *d.selectedGroup.Load(); g != "" {
 		if _, ok := c.MsgStruct.Groups[g]; ok {
 			c.SelectedGroup = g
 		}
@@ -729,12 +744,12 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 		d.hPrependHistory(&types.MachAddress{MachId: msg.ID})
 
 		// re-select the state
-		if d.lastSelectedState != "" {
+		if selected := *d.selectedState.Load(); selected != "" {
 			d.Mach.EvAdd1(e, ss.StateNameSelected, Pass(&A{
-				State: d.lastSelectedState,
+				State: selected,
 			}))
 			// TODO Keep in StateNameSelected behind a flag
-			d.hSelectTreeState(d.lastSelectedState)
+			d.hSelectTreeState(selected)
 		}
 	}
 
@@ -755,6 +770,11 @@ func (d *Debugger) ConnectEventState(e *am.Event) {
 		Id: msg.ID,
 	}))
 
+	// update graph
+	d.hUpdateGraphHash()
+	// TODO use Add relation once partial negotiation lands
+	d.Mach.EvAdd1(e, ss.DiagramsGraphRendering, nil)
+
 	d.draw()
 }
 
@@ -770,6 +790,8 @@ func (d *Debugger) DisconnectEventEnter(e *am.Event) bool {
 }
 
 func (d *Debugger) DisconnectEventState(e *am.Event) {
+	d.hUpdateGraphHash()
+
 	connID := am.ParseArgs[A](e.Args).ConnId
 	for _, c := range d.Clients {
 		if c.ConnId != "" && c.ConnId == connID {
@@ -961,7 +983,9 @@ func (d *Debugger) RemoveClientEnter(e *am.Event) bool {
 }
 
 func (d *Debugger) RemoveClientState(e *am.Event) {
-	d.Mach.EvRemove1(e, ss.RemoveClient, nil)
+	// TODO use Add relation once partial negotiation lands
+	d.Mach.EvAdd1(e, ss.DiagramsGraphRendering, nil)
+
 	cid := am.ParseArgs[A](e.Args).ClientId
 	c := d.Clients[cid]
 
@@ -1013,14 +1037,20 @@ func (d *Debugger) SetGroupState(e *am.Event) {
 	} else {
 		c.SelectedGroup = strings.Split(group, ":")[0]
 	}
-	d.lastSelectedGroup = c.SelectedGroup
+	d.selectedGroup.Store(&c.SelectedGroup)
 	d.hBuildSchemaTree()
 	d.hUpdateSchemaTree()
-	go amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
+	// TODO merge once partial negotiation lands
+	d.Mach.EvAdd1(e, ss.DiagramsMachRendering, nil)
+	d.Mach.EvAdd1(e, ss.DiagramsStatesRendering, nil)
 	d.Mach.EvAdd(e, am.S{ss.ToolToggled, ss.UpdateLogScheduled}, Pass(&A{
 		FilterTxs:     true,
 		LogRebuildEnd: len(c.MsgTxs),
 	}))
+	d.diagSkipGroup.Store(new(string))
+	if d.params.OutputDiagGroup == types.ParamsOutDiagGroupSkip {
+		d.diagSkipGroup.Store(&group)
+	}
 }
 
 var _ = ss.SelectingClient
@@ -1039,10 +1069,10 @@ func (d *Debugger) SelectingClientEnter(e *am.Event) bool {
 
 func (d *Debugger) SelectingClientState(e *am.Event) {
 	// TODO support tx ID
-	sArgs := am.ParseArgs[A](e.Args)
-	clientID := sArgs.ClientId
-	group := sArgs.Group
-	fromConnected := sArgs.FromConnected
+	args := am.ParseArgs[A](e.Args)
+	clientID := args.ClientId
+	group := args.Group
+	fromConnected := args.FromConnected
 	fromPlaying := slices.Contains(e.Transition().StatesBefore(), ss.Playing)
 
 	if d.Clients[clientID] == nil {
@@ -1059,7 +1089,10 @@ func (d *Debugger) SelectingClientState(e *am.Event) {
 	logRebuildEnd := len(d.C.LogMsgs)
 	// remain in TailMode after the selection
 	wasTailMode := slices.Contains(e.Transition().StatesBefore(), ss.TailMode)
-	d.C.SelectedGroup = group
+
+	if group != "" {
+		d.C.SelectedGroup = group
+	}
 
 	// TODO extract SelectingClientFiltered
 	// TODO Remove selecting with a timeout (in case it fails)
@@ -1086,11 +1119,9 @@ func (d *Debugger) SelectingClientState(e *am.Event) {
 				return // expired
 			}
 
-		} else {
-			// [hSetCursor1] triggers DiagramsScheduled, so do we
-			// TODO optimize: push diagram after the initial rendering
-			go amhelp.AskEvAdd1(e, d.Mach, ss.DiagramsScheduled, nil)
 		}
+
+		// TODO diagrams?
 
 		// scroll client list item into view
 		selOffset := d.hGetSidebarCurrClientIdx()
@@ -1128,6 +1159,10 @@ func (d *Debugger) ClientSelectedState(e *am.Event) {
 		return // expired
 	}
 
+	// TODO merge once partial negotiation lands
+	d.Mach.EvAdd1(e, ss.DiagramsMachRendering, nil)
+	d.Mach.EvAdd1(e, ss.DiagramsStatesRendering, nil)
+
 	// catch up with new log msgs
 	for i := max(0, d.logRebuildEnd-1); i < len(d.C.LogMsgs); i++ {
 		err := d.hAppendLogEntry(i)
@@ -1162,13 +1197,15 @@ func (d *Debugger) ClientSelectedState(e *am.Event) {
 	}
 
 	// re-select the state
-	if d.lastSelectedState != "" {
+	if selected := *d.selectedState.Load(); selected != "" {
 		d.Mach.EvAdd1(e, ss.StateNameSelected, Pass(&A{
-			State: d.lastSelectedState,
+			State: selected,
 		}))
 		// TODO Keep in StateNameSelected behind a flag
-		d.hSelectTreeState(d.lastSelectedState)
+		d.hSelectTreeState(selected)
 	}
+	d.selectedClient.Store(&d.C.Id)
+	d.selectedSchemaHash.Store(&d.C.MsgSchemaParsed.Hash)
 
 	d.hUpdateBorderColor()
 	d.hUpdateAddressBar()
@@ -1181,6 +1218,8 @@ func (d *Debugger) ClientSelectedEnd(e *am.Event) {
 	if !e.Mutation().IsCalled(idx) {
 		d.C = nil
 	}
+	d.selectedClient.Store(new(string))
+	d.selectedSchemaHash.Store(new(string))
 
 	d.log.Clear()
 	d.treeRoot.ClearChildren()
@@ -1450,7 +1489,7 @@ func (d *Debugger) ToggleToolState(e *am.Event) {
 		case types.ParamsOutputDiagramsThree:
 			d.params.OutputDiagrams = types.ParamsOutputDiagramsNone
 		}
-		d.Mach.EvAdd1(e, ss.DiagramsScheduled, nil)
+		d.Mach.EvAdd(e, S{ss.DiagramsGraphRendering, ss.DiagramsMachRendering}, nil)
 
 	case types.ToolDiagramsSteps:
 		d.params.OutputTx = !d.params.OutputTx
@@ -1477,7 +1516,20 @@ func (d *Debugger) ToggleToolState(e *am.Event) {
 		case types.ParamsOutDiagTxRelations:
 			d.params.OutputDiagTx = types.ParamsOutDiagTxNone
 		}
-		d.Mach.EvAdd1(e, ss.DiagramsScheduled, nil)
+
+		// render
+		if d.params.OutputDiagrams != types.ParamsOutputDiagramsNone {
+			_ = d.hInitDiagFiles()
+			d.Mach.EvAdd1(e, ss.DiagramsGraphRendering, nil)
+			d.Mach.EvAdd1(e, ss.DiagramsMachRendering, nil)
+			d.Mach.EvAdd1(e, ss.DiagramsStatesRendering, nil)
+			if tx := d.hCurrentTx(); tx != nil {
+				ctx := am.EvToCtx(d.Mach.Context(), e)
+				d.hDiagramsStepsRendering(ctx, tx, d.hCurrentTxParsed())
+			}
+		} else {
+			d.hCloseDiagFiles()
+		}
 
 	case types.ToolDiagramsGroup:
 		switch d.params.OutputDiagGroup {
@@ -1488,7 +1540,7 @@ func (d *Debugger) ToggleToolState(e *am.Event) {
 		case types.ParamsOutDiagGroupSkip:
 			d.params.OutputDiagGroup = types.ParamsOutDiagGroupNone
 		}
-		d.Mach.EvAdd1(e, ss.DiagramsScheduled, nil)
+		d.Mach.EvAdd1(e, ss.DiagramsMachRendering, nil)
 
 	case types.ToolCallLog:
 		d.params.OutputCallLog = !d.params.OutputCallLog
@@ -1931,159 +1983,6 @@ func (d *Debugger) SetCursorState(e *am.Event) {
 	d.hSetCursor1(e, am.ParseArgs[A](e.Args))
 }
 
-// func (d *Debugger) CursorSetState(e *am.Event) {
-// }
-
-var _ = ss.DiagramsScheduled
-
-func (d *Debugger) DiagramsScheduledEnter(e *am.Event) bool {
-	// TODO refuse on too many ErrDiagrams, remove ErrDiagrams in ErrDiagramsState
-	return d.C != nil && d.params.OutputDiagrams != types.ParamsOutputDiagramsNone
-}
-
-func (d *Debugger) DiagramsScheduledState(e *am.Event) {
-	// TODO cancel rendering on:
-	//  - client change
-	//  - details change
-	//  - but not on tx change (wait until completed)
-	d.Mach.EvAdd1(e, ss.DiagramsRendering, nil)
-}
-
-var _ = ss.DiagramsRendering
-
-func (d *Debugger) DiagramsRenderingEnter(e *am.Event) bool {
-	return d.params.OutputDiagrams.Value > 0 && d.C != nil
-}
-
-func (d *Debugger) DiagramsRenderingState(e *am.Event) {
-	ctx := d.Mach.NewStateCtx(ss.DiagramsRendering)
-	lvl := d.params.OutputDiagrams.Value
-	diagDir := path.Join(d.params.OutputDir, "diagrams")
-	c := d.C
-	tx := d.hCurrentTx()
-	svgName := fmt.Sprintf("%s-%d-%s", c.Id, lvl, c.SchemaHash)
-
-	// state groups
-	var states S
-	if g := c.SelectedGroup; g != "" &&
-		d.params.OutputDiagGroup == types.ParamsOutDiagGroupSkip {
-
-		states = c.MsgSchemaParsed.Groups[g]
-		svgName = fmt.Sprintf("%s-%s-%d-%s",
-			c.Id, types.NormalizeGroupName(g), lvl, c.SchemaHash)
-	}
-	svgPath := filepath.Join(diagDir, svgName+".svg")
-
-	// output dir
-	if err := os.MkdirAll(diagDir, 0o755); err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams,
-			fmt.Errorf("create output dir: %w", err), nil)
-	}
-
-	// cached?
-
-	// build update fragment
-	index := c.MsgStruct.StatesIndex
-	diagFilters := &amvis.Filters{
-		MachId:   c.Id,
-		Index:    index,
-		Selected: am.S{d.C.SelectedState},
-	}
-	if tx != nil {
-		diagFilters.Active = tx.ActiveStates(index)
-
-		// dim
-		if d.params.OutputDiagTx != types.ParamsOutDiagTxNone {
-			parsed := c.MsgTxsParsed[c.CursorTx1-1]
-			showIdxs := tx.CalledStatesIdxs
-			switch d.params.OutputDiagTx {
-			case types.ParamsOutDiagTxMutated:
-				showIdxs = slices.Concat(parsed.StatesAdded, parsed.StatesRemoved)
-			case types.ParamsOutDiagTxTouched:
-				fallthrough
-			case types.ParamsOutDiagTxRelations:
-				showIdxs = parsed.StatesTouched
-			}
-			diagFilters.Highlighted = c.IndexesToStates(showIdxs)
-		}
-
-		// collect touched rels TODO add to step timeline 1-by-1
-		if d.params.OutputDiagTx == types.ParamsOutDiagTxRelations {
-			for _, step := range tx.Steps {
-				if step.Type != am.StepRelation {
-					continue
-				}
-
-				diagFilters.HighlightedRels = append(diagFilters.HighlightedRels,
-					[3]string{
-						step.GetFromState(index),
-						step.GetToState(index),
-						step.RelType.String(),
-					})
-			}
-		}
-	}
-	if d.params.OutputDiagGroup == types.ParamsOutDiagGroupHide &&
-		c.SelectedGroup != "" {
-
-		diagFilters.Visible = c.MsgSchemaParsed.Groups[c.SelectedGroup]
-	}
-
-	// mem cache
-	if d.cache.diagramName == svgName {
-		cache := d.cache.diagramDom
-		d.Mach.Fork(ctx, e, func() {
-			d.diagramsMemCache(am.EvToCtx(ctx, e), cache, diagFilters,
-				diagDir, svgName)
-		})
-		return
-
-		// file cache, move to mem cache
-	} else if _, err := os.Stat(svgPath); err == nil {
-		d.Mach.Fork(ctx, e, func() {
-			d.diagramsFileCache(am.EvToCtx(ctx, e), diagFilters, lvl,
-				diagDir, svgName)
-		})
-		return
-	}
-
-	// no cache - render
-
-	// clone the current graph TODO optimize
-	shot, err := d.graph.Clone()
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-
-	// unblock
-	d.Mach.EvAdd1(e, ss.DiagramsNoCache, nil)
-	d.Mach.Fork(ctx, e, func() {
-		d.diagramsRender(am.EvToCtx(ctx, e), shot, c.Id, diagFilters, lvl,
-			len(d.Clients), diagDir, svgName, states)
-	})
-}
-
-var _ = ss.DiagramsReady
-
-func (d *Debugger) DiagramsReadyState(e *am.Event) {
-	defer d.Mach.EvRemove1(e, ss.DiagramsReady, nil)
-
-	// update cache
-	args := am.ParseArgs[A](e.Args)
-	if args.DiagramCache != nil {
-		d.cache.diagramDom = args.DiagramCache
-		d.cache.diagramName = args.DiagramName
-	}
-
-	// render a fresher one, if scheduled
-	d.genGraphsLast = time.Now()
-	if d.Mach.Is1(ss.DiagramsScheduled) {
-		d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
-		d.Mach.EvAdd1(e, ss.DiagramsRendering, nil)
-	}
-}
-
 var _ = ss.ClientListVisible
 
 func (d *Debugger) ClientListVisibleState(e *am.Event) {
@@ -2311,164 +2210,6 @@ func (d *Debugger) AnyState(e *am.Event) {
 	}
 }
 
-var _ = ss.WebReq
-
-func (d *Debugger) WebReqState(e *am.Event) {
-	wrArgs := am.ParseArgs[A](e.Args)
-	r := wrArgs.HttpRequest
-	w := wrArgs.HttpResponseWriter
-	done := wrArgs.DoneChan
-	defer close(done)
-
-	uri := r.RequestURI
-	switch {
-
-	// diagram viewer
-	case uri == "/":
-		fallthrough
-	case uri == "/diagrams/mach":
-		html := string(amvis.HtmlDiagram)
-		html = strings.ReplaceAll(html, "localhost:6831",
-			d.listenHost+":"+d.httpPort)
-		_, err := w.Write([]byte(html))
-		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-
-	// default svg symlink
-	case strings.HasPrefix(uri, "/diagrams/mach.svg"):
-		svgPath := filepath.Join(d.params.OutputDir, "diagrams", "am-vis.svg")
-		b, err := os.ReadFile(svgPath)
-		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-		if err != nil {
-			return
-		}
-
-		// send
-		w.Header().Set("Content-Type", "image/svg+xml")
-		_, err = w.Write(b)
-		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-	}
-}
-
-type WsDiagMsg struct {
-	Type  string
-	Addr  *types.MachAddress
-	Group string
-}
-
-var _ = ss.WebSocketDiag
-
-func (d *Debugger) WebSocketDiagState(e *am.Event) {
-	mach := d.Mach
-	ctx := mach.NewStateCtx(ss.WebSocketDiag)
-	wsdArgs := am.ParseArgs[A](e.Args)
-	ws := wsdArgs.WebSocketConn
-	r := wsdArgs.HttpRequest
-	done := wsdArgs.DoneChan
-	clientDone := make(chan struct{})
-
-	mach.EvAdd1(e, ss.DiagramsScheduled, nil)
-
-	// unblock
-	mach.Fork(ctx, e, func() {
-		defer close(done)
-		var ctxReq context.Context
-		var cancelReq context.CancelFunc
-		for {
-			// release prev run's wait chans
-			if cancelReq != nil {
-				cancelReq()
-			}
-
-			ctxReq, cancelReq = context.WithCancel(ctx)
-			defer cancelReq()
-
-			// wait for diagrams start
-			select {
-			case <-clientDone:
-				return
-			case <-mach.When1(ss.DiagramsScheduled, ctxReq):
-			}
-
-			// show progress
-			select {
-
-			case <-clientDone:
-				return
-
-			case <-mach.When1(ss.DiagramsNoCache, ctxReq):
-				// msg
-				msg, err := json.Marshal(WsDiagMsg{
-					Type: "loading",
-				})
-				if err != nil {
-					mach.Log(err.Error())
-					continue
-				}
-
-				// send
-				err = ws.Write(r.Context(), websocket.MessageText, msg)
-				if err != nil {
-					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-					return
-				}
-
-			case <-mach.When1(ss.DiagramsReady, ctxReq):
-				// ok
-			}
-
-			// wait for diagrams ready
-			select {
-
-			case <-clientDone:
-				return
-
-			// TODO loop over WSs in DiagramsReady. no goroutine per each
-			case <-mach.When1(ss.DiagramsReady, ctxReq):
-				// msg
-				msg := WsDiagMsg{
-					Type: "refresh",
-					Addr: d.MachAddr(),
-				}
-				mach.Eval("WebSocketDiagState", func() {
-					if d.params.OutputDiagGroup == types.ParamsOutDiagGroupSkip {
-						msg.Group = d.C.SelectedGroup
-					}
-				}, r.Context())
-				msgB, err := json.Marshal(msg)
-				if err != nil {
-					mach.Log(err.Error())
-					continue
-				}
-
-				// send
-				err = ws.Write(r.Context(), websocket.MessageText, msgB)
-				if err != nil {
-					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-					return
-				}
-			}
-		}
-	})
-
-	mach.Fork(ctx, e, func() {
-		for {
-			// msgType, msg, err := ws.Read(r.Context())
-			_, _, err := ws.Read(r.Context())
-			if err != nil {
-				mach.Log("websocket closed")
-				if websocket.CloseStatus(err) == -1 {
-					err = fmt.Errorf("websocket read: %w", err)
-					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
-				}
-
-				// close up
-				close(clientDone)
-				return
-			}
-		}
-	})
-}
-
 var _ = ss.FilterCanceledTx
 
 func (d *Debugger) FilterCanceledTxEnd(e *am.Event) {
@@ -2638,4 +2379,39 @@ func (d *Debugger) SshServerState(e *am.Event) {
 
 func (d *Debugger) SshServerEnd(e *am.Event) {
 	d.sshSrv.Close()
+}
+
+var _ = ss.Loading
+
+func (d *Debugger) LoadingState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.Loading)
+	mach := d.Mach
+
+	mach.Fork(ctx, e, func() {
+		i := 0
+		for ctx.Err() == nil {
+			i++
+			mach.Eval(ss.Loading+am.SuffixState, func() {
+				d.loadingPos = i
+				d.hUpdateStatusBar()
+			}, ctx)
+			d.draw(d.statusBarLeft)
+			i = i % 9
+			time.Sleep(100 * time.Millisecond)
+
+			// check if valid TODO push when leaving states
+			if !d.Mach.Any1(states.DebuggerGroups.Loading...) {
+				d.Mach.EvRemove1(e, ss.Loading, nil)
+			}
+		}
+	})
+}
+
+func (d *Debugger) LoadingExit(e *am.Event) bool {
+	return !d.Mach.Any1(states.DebuggerGroups.Loading...)
+}
+
+func (d *Debugger) LoadingEnd(e *am.Event) {
+	d.hUpdateStatusBar()
+	d.draw(d.statusBarLeft)
 }

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -115,17 +115,19 @@ type Debugger struct {
 	genGraphsLast  time.Time
 	graph          *amgraph.Graph
 	// update client list scheduled
-	updateCLScheduled atomic.Bool
-	buildCLScheduled  atomic.Bool
-	lastKeystroke     tcell.Key
-	lastKeystrokeTime time.Time
-	matrix            *cview.Table
-	exportDialog      *cview.Modal
-	contentPanels     *cview.Panels
-	toolbars          [4]*cview.Table
-	schemaLogGrid     *cview.Grid
-	treeMatrixGrid    *cview.Grid
-	lastSelectedState string
+	updateCLScheduled  atomic.Bool
+	buildCLScheduled   atomic.Bool
+	lastKeystroke      tcell.Key
+	lastKeystrokeTime  time.Time
+	matrix             *cview.Table
+	exportDialog       *cview.Modal
+	contentPanels      *cview.Panels
+	toolbars           [4]*cview.Table
+	schemaLogGrid      *cview.Grid
+	treeMatrixGrid     *cview.Grid
+	selectedState      atomic.Pointer[string]
+	selectedClient     atomic.Pointer[string]
+	selectedSchemaHash atomic.Pointer[string]
 	// TODO should be after a redraw, not before
 	// redrawCallback is auto-disposed in draw()
 	redrawCallback func()
@@ -196,8 +198,30 @@ type Debugger struct {
 	// count value of the last active separator
 	callLogLastSep map[string]int
 	// host to connect to, resolved from 0.0.0.0
-	listenHost string
-	httpPort   string
+	listenHost     string
+	listenAddrRpc  string
+	listenAddrHttp string
+	listenAddrSsh  string
+
+	// diagrams
+
+	// machine diagram cache
+	diagMachDom atomic.Pointer[goquery.Document]
+	// machine diagram name (no dir, no extension)
+	diagMachName atomic.Pointer[string]
+	// state diagram cache
+	diagStateDom atomic.Pointer[goquery.Document]
+	// state diagram path (no extension)
+	diagStatePath             atomic.Pointer[string]
+	diagMachUpdate            chan struct{}
+	diagStepsUpdate           chan struct{}
+	diagStateUpdate           chan struct{}
+	diagSkipGroup             atomic.Pointer[string]
+	diagStepsFileD2           *os.File
+	diagStepsFileD2Svg        *os.File
+	diagStepsFileMermaid      *os.File
+	diagStepsFileMermaidAscii *os.File
+	loadingPos                int
 }
 
 // TODO split to New and
@@ -213,8 +237,20 @@ func New(ctx context.Context, p types.Params) (*Debugger, error) {
 		callLogFilesLen:   make(map[string]int64),
 		callLogCount:      make(map[string]int),
 		callLogLastSep:    make(map[string]int),
+		diagMachUpdate:    make(chan struct{}, 1),
+		diagStepsUpdate:   make(chan struct{}, 1),
+		diagStateUpdate:   make(chan struct{}, 1),
 	}
-	d.P = message.NewPrinter(language.English)
+
+	// pointer defs
+	d.diagSkipGroup.Store(new(string))
+	d.diagMachName.Store(new(string))
+	d.diagStatePath.Store(new(string))
+	d.selectedState.Store(new(string))
+	d.selectedGroup.Store(new(string))
+	d.selectedSchemaHash.Store(new(string))
+	d.selectedClient.Store(new(string))
+	// TODO params def
 
 	id := utils.RandId(0)
 	if p.Id != "" {
@@ -533,6 +569,16 @@ func (d *Debugger) hInitOutputTxFiles() {
 	}
 }
 
+func (d *Debugger) hCloseDiagFiles() {
+	if d.diagStepsFileD2Svg == nil {
+		return
+	}
+	d.diagStepsFileD2Svg.Close()
+	d.diagStepsFileD2.Close()
+	d.diagStepsFileMermaid.Close()
+	d.diagStepsFileMermaidAscii.Close()
+}
+
 // hSetCursor1 sets both the tx and steps cursors, 1-based.
 func (d *Debugger) hSetCursor1(e *am.Event, args *A) {
 	cursor1 := args.Cursor1
@@ -598,42 +644,20 @@ func (d *Debugger) hGenSeqDiagram(
 ) {
 	//
 
-	e := am.CtxToEv(ctx)
-	index := d.C.MsgStruct.StatesIndex
-	_ = d.txFileMd.Truncate(0)
-	_ = d.txFileD2.Truncate(0)
-	_ = d.txFileD2Svg.Truncate(0)
-	_ = d.txFileMermaid.Truncate(0)
-	_ = d.txFileMermaidAscii.Truncate(0)
-	_, _ = d.txFileMd.WriteAt([]byte(tx.TxString(index)), 0)
-
-	if tx.Steps == nil {
-		return
-	}
-
-	visTx := amvis.Transition{
-		Log:        amhelp.MachToSlog(d.Mach),
-		Tx:         tx,
-		TxParsed:   parsed,
-		PrevTx:     d.hPrevTx(),
-		StateTrace: d.hStateTrace(tx),
-		// add queue-tx with stack trace
-	}
-
-	// D2
-	d2Diag, d2Svg, err := visTx.D2(ctx, index)
-	if ctx.Err() != nil {
-		return // expired
-	}
-	if err != nil {
-		d.Mach.Log("err: genSeqDiagram D2: %s", err)
-	}
-	_, _ = d.txFileD2.WriteAt([]byte(d2Diag), 0)
-	if err != nil {
-		d.Mach.EvAddErr(e, err, nil)
-	} else {
-		_, _ = d.txFileD2Svg.WriteAt([]byte(d2Svg), 0)
-	}
+	// diagrams TODO merged mutation once partial negotiation lands
+	d.Mach.GoAfter(ctx, time.Second, func() {
+		if err := d.diagramsMachUpdating(ctx); err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+	})
+	d.Mach.GoAfter(ctx, time.Second, func() {
+		if err := d.diagramsStateUpdating(ctx); err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+	})
+}
 
 	// mermaid
 	mermaid, ascii, err := visTx.Mermaid(index)
@@ -758,12 +782,11 @@ func (d *Debugger) GoToMachAddress(
 					break
 				}
 			}
-			d.lastSelectedGroup = label
+			d.selectedGroup.Store(&label)
 			d.C.SelectedGroup = label
 			d.hBuildSchemaTree()
 			d.hUpdateSchemaTree()
 			d.hUpdateTreeGroups()
-			go amhelp.AskAdd1(d.Mach, ss.DiagramsScheduled, nil)
 			d.Mach.Add(am.S{ss.ToolToggled, ss.UpdateLogScheduled}, Pass(&A{
 				FilterTxs:     true,
 				LogRebuildEnd: len(d.C.MsgTxs),
@@ -2646,106 +2669,6 @@ func (d *Debugger) hGetParentTags(c *Client, tags []string) []string {
 	return d.hGetParentTags(parent, tags)
 }
 
-func (d *Debugger) initGraphGen(
-	snapshot *amgraph.Graph, id string, detailsLvl, numClients int, diagDir,
-	svgName string, statesAllowlist S,
-) []*amvis.Renderer {
-	//
-
-	var vizs []*amvis.Renderer
-
-	// render single (current one)
-	vis := amvis.NewRenderer(snapshot, d.Mach.Log)
-	amvis.PresetSingle(vis)
-	// TODO enum
-	switch detailsLvl {
-	default:
-		return vizs
-
-		// single (simple)
-	case 1:
-		vis.RenderNestSubmachines = false
-		vis.RenderStart = false
-		vis.RenderInherited = false
-		vis.RenderPipes = false
-		vis.RenderHalfPipes = false
-		vis.RenderHalfConns = false
-		vis.RenderHalfHierarchy = false
-		vis.RenderParentRel = false
-
-		// single (detailed)
-	case 2:
-		vis.RenderNestSubmachines = false
-		vis.RenderStart = true
-		vis.RenderInherited = true
-		vis.RenderPipes = false
-		vis.RenderHalfPipes = false
-		vis.RenderHalfConns = false
-		vis.RenderHalfHierarchy = false
-
-		// single (external)
-	case 3:
-		vis.RenderNestSubmachines = true
-		vis.RenderStart = true
-		vis.RenderInherited = true
-		vis.RenderPipes = true
-	}
-
-	d.Mach.Log("rendering graphs lvl %d", detailsLvl)
-
-	// machine diagram
-	vis.RenderMachs = []string{id}
-	vis.OutputFilename = path.Join(diagDir, svgName)
-	if len(statesAllowlist) > 0 {
-		vis.RenderAllowlist = statesAllowlist
-	}
-
-	vizs = append(vizs, vis)
-
-	// TODO render by prefixes
-	// } else {
-	// 	for _, p := range strings.Split(d.Params.Graph, ",") {
-	//
-	// 		// vis
-	// 		vis := amvis.NewRenderer(d.Mach, shot)
-	// 		if p == "1" || p == "true" {
-	// 			// render single (current one)
-	// 			amvis.PresetSingle(vis)
-	// 			vis.RenderMachs = []string{p}
-	// 			vis.RenderNestSubmachines = true
-	// 			vis.RenderStart = true
-	// 		} else {
-	// 			// render by prefix
-	// 			prefix := regexp.MustCompile("^" + p)
-	// 			amvis.PresetNeighbourhood(vis)
-	// 			vis.RenderMachsRe = []*regexp.Regexp{prefix}
-	// 			vis.RenderDistance = 1
-	// 			vis.RenderDepth = 1
-	// 		}
-	// 		// prefix with am-vis
-	// 		vis.OutputFilename = path.Join(d.Params.OutputDir, "am-vis-"+p)
-	//
-	// 		vizs = append(vizs, vis)
-	// 	}
-	// }
-
-	// TODO render a mutation
-
-	// map
-	// TODO skip if there was no change in schemas
-	//  hash schemas and schema's hashes, then compare
-
-	// map renderer, check cache TODO extract
-	mapPath := fmt.Sprintf("am-vis-map-%d", numClients)
-	if _, err := os.Stat(mapPath); err != nil {
-		vis = amvis.NewRenderer(snapshot, d.Mach.Log)
-		amvis.PresetMap(vis)
-		vis.OutputFilename = path.Join(diagDir, mapPath)
-	}
-
-	return append(vizs, vis)
-}
-
 func (d *Debugger) hSyncOptsTimelines() {
 	switch d.params.ViewTimelines {
 	case types.ParamsViewTimelinesNone:
@@ -2756,148 +2679,6 @@ func (d *Debugger) hSyncOptsTimelines() {
 	case types.ParamsViewTimelinesTwo:
 		d.Mach.Remove(S{ss.TimelineStepsHidden, ss.TimelineTxHidden}, nil)
 	}
-}
-
-func (d *Debugger) diagramsRender(
-	ctx context.Context, shot *amgraph.Graph, id string,
-	diagFilters *amvis.Filters, details, clients int, diagDir string,
-	svgName string, states S,
-) {
-	e := am.CtxToEv(ctx)
-	if ctx.Err() != nil {
-		return // expired
-	}
-	// mark rendering as in-progress
-	d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
-
-	// create the visualizer
-	vizs := d.initGraphGen(shot, id, details, clients, diagDir, svgName, states)
-	// TODO config
-	pool := amhelp.Pool(ctx, 2)
-
-	for _, vis := range vizs {
-		pool.SubmitErr(func() error {
-			return vis.GenDiagrams(ctx)
-		})
-	}
-
-	err := pool.Wait()
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-
-	// link
-	d.diagramLink(diagDir, svgName)
-	if ctx.Err() != nil {
-		return // expired
-	}
-
-	// symlink am-vis-map.svg -> am-vis-map-CLIENTS.svg
-	source := path.Join(diagDir, "am-vis-map.svg")
-	target := fmt.Sprintf("am-vis-map-%d.svg", clients)
-	_ = os.Remove(source)
-	err = os.Symlink(target, source)
-	if ctx.Err() != nil {
-		return // expired
-	}
-	d.Mach.EvAddErr(e, err, nil)
-
-	// next
-	if !diagFilters.Empty() {
-		// apply filters
-		d.Mach.Go(ctx, func() {
-			d.diagramsFileCache(ctx, diagFilters, details, diagDir, svgName)
-		})
-	} else {
-		d.Mach.EvAdd1(e, ss.DiagramsReady, nil)
-	}
-}
-
-func (d *Debugger) diagramLink(diagDir string, svgName string) {
-	// symlink am-vis.svg -> ID-LVL-HASH.svg
-	source := path.Join(diagDir, "am-vis.svg")
-	target := svgName + ".svg"
-	_ = os.Remove(source)
-	err := os.Symlink(target, source)
-	d.Mach.AddErr(err, nil)
-}
-
-// diagramsMemCache - update diagram from memory cache
-func (d *Debugger) diagramsMemCache(
-	ctx context.Context, cache *goquery.Document, diagFilters *amvis.Filters,
-	diagDir, svgName string,
-) {
-	//
-
-	e := am.CtxToEv(ctx)
-	svgPath := path.Join(diagDir, svgName+".svg")
-	// mark rendering as in-progress
-	d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
-
-	// update cache DOM
-	err := amvis.UpdateCache(ctx, svgPath, cache, diagFilters)
-	if ctx.Err() != nil {
-		return // expired
-	}
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-
-	// link
-	d.diagramLink(diagDir, svgName)
-	if ctx.Err() != nil {
-		return // expired
-	}
-
-	// next
-	d.Mach.EvAdd1(e, ss.DiagramsReady, nil)
-}
-
-// diagramsFileCache - update diagram from file cache
-func (d *Debugger) diagramsFileCache(
-	ctx context.Context, diagFilters *amvis.Filters, lvl int, diagDir,
-	svgName string,
-) {
-	e := am.CtxToEv(ctx)
-	svgPath := path.Join(diagDir, svgName+".svg")
-	// mark rendering as in-progress
-	d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
-
-	// read cache from a file
-	file, err := os.Open(svgPath)
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-	cache, err := goquery.NewDocumentFromReader(file)
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-
-	// update cache DOM
-	err = amvis.UpdateCache(ctx, svgPath, cache, diagFilters)
-	if ctx.Err() != nil {
-		return // expired
-	}
-	if err != nil {
-		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
-		return
-	}
-
-	// link
-	d.diagramLink(diagDir, svgName)
-	if ctx.Err() != nil {
-		return // expired
-	}
-
-	// next
-	d.Mach.EvAdd1(e, ss.DiagramsReady, Pass(&A{
-		DiagramCache: cache,
-		DiagramName:  svgName,
-	}))
 }
 
 func (d *Debugger) getFocusColor() tcell.Color {

--- a/tools/debugger/diagrams.go
+++ b/tools/debugger/diagrams.go
@@ -1,0 +1,1002 @@
+package debugger
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/coder/websocket"
+
+	amgraph "github.com/pancsta/asyncmachine-go/pkg/graph"
+	amhelp "github.com/pancsta/asyncmachine-go/pkg/helpers"
+	am "github.com/pancsta/asyncmachine-go/pkg/machine"
+	"github.com/pancsta/asyncmachine-go/pkg/telemetry/dbg"
+	"github.com/pancsta/asyncmachine-go/tools/debugger/types"
+	amvis "github.com/pancsta/asyncmachine-go/tools/visualizer"
+)
+
+// ///// ///// /////
+
+// ///// HANDLERS
+
+// ///// ///// /////
+
+var _ = ss.WebReqDiag
+
+// TODO enter
+
+func (d *Debugger) WebReqDiagState(e *am.Event) {
+	args := am.ParseArgs[A](e.Args)
+	r := args.HttpRequest
+	w := args.HttpResponseWriter
+	diagType := args.DiagType
+	done := args.DoneChan
+	defer close(done)
+
+	name := diagType.Value
+	uri := r.RequestURI
+	switch {
+
+	// diagram viewer
+	case uri == "/viewer/"+name:
+		// adjust HTML
+		html := string(amvis.HtmlDiagram)
+		html = strings.ReplaceAll(html, "localhost:6831", d.listenAddrHttp)
+		html = strings.ReplaceAll(html, `const TYPE = "mach";`,
+			fmt.Sprintf(`const TYPE = "%s";`, name))
+		// TODO <title>am-vis machine diagram</title>
+
+		_, err := w.Write([]byte(html))
+		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+
+	// default svg symlink
+	case strings.HasPrefix(uri, "/viewer/"+name+".svg"):
+		svgPath := filepath.Join(d.params.OutputDir, "am-vis-"+name+".svg")
+		b, err := os.ReadFile(svgPath)
+		// skip errs for state when no state
+		if name != "state" && *d.selectedState.Load() != "" {
+			d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+		}
+		if err != nil {
+			return
+		}
+
+		// send
+		w.Header().Set("Content-Type", "image/svg+xml")
+		_, err = w.Write(b)
+		d.Mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+	}
+}
+
+var _ = ss.WebSocketDiag
+
+// TODO enter
+
+func (d *Debugger) WebSocketDiagState(e *am.Event) {
+	mach := d.Mach
+	// TODO ctx type per diag type
+	ctx, cancel := context.WithCancel(mach.NewStateCtx(ss.Start, e))
+	args := am.ParseArgs[A](e.Args)
+	ws := args.WebSocketConn
+	r := args.HttpRequest
+	done := args.DoneChan
+
+	// check params
+	if d.Params.Load().OutputDiagrams == types.ParamsOutputDiagramsNone {
+		ws.Close(websocket.StatusNormalClosure, "Diagrams disabled")
+		cancel()
+		return
+	}
+
+	// diagram types TODO keep all as states once partial negotiation lands
+	var progressState string
+	var readyState string
+	var updateChan chan struct{}
+	// TODO support >1 client (use states instead)
+	switch args.DiagType {
+
+	case types.DiagramTypeMach:
+		// readyState = ss.DiagramsMachReady
+		progressState = ss.DiagramsMachRendering
+		updateChan = d.diagMachUpdate
+		go func() {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams,
+				d.diagramsMachUpdating(ctx), nil)
+		}()
+
+	case types.DiagramTypeGraph:
+		progressState = ss.DiagramsGraphRendering
+		readyState = ss.DiagramsGraphReady
+
+	case types.DiagramTypeState:
+		// readyState = ss.DiagramsStatesRendering
+		progressState = ss.DiagramsStatesRendering
+		updateChan = d.diagStateUpdate
+		go func() {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams,
+				d.diagramsStateUpdating(ctx), nil)
+		}()
+
+	case types.DiagramTypeSteps:
+		updateChan = d.diagStepsUpdate
+		d.hDiagramsStepsRendering(ctx, d.hCurrentTx(), d.hCurrentTxParsed())
+	}
+
+	// WS push update loop
+	mach.Go(ctx, func() {
+		defer close(done)
+
+		// chan based updates
+		if updateChan != nil {
+			d.diagramWsUpdateChan(ctx, updateChan, progressState, ws, r)
+			return
+		}
+
+		// state based updates
+		d.diagramsWsUpdateStates(ctx, progressState, ws, r, readyState)
+	})
+
+	// WS read loop with closing
+	mach.Fork(ctx, e, func() {
+		for {
+			// msgType, msg, err := ws.Read(r.Context())
+			_, _, err := ws.Read(r.Context())
+			if err != nil {
+				mach.Log("websocket closed")
+				if websocket.CloseStatus(err) == -1 {
+					err = fmt.Errorf("websocket read: %w", err)
+					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+				}
+
+				// close up
+				cancel()
+				return
+			}
+		}
+	})
+}
+
+// GRAPH
+
+var _ = ss.DiagramsGraphRendering
+
+func (d *Debugger) DiagramsGraphRenderingEnter(e *am.Event) bool {
+	return len(d.Clients) > 0 &&
+		d.params.OutputDiagrams != types.ParamsOutputDiagramsNone
+}
+
+func (d *Debugger) DiagramsGraphRenderingState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.DiagramsGraphRendering, e)
+	d.hUpdateGraphHash()
+
+	graphHash := d.graphHash
+	diagDir := path.Join(d.params.OutputDir, "diagrams")
+	// TODO optimize
+	snapshot, err := d.graph.Clone()
+	if err != nil {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		return
+	}
+
+	d.Mach.Fork(ctx, e, func() {
+		svgName := fmt.Sprintf("graph-%s", graphHash)
+		svgPath := path.Join(diagDir, svgName)
+
+		// render if missing
+		if _, err := os.Stat(svgPath + ".svg"); err != nil {
+			vis := amvis.NewRenderer(snapshot, d.Mach.Log)
+			// TODO fix RPC conns not visible
+			amvis.PresetMap(vis)
+			vis.OutputFilename = svgPath
+			err := vis.GenDiagrams(ctx)
+			if ctx.Err() != nil {
+				return // expired
+			}
+			if err != nil {
+				d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+				return
+			}
+		}
+
+		// symlink
+		_ = d.diagramsLink(svgName, types.DiagramTypeGraph)
+		d.Mach.EvAdd1(e, ss.DiagramsGraphReady, nil)
+	})
+}
+
+// MACH
+
+var _ = ss.DiagramsMachRendering
+
+func (d *Debugger) DiagramsMachRenderingEnter(e *am.Event) bool {
+	return d.params.OutputDiagrams != types.ParamsOutputDiagramsNone &&
+		d.C != nil
+}
+
+func (d *Debugger) DiagramsMachRenderingState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.DiagramsMachRendering, e)
+	lvl := d.params.OutputDiagrams.Value
+	c := d.C
+	diagName := fmt.Sprintf("mach-%s-%d-%s", c.Id, lvl, c.SchemaHash)
+	// clone the current graph TODO optimize
+	shot, err := d.graph.Clone()
+	if err != nil {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		return
+	}
+
+	// state groups
+	var states S
+	if g := c.SelectedGroup; g != "" &&
+		d.params.OutputDiagGroup == types.ParamsOutDiagGroupSkip {
+
+		states = c.MsgSchemaParsed.Groups[g]
+		diagName = fmt.Sprintf("mach-%s-%s-%d-%s",
+			c.Id, types.NormalizeGroupName(g), lvl, c.SchemaHash)
+	}
+
+	// unblock
+	d.Mach.Fork(ctx, e, func() {
+		// update or render
+		err := d.diagramsMachRender(ctx, shot, c.Id, lvl, diagName, states)
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+
+		// link and load DOM
+		_ = d.diagramsLink(diagName, types.DiagramTypeMach)
+		file, err := os.Open(d.diagramsDiagPath(diagName) + ".svg")
+		if err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+		dom, err := goquery.NewDocumentFromReader(file)
+		if err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+
+		d.Mach.EvAdd1(e, ss.DiagramsMachReady, Pass(&A{
+			DiagDom:  dom,
+			DiagName: diagName,
+		}))
+	})
+}
+
+var _ = ss.DiagramsMachReady
+
+// TODO enter
+
+func (d *Debugger) DiagramsMachReadyState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.DiagramsMachReady)
+	args := am.ParseArgs[A](e.Args)
+	d.diagMachDom.Store(args.DiagDom)
+	d.diagMachName.Store(&args.DiagName)
+
+	d.Mach.Go(ctx, func() {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams,
+			d.diagramsMachUpdating(ctx), nil)
+	})
+}
+
+// STATE
+
+var _ = ss.DiagramsStatesRendering
+
+func (d *Debugger) DiagramsStatesRenderingEnter(e *am.Event) bool {
+	return d.params.OutputDiagrams != types.ParamsOutputDiagramsNone &&
+		d.C != nil
+}
+
+func (d *Debugger) DiagramsStatesRenderingState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.DiagramsStatesRendering)
+	c := d.C
+	diagDir := path.Join(d.params.OutputDir, "diagrams")
+	index := c.MsgStruct.StatesIndex
+	groupName := c.SelectedGroup
+	groupOnly := d.params.OutputDiagGroup != types.ParamsOutDiagGroupNone
+	hash := c.SchemaHash
+	var allowStates S
+	if groupName != "" {
+		allowStates = c.MsgSchemaParsed.Groups[groupName]
+	}
+	machId := c.Id
+	schema := c.MsgStruct.States.Clone()
+
+	// TODO pool state
+	d.Mach.Go(ctx, func() {
+		for _, state := range index {
+			if ctx.Err() != nil {
+				return // expired
+			}
+			// skip
+			if state == am.StateStart || state == am.StateReady {
+				continue
+			}
+
+			diagName := d.diagramsStateDiagName(
+				machId, state, hash, groupName, groupOnly,
+			)
+
+			// gen
+			err := d.diagramsStateRender(ctx, schema, state,
+				diagName, diagDir, allowStates)
+			if ctx.Err() != nil {
+				return // expired
+			}
+			if err != nil {
+				d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+				return
+			}
+
+			// push update (if relevant)
+			if *d.selectedState.Load() == state {
+				d.diagramsStatesPush(ctx, d.diagramsDiagPath(diagName))
+			}
+		}
+
+		d.Mach.EvAdd1(e, ss.DiagramsStatesReady, nil)
+	})
+}
+
+// ///// ///// /////
+
+// ///// SUB-HANDLERS
+
+// ///// ///// /////
+
+func (d *Debugger) hDiagramsStepsRendering(
+	ctx context.Context, tx *dbg.DbgMsgTx, parsed *types.MsgTxParsed,
+) {
+	if tx == nil {
+		return
+	}
+
+	c := d.C
+	e := am.CtxToEv(ctx)
+	index := c.MsgStruct.StatesIndex
+
+	// reset files
+	_ = d.txFileMd.Truncate(0)
+	_ = d.diagStepsFileD2.Truncate(0)
+	_ = d.diagStepsFileD2Svg.Truncate(0)
+	_ = d.diagStepsFileMermaid.Truncate(0)
+	_ = d.diagStepsFileMermaidAscii.Truncate(0)
+
+	// TODO move to cursor set
+	_, _ = d.txFileMd.WriteAt([]byte(tx.TxString(index)), 0)
+
+	if tx.Steps == nil {
+		return
+	}
+
+	var group am.S
+	if d.params.OutputDiagGroup != types.ParamsOutDiagGroupNone &&
+		c.SelectedGroup != "" {
+
+		group = c.MsgSchemaParsed.Groups[c.SelectedGroup]
+	}
+
+	visTx := amvis.Transition{
+		Log:        amhelp.MachToSlog(d.Mach),
+		Tx:         tx,
+		TxParsed:   parsed,
+		PrevTx:     d.hPrevTx(),
+		StateTrace: d.hStateTrace(tx),
+		Group:      group,
+		// TODO add queue-tx with stack trace
+	}
+
+	// unblock
+	d.Mach.Go(ctx, func() {
+		if err := d.diagramsStepsRender(ctx, visTx, index); err != nil {
+			if ctx.Err() != nil {
+				return // expired
+			}
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		}
+
+		// push update
+		select {
+		case d.diagStepsUpdate <- struct{}{}:
+		default:
+			// skip
+		}
+	})
+}
+
+func (d *Debugger) hDiagramsFilters(
+	c *Client, tx *dbg.DbgMsgTx,
+) *amvis.Filters {
+	//
+
+	index := c.MsgStruct.StatesIndex
+	diagFilters := &amvis.Filters{
+		MachId:   c.Id,
+		Index:    index,
+		Selected: am.S{d.C.SelectedState},
+	}
+	if tx != nil {
+		diagFilters.Active = tx.ActiveStates(index)
+
+		// dim
+		if d.params.OutputDiagTx != types.ParamsOutDiagTxNone {
+			parsed := c.MsgTxsParsed[c.CursorTx1-1]
+			showIdxs := tx.CalledStatesIdxs
+			switch d.params.OutputDiagTx {
+			case types.ParamsOutDiagTxMutated:
+				showIdxs = slices.Concat(parsed.StatesAdded, parsed.StatesRemoved)
+			case types.ParamsOutDiagTxTouched:
+				fallthrough
+			case types.ParamsOutDiagTxRelations:
+				showIdxs = parsed.StatesTouched
+			}
+			diagFilters.Highlighted = c.IndexesToStates(showIdxs)
+		}
+
+		// collect touched rels TODO add to step timeline 1-by-1
+		if d.params.OutputDiagTx == types.ParamsOutDiagTxRelations {
+			for _, step := range tx.Steps {
+				if step.Type != am.StepRelation {
+					continue
+				}
+
+				diagFilters.HighlightedRels = append(diagFilters.HighlightedRels,
+					[3]string{
+						step.GetFromState(index),
+						step.GetToState(index),
+						step.RelType.String(),
+					})
+			}
+		}
+	}
+	if d.params.OutputDiagGroup == types.ParamsOutDiagGroupHide &&
+		c.SelectedGroup != "" {
+
+		diagFilters.Visible = c.MsgSchemaParsed.Groups[c.SelectedGroup]
+	}
+
+	return diagFilters
+}
+
+// ///// ///// /////
+
+// ///// METHODS
+
+// ///// ///// /////
+
+func (d *Debugger) diagramsMachUpdating(ctx context.Context) error {
+	// check params
+	if d.Params.Load().OutputDiagrams == types.ParamsOutputDiagramsNone {
+		return nil
+	}
+
+	// skip if no cache to update
+	if d.diagMachDom.Load() == nil {
+		return nil
+	}
+
+	// wait for Mach Ready
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-d.Mach.When1(ss.DiagramsMachReady, ctx):
+	}
+	diagFilters, err := d.diagramsMachFilters(ctx)
+	if ctx.Err() != nil {
+		return nil // expired
+	}
+	if err != nil {
+		return err
+	}
+
+	// update cache DOM
+	diagPath := d.diagramsDiagPath(*d.diagMachName.Load())
+	err = amvis.UpdateCache(ctx, diagPath+".svg",
+		d.diagMachDom.Load(), diagFilters)
+	if ctx.Err() != nil {
+		return nil // expired
+	}
+	if err != nil {
+		return err
+	}
+
+	// push update
+	select {
+	case d.diagMachUpdate <- struct{}{}:
+	default:
+		// skip
+	}
+
+	return nil
+}
+
+// diagramsStateUpdating will link the correct state diagram.
+func (d *Debugger) diagramsStateUpdating(ctx context.Context) error {
+	// check params
+	if d.Params.Load().OutputDiagrams == types.ParamsOutputDiagramsNone {
+		return nil
+	}
+
+	state := *d.selectedState.Load()
+	machId := *d.selectedClient.Load()
+	group := *d.selectedGroup.Load()
+	schemaHash := *d.selectedSchemaHash.Load()
+
+	groupOnly := d.params.OutputDiagGroup != types.ParamsOutDiagGroupNone
+	diagName := d.diagramsStateDiagName(machId, state, schemaHash,
+		group, groupOnly)
+
+	if err := d.diagramsLink(diagName, types.DiagramTypeState); err != nil {
+		return err
+	}
+
+	// push update if ready
+	diagPath := d.diagramsDiagPath(diagName)
+	if _, err := os.Stat(diagPath + ".svg"); err == nil {
+		d.diagramsStatesPush(ctx, diagPath)
+	} else {
+		select {
+		case d.diagStateUpdate <- struct{}{}:
+		default:
+			// skip
+		}
+		// TODO push "loading" event
+	}
+
+	return nil
+}
+
+func (d *Debugger) diagramsMachFilters(
+	ctx context.Context,
+) (*amvis.Filters, error) {
+	//
+
+	return amhelp.EvalGetter(ctx, "diagramsFilters", 3, d.Mach,
+		func() (*amvis.Filters, error) {
+			tx := d.hCurrentTx()
+			return d.hDiagramsFilters(d.C, tx), nil
+		})
+}
+
+func (d *Debugger) diagramWsUpdateChan(
+	ctx context.Context, updateChan chan struct{}, renderingState string,
+	ws *websocket.Conn, r *http.Request,
+) {
+	//
+
+	e := am.CtxToEv(ctx)
+	mach := d.Mach
+
+	for {
+		// "loading" indicator
+		if d.Mach.Is1(renderingState) {
+			// debounce
+			time.Sleep(100 * time.Millisecond)
+			if d.Mach.Is1(renderingState) {
+
+				// show progress msg
+				msg, err := json.Marshal(types.WsDiagMsg{
+					Event: "loading",
+				})
+				if err != nil {
+					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+					continue
+				}
+				err = ws.Write(r.Context(), websocket.MessageText, msg)
+				if err != nil {
+					mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+					// TODO continue?
+					return
+				}
+			}
+		}
+
+		// refresh event
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-updateChan:
+			// msg
+			msg, err := json.Marshal(types.WsDiagMsg{
+				Event: "refresh",
+				// TODO no eval
+				Id: d.MachAddr().MachId,
+			})
+			if err != nil {
+				mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+				continue
+			}
+
+			// send
+			err = ws.Write(r.Context(), websocket.MessageText, msg)
+			if err != nil {
+				mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+				// TODO continue?
+				return
+			}
+
+			continue
+		}
+	}
+}
+
+func (d *Debugger) diagramsWsUpdateStates(
+	ctx context.Context, progressState string, ws *websocket.Conn,
+	r *http.Request, readyState string,
+) {
+	//
+	e := am.CtxToEv(ctx)
+	mach := d.Mach
+
+	var ctxStep context.Context
+	var cancelStep context.CancelFunc
+	var lastReady uint64
+	for {
+		// step ctx - release prev run's wait chans
+		if cancelStep != nil {
+			cancelStep()
+		}
+		ctxStep, cancelStep = context.WithCancel(ctx)
+		defer cancelStep()
+
+		// wait if tick served
+		tickReady := d.Mach.Tick(readyState)
+		if lastReady == tickReady {
+			// wait for rendering to start
+			if progressState != "" {
+				select {
+				case <-ctx.Done():
+					return
+				case <-mach.When1(progressState, ctxStep):
+				}
+			}
+		}
+		lastReady = tickReady
+
+		// show progress msg
+		msg, err := json.Marshal(types.WsDiagMsg{
+			Event: "loading",
+		})
+		if err != nil {
+			mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+			continue
+		}
+		err = ws.Write(r.Context(), websocket.MessageText, msg)
+		if err != nil {
+			mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+			// TODO continue?
+			return
+		}
+
+		// wait for rendering to end
+		if readyState != "" {
+			select {
+
+			case <-ctx.Done():
+				return
+
+			case <-mach.When1(readyState, ctxStep):
+				// ok
+			}
+		}
+
+		// msg
+		msg, err = json.Marshal(types.WsDiagMsg{
+			Event: "refresh",
+			Id:    d.MachAddr().MachId,
+			Group: *d.diagSkipGroup.Load(),
+		})
+		if err != nil {
+			mach.Log(err.Error())
+			continue
+		}
+
+		// send
+		err = ws.Write(r.Context(), websocket.MessageText, msg)
+		if err != nil {
+			mach.EvAddErrState(e, ss.ErrWeb, err, nil)
+			// TODO continue?
+			return
+		}
+	}
+}
+
+func (d *Debugger) diagramsMachRender(
+	ctx context.Context, shot *amgraph.Graph, machId string,
+	detailLvl int, diagName string, states S,
+) error {
+	diagPath := d.diagramsDiagPath(diagName)
+
+	// check cache
+	if _, err := os.Stat(diagPath + ".svg"); err == nil {
+		return nil
+	}
+
+	vis := amvis.NewRenderer(shot, d.Mach.Log)
+	amvis.PresetSingle(vis)
+	// TODO enum
+	switch detailLvl {
+	default:
+		return fmt.Errorf("unknown diagram detail level: %d", detailLvl)
+
+		// single (simple)
+	case 1:
+		vis.RenderNestSubmachines = false
+		vis.RenderStart = false
+		vis.RenderInherited = false
+		vis.RenderPipes = false
+		vis.RenderHalfPipes = false
+		vis.RenderHalfConns = false
+		vis.RenderHalfHierarchy = false
+		vis.RenderParentRel = false
+
+		// single (detailed)
+	case 2:
+		vis.RenderNestSubmachines = false
+		vis.RenderStart = true
+		vis.RenderInherited = true
+		vis.RenderPipes = false
+		vis.RenderHalfPipes = false
+		vis.RenderHalfConns = false
+		vis.RenderHalfHierarchy = false
+
+		// single (external)
+	case 3:
+		vis.RenderNestSubmachines = true
+		vis.RenderStart = true
+		vis.RenderInherited = true
+		vis.RenderPipes = true
+	}
+
+	d.Mach.Log("rendering graphs lvl %d", detailLvl)
+
+	// common
+	vis.RenderActive = false
+	vis.RenderMachs = []string{machId}
+	vis.OutputFilename = diagPath
+	if len(states) > 0 {
+		vis.RenderAllowlist = states
+	}
+
+	return vis.GenDiagrams(ctx)
+}
+
+func (d *Debugger) diagramsStateRender(
+	ctx context.Context, schema am.Schema, state string, diagName string,
+	diagDir string, allowStates S,
+) error {
+	//
+
+	// cached?
+	diagPath := d.diagramsDiagPath(diagName)
+	_, err := os.Stat(diagPath + ".svg")
+	if err == nil {
+		return nil
+	}
+
+	// clone the current graph TODO optimize
+	e := am.CtxToEv(ctx)
+	shot, err := d.graph.Clone()
+	if err != nil {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		return nil
+	}
+
+	direct := schema.AdjacentStates(state)
+	show := S{state}.Add(direct)
+	for _, s2 := range direct {
+		// skip popular states
+		if s2 == am.StateReady || s2 == am.StateStart {
+			continue
+		}
+
+		show = show.Add(schema.AdjacentStates(s2))
+	}
+	show = show.Unique()
+
+	// group narrow down
+	if allowStates != nil {
+		show = slices.DeleteFunc(show, func(s string) bool {
+			return !slices.Contains(allowStates, s)
+		})
+	}
+
+	// skip empty sets
+	if len(show) == 0 {
+		return nil
+	}
+
+	// keep blocking
+	if ctx.Err() != nil {
+		return nil // expired
+	}
+	// mark rendering as in-progress TODO dedicated state
+	// d.Mach.EvRemove1(e, ss.DiagramsScheduled, nil)
+
+	vis := amvis.NewRenderer(shot, d.Mach.Log)
+	amvis.PresetSingle(vis)
+	vis.RenderNestSubmachines = false
+	vis.RenderStart = false
+	vis.RenderActive = false
+	vis.RenderReady = false
+	vis.RenderInherited = true
+	vis.RenderPipes = true
+	vis.RenderHalfPipes = false
+	vis.RenderHalfConns = false
+	vis.RenderHalfHierarchy = false
+	vis.RenderParentRel = false
+	// TODO add pipes
+	vis.RenderZoom = S{show[0]}
+	vis.RenderMachTitles = false
+	vis.RenderAllowlist = show
+	vis.RenderMachs = []string{d.C.Id}
+	vis.OutputMermaid = false
+	vis.OutputFilename = diagPath
+	// TODO test
+	// vis.OutputElk = false
+	// TODO skip Start, Ready
+
+	return vis.GenDiagrams(ctx)
+}
+
+func (d *Debugger) diagramsStepsRender(
+	ctx context.Context, visTx amvis.Transition, index am.S,
+) error {
+	//
+
+	e := am.CtxToEv(ctx)
+	var err error
+
+	// D2
+	d2Diag, d2Svg, errD2 := visTx.D2(ctx, index)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	err = errors.Join(err, errD2)
+
+	// mermaid
+	mermaid, ascii, errMer := visTx.Mermaid(index)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	err = errors.Join(err, errMer)
+
+	// store
+	d.Mach.Eval("diagramsStepsRender", func() {
+		if errD2 == nil {
+			_, err := d.diagStepsFileD2.WriteAt([]byte(d2Diag), 0)
+			if err != nil {
+				d.Mach.EvAddErr(e, err, nil)
+			} else {
+				_, _ = d.diagStepsFileD2Svg.WriteAt(d2Svg, 0)
+			}
+		}
+
+		if errMer == nil {
+			_, err := d.diagStepsFileMermaid.WriteAt([]byte(mermaid), 0)
+			if err != nil {
+				d.Mach.EvAddErr(e, err, nil)
+			} else {
+				_, _ = d.diagStepsFileMermaidAscii.WriteAt([]byte(ascii), 0)
+			}
+		}
+	}, ctx)
+
+	return errors.Join(
+		err,
+		d.diagramsLink("steps.d2", types.DiagramTypeSteps),
+	)
+}
+
+func (d *Debugger) diagramsLink(
+	diagName string, diagType types.DiagramType,
+) error {
+	dir := d.Params.Load().OutputDir
+	diag := diagType.Value
+
+	// symlink am-vis.svg -> ID-LVL-HASH.svg
+	source := path.Join(dir, "am-vis-"+diag+".svg")
+	target := path.Join("diagrams", diagName+".svg")
+	_ = os.Remove(source)
+
+	d.Mach.Log("diaglink %s -> %s", source, target)
+
+	return os.Symlink(target, source)
+}
+
+// diagramsDiagPath returns a path to the diagram file WITHOUT the extensions.
+func (d *Debugger) diagramsDiagPath(name string) string {
+	return path.Join(d.Params.Load().OutputDir, "diagrams", name)
+}
+
+func (d *Debugger) diagramsStateDiagName(
+	machId, state string, hash string, groupName string, groupOnly bool,
+) string {
+	//
+
+	name := fmt.Sprintf("state-%s-%s-%s", machId, state, hash)
+
+	// narrow down to a state group
+	if groupName != "" && groupOnly {
+		name = fmt.Sprintf("state-%s-%s-%s-%s",
+			machId, types.NormalizeGroupName(groupName), state, hash)
+	}
+
+	return name
+}
+
+func (d *Debugger) diagramsStatesPush(ctx context.Context, diagPath string) {
+	// push even with errs
+	defer func() {
+		select {
+		case d.diagStateUpdate <- struct{}{}:
+		default:
+			// skip
+		}
+	}()
+	e := am.CtxToEv(ctx)
+
+	// overlay active states, cache DOM
+	file, err := os.Open(diagPath + ".svg")
+	if err != nil {
+		// file is optional
+		return
+	}
+
+	var dom *goquery.Document
+	if *d.diagStatePath.Load() == diagPath {
+		dom = d.diagStateDom.Load()
+	} else {
+		dom, err = goquery.NewDocumentFromReader(file)
+		if ctx.Err() != nil {
+			return // expired
+		}
+		if err != nil {
+			d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+			return
+		}
+
+		d.diagStateDom.Store(dom)
+		d.diagStatePath.Store(&diagPath)
+	}
+
+	diagMachFilters, err := d.diagramsMachFilters(ctx)
+	if ctx.Err() != nil {
+		return // expired
+	}
+	if err != nil {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		return
+	}
+
+	// only active states filter
+	diagStepFilters := &amvis.Filters{
+		Active: diagMachFilters.Active,
+		Index:  diagMachFilters.Index,
+	}
+
+	// update cache DOM
+	err = amvis.UpdateCache(ctx, diagPath+".svg", dom, diagStepFilters)
+	if ctx.Err() != nil {
+		return // expired
+	}
+	if err != nil {
+		d.Mach.EvAddErrState(e, ss.ErrDiagrams, err, nil)
+		return
+	}
+}

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -165,14 +165,18 @@ type DebuggerStatesDef struct {
 	BuildingLog     string
 	LogBuilt        string
 
-	SetCursor         string
-	SetGroup          string
-	DiagramsScheduled string
-	DiagramsRendering string
-	DiagramsReady     string
-	DiagramsNoCache   string
-	SshServer         string
-	SshDisconn        string
+	SetCursor  string
+	SetGroup   string
+	SshServer  string
+	SshDisconn string
+
+	DiagramsGraphRendering string
+	DiagramsGraphReady     string
+	DiagramsMachRendering  string
+	DiagramsMachReady      string
+	// pre-render all state-zoom diagrams for the selected machine
+	DiagramsStatesRendering string
+	DiagramsStatesReady     string
 
 	*ssam.BasicStatesDef
 	*ServerStatesDef
@@ -192,7 +196,6 @@ var DebuggerSchema = ssam.BasicSchema.Merge(
 		ssD.ErrDiagrams: {
 			Multi:   true,
 			Require: S{Exception},
-			Remove:  S{ssD.DiagramsRendering},
 		},
 		ssD.ErrWeb: {
 			Multi:   true,
@@ -201,7 +204,7 @@ var DebuggerSchema = ssam.BasicSchema.Merge(
 
 		// ///// Input events
 
-		ssD.WebReq: {
+		ssD.WebReqDiag: {
 			Multi:   true,
 			Require: S{Start},
 		},
@@ -209,7 +212,6 @@ var DebuggerSchema = ssam.BasicSchema.Merge(
 			Multi:   true,
 			Require: S{Start},
 		},
-		ssD.WebSocketDbg: {Require: S{Start}},
 
 		// user scrolling tx / steps
 		ssD.UserFwd: {
@@ -440,21 +442,43 @@ var DebuggerSchema = ssam.BasicSchema.Merge(
 			Multi:   true,
 			Require: S{ssD.ClientSelected},
 		},
-		ssD.DiagramsScheduled: {
-			Multi:   true,
-			Require: S{Ready},
-		},
-		ssD.DiagramsRendering: {
-			Require: S{Ready},
-			Remove:  S{ssD.DiagramsReady},
-		},
-		ssD.DiagramsReady:   {Remove: S{ssD.DiagramsRendering}},
-		ssD.DiagramsNoCache: {Require: S{ssD.DiagramsRendering}},
-
 		ssD.SshServer: {Require: S{Start}},
 		ssD.SshDisconn: {
 			Multi:   true,
 			Require: S{ssD.SshServer},
+		},
+
+		// diagrams
+
+		ssD.DiagramsGraphRendering: {
+			Multi:   true,
+			Require: S{ssD.Ready},
+			Add:     S{ssD.Loading},
+			Remove:  S{ssD.DiagramsGraphReady},
+		},
+		ssD.DiagramsGraphReady: {
+			Require: S{ssD.Ready},
+			Remove:  S{ssD.DiagramsGraphRendering},
+		},
+		ssD.DiagramsMachRendering: {
+			Multi:   true,
+			Require: S{ssD.ClientSelected},
+			Add:     S{ssD.Loading},
+			Remove:  S{ssD.DiagramsMachReady},
+		},
+		ssD.DiagramsMachReady: {
+			Require: S{ssD.ClientSelected},
+			Remove:  S{ssD.DiagramsMachRendering},
+		},
+		ssD.DiagramsStatesRendering: {
+			Multi:   true,
+			Require: S{ssD.ClientSelected},
+			Add:     S{ssD.Loading},
+			Remove:  S{ssD.DiagramsStatesReady},
+		},
+		ssD.DiagramsStatesReady: {
+			Require: S{ssD.ClientSelected},
+			Remove:  S{ssD.DiagramsStatesRendering},
 		},
 	},
 )

--- a/tools/visualizer/d2.go
+++ b/tools/visualizer/d2.go
@@ -204,8 +204,14 @@ var d2Header = utils.Sp(`
 				stroke-width: 5
 			}
 		}
-		selected: {
-			style.stroke: "` + colorSelected + `"
+		state-zoom: {
+			style: {
+				font-size: 50
+				stroke-width: 10
+			}
+		}
+		rel-zoom: {
+			style.stroke-width: 10
 		}
 		rpc: {
 			style: {
@@ -255,7 +261,7 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 	// 1st pass - requested machs and neighbours
 	for src := range r.adjMap {
 		if ctx.Err() != nil {
-			return nil
+			return ctx.Err()
 		}
 
 		srcVertex, err := r.graph.G.Vertex(src)
@@ -278,6 +284,10 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 	// 2nd pass - render adjecents as halfs
 	adjs := r.adjsMachsToRender
 	for _, machId := range adjs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		// only not already rendered
 		if _, ok := r.renderedMachs[machId]; ok {
 			continue
@@ -302,7 +312,7 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 		}
 		for _, machId := range renderedMachs {
 			if ctx.Err() != nil {
-				return nil
+				return ctx.Err()
 			}
 
 			for predId := range predMap[machId] {
@@ -364,6 +374,9 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 	r.log("Generating %s.svg\n", r.OutputFilename)
 	d2Diag, d2Graph, err := d2lib.Compile(ctx, diagTxt,
 		compileOpts, renderOpts)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	if err != nil {
 		return fmt.Errorf("failed to compile D2: %w", err)
 	}
@@ -373,6 +386,9 @@ func (r *Renderer) outputD2(ctx context.Context) error {
 	// render svg
 	if r.OutputD2Svg {
 		out, err := d2svg.Render(d2Diag, renderOpts)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return fmt.Errorf("failed to render D2: %w", err)
 		}
@@ -402,7 +418,13 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 	r.renderedMachs[machId] = struct{}{}
 
 	// TAGS
-	c := r.graph.Clients[machId]
+	c, ok := r.graph.Clients[machId]
+	if !ok {
+		// TODO fix with virtual machine placeholders
+		return nil
+		// return fmt.Errorf("failed to get client for mach %s", machId)
+	}
+
 	tags := "\n"
 	if r.RenderTags && len(c.MsgSchema.Tags) > 0 {
 		txt := "#" + strings.Join(c.MsgSchema.Tags, "\n#")
@@ -423,7 +445,11 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 	} else if len(r.renderMachIds()) > 0 {
 		border = "\tstyle.stroke: white\n"
 	}
-	r.buf.WriteString(shortMachId + ": " + machId + " {\n" +
+	label := ": " + machId
+	if !r.RenderMachTitles {
+		label = `: ""`
+	}
+	r.buf.WriteString(shortMachId + label + " {\n" +
 		"\tclass: [M_" + machId + "; mach]\n" +
 		border + tags)
 
@@ -434,7 +460,7 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 	// TODO extract & split
 	for _, edge := range r.adjMap[machId] {
 		if ctx.Err() != nil {
-			return nil
+			return ctx.Err()
 		}
 
 		target, err := r.graph.G.Vertex(edge.Target)
@@ -454,6 +480,7 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 			class := "_0"
 			if r.RenderActive {
 				idx := slices.Index(c.MsgSchema.StatesIndex, stateName)
+				// TODO current mach time, not latest
 				if c.LatestMTime.Is1(idx) {
 					class = "_1"
 				}
@@ -471,6 +498,10 @@ func (r *Renderer) outputD2Mach(ctx context.Context, machId string) error {
 				classSuffix = "r"
 			} else if r.RenderStart && stateName == am.StateStart {
 				classSuffix = "s"
+			}
+
+			if slices.Contains(r.RenderZoom, stateName) {
+				class += "; state-zoom"
 			}
 
 			r.buf.WriteString("\t" + shortStateId + ":" + stateName + "\n")
@@ -513,7 +544,11 @@ func (r *Renderer) outputD2HalfMach(
 	if r.RenderNestSubmachines {
 		shortMachId = strings.Join(r.fullIdPath(machId, true), ".")
 	}
-	r.buf.WriteString(shortMachId + ": " + machId + " {\n" +
+	label := ": " + machId
+	if !r.RenderMachTitles {
+		label = `: ""`
+	}
+	r.buf.WriteString(shortMachId + label + " {\n" +
 		"\tclass: [M_" + machId + "; mach]\n")
 
 	parent := ""
@@ -521,7 +556,7 @@ func (r *Renderer) outputD2HalfMach(
 	conns := ""
 	for _, edge := range r.adjMap[machId] {
 		if ctx.Err() != nil {
-			return nil
+			return ctx.Err()
 		}
 
 		graphConn, err := r.graph.Connection(machId, edge.Target)
@@ -574,7 +609,14 @@ func (r *Renderer) renderD2Relations(
 			continue
 		}
 
-		class := classBase + relState + "; " + "req]\n"
+		classSuffix := ""
+		if slices.Contains(r.RenderZoom, relState) ||
+			slices.Contains(r.RenderZoom, stateName) {
+
+			classSuffix += "; rel-zoom"
+		}
+
+		class := classBase + relState + "; " + "req" + classSuffix + "]\n"
 		r.buf.WriteString("\t" + shortStateId + " --> " +
 			r.shortId(relState) + ": require {\n" +
 			"\t\tclass: " + class +
@@ -586,8 +628,14 @@ func (r *Renderer) renderD2Relations(
 		if !r.shouldRenderState(machId, relState) {
 			continue
 		}
+		classSuffix := ""
+		if slices.Contains(r.RenderZoom, relState) ||
+			slices.Contains(r.RenderZoom, stateName) {
 
-		class := classBase + relState + "; " + "add]\n"
+			classSuffix += "; rel-zoom"
+		}
+
+		class := classBase + relState + "; " + "add" + classSuffix + "]\n"
 		r.buf.WriteString("\t" + shortStateId + " --> " +
 			r.shortId(relState) + ": add {\n" +
 			"\t\tclass: " + class +
@@ -600,6 +648,12 @@ func (r *Renderer) renderD2Relations(
 	for _, relState := range state.Remove {
 		if !r.shouldRenderState(machId, relState) {
 			continue
+		}
+		classSuffix := ""
+		if slices.Contains(r.RenderZoom, relState) ||
+			slices.Contains(r.RenderZoom, stateName) {
+
+			classSuffix += "; rel-zoom"
 		}
 
 		// no self removal
@@ -619,13 +673,16 @@ func (r *Renderer) renderD2Relations(
 			}
 			edgeType = " <--> "
 			label = "double remove"
-			relClass = "rem2"
+			// not when zoomed in
+			if !slices.Contains(r.RenderZoom, stateName) {
+				relClass = "rem2"
+			}
 
 			// mark
 			renderedRemoves[relState+":"+stateName] = struct{}{}
 			renderedRemoves[relState+":"+stateName] = struct{}{}
 		}
-		class := classBase + relState + "; " + relClass + "]\n"
+		class := classBase + relState + "; " + relClass + classSuffix + "]\n"
 
 		r.buf.WriteString("\t" + shortStateId + edgeType +
 			r.shortId(relState) + ": " + label + " {\n" +

--- a/tools/visualizer/diagram.html
+++ b/tools/visualizer/diagram.html
@@ -69,11 +69,14 @@
 </div>
 
 <script>
+    // mach. state, graph, tx
+    const TYPE = "mach";
+
     document.addEventListener('DOMContentLoaded', () => {
         // --- Configuration ---
-        const SVG_URL = 'http://localhost:6831/diagrams/mach.svg';
-        const WEBSOCKET_URL = 'ws://localhost:6831/diagrams/mach.ws';
-        let currentMemKey = 'svg-viewbox-state';
+        const SVG_URL = `http://localhost:6831/viewer/${TYPE}.svg`;
+        const WEBSOCKET_URL = `ws://localhost:6831/viewer/${TYPE}.ws`;
+        let currentMemKey = 'am-diagram-' + TYPE;
 
         const svgContainer = document.getElementById('svg-container');
         const statusBar = document.getElementById('status-bar');
@@ -130,7 +133,7 @@
                 svg = svgContainer.querySelector('svg');
 
                 if (!svg) {
-                    throw new Error('Enable diagrams on the toolbar.');
+                    throw new Error('Enable diagrams on the toolbar and check the group.');
                 }
 
                 // Try to load the saved viewbox state only if requested
@@ -154,6 +157,10 @@
                 }
                 svg.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`);
                 console.log('SVG loaded successfully.');
+
+                if (!restoreState) {
+                    fitToScreen()
+                }
             } catch (error) {
                 console.error('Failed to load SVG:', error);
                 svgContainer.innerHTML = `<p style="color: red; padding: 1rem;">Error loading SVG: ${error.message}</p>`;
@@ -188,14 +195,15 @@
 
             socket.onmessage = (event) => {
                 msg = JSON.parse(event.data);
-                if (msg.Type === 'refresh') {
+                if (msg.Event === 'refresh') {
                     console.log('Received "refresh" event, reloading SVG and restoring view.');
-                    currentMemKey = "svg-viewbox-state-" + msg.Addr.MachId + "-" + msg.Group;
-                    loadSVG(true); // Pass true to restore state
-                } else if (msg.Type == "loading") {
+                    currentMemKey = "am-diagram-" + TYPE + "-" + msg.Id + "-" + msg.Group;
+                    // dont restore state for "state" diagrams
+                    loadSVG(TYPE != "state");
+                } else if (msg.Event === "loading") {
                     svgContainer.innerHTML = `<p style="color: white; padding: 1rem;">Rendering...<br /><br />"M": maximize<br />wheel: zoom<br />drag: move</p>`;
                 } else {
-                    console.log('Received message:', msg);
+                    console.log('Unknown message:', msg);
                 }
             };
 

--- a/tools/visualizer/tx.go
+++ b/tools/visualizer/tx.go
@@ -42,6 +42,8 @@ type Transition struct {
 	TxParsed   *dbgtypes.MsgTxParsed
 	StateTrace []*dbgtypes.StateTraceItem
 	Log        *slog.Logger
+	// Render only the following states
+	Group am.S
 }
 
 var p = message.NewPrinter(language.English)
@@ -66,8 +68,13 @@ func (t *Transition) D2(
 
 	info := t.info(statesIndex)
 	anyStep, steps := t.steps(statesIndex)
-	states := t.funcName(t.PrevTx, statesIndex, anyStep)
-	statesAfter := t.funcName(t.Tx, statesIndex, anyStep)
+	states := t.stateNames(t.PrevTx, statesIndex, anyStep)
+	statesAfter := t.stateNames(t.Tx, statesIndex, anyStep)
+
+	// filtered out by group
+	if states == "" {
+		return "", nil, ErrEmptyTx
+	}
 
 	// generate
 
@@ -155,20 +162,30 @@ func (t *Transition) steps(statesIndex am.S) (bool, string) {
 			if op == "handler" {
 				// TODO func suffix? "FooState(e)"
 				state = helpers.HandlerToState(state)
+			}
+
+			if state == am.StateAny {
+				anyStep = true
+
+				// skip out of group
+			} else if len(t.Group) > 0 && !t.Group.Has(state) {
+				continue
+			}
+
+			// handle "handler FooState" -> Foo
+			if op == "handler" {
 				steps += state + " -> " + state + ": " + line[1]
 			} else {
 				steps += state + " -> " + state + ": " + line[0]
 			}
-			if state == am.StateAny {
-				anyStep = true
-			}
 
 		// "Foo require Bar"
 		case 3:
-			steps += line[0] + " -> " + line[2] + ": " + line[1]
-			if line[0] == am.StateAny || line[2] == am.StateAny {
-				anyStep = true
+			// skip out of group
+			if len(t.Group) > 0 && (!t.Group.Has(line[0]) || !t.Group.Has(line[2])) {
+				continue
 			}
+			steps += line[0] + " -> " + line[2] + ": " + line[1]
 			op = line[1]
 
 		default:
@@ -208,16 +225,22 @@ func (t *Transition) steps(statesIndex am.S) (bool, string) {
 	return anyStep, steps
 }
 
-func (t *Transition) funcName(
+func (t *Transition) stateNames(
 	tx *dbg.DbgMsgTx, statesIndex am.S, anyStep bool,
 ) string {
-	states := ""
+	ret := ""
 	for idx, state := range slices.Concat(statesIndex, am.S{am.StateAny}) {
 		if !slices.Contains(t.TxParsed.StatesTouched, idx) &&
 			!(anyStep && state == am.StateAny) {
 
 			continue
 		}
+
+		// skip out of group
+		if len(t.Group) > 0 && state != am.StateAny && !t.Group.Has(state) {
+			continue
+		}
+
 		class := "; state; lifeline"
 		if slices.Contains(t.Tx.CalledStatesIdxs, idx) {
 			class += "; called"
@@ -225,31 +248,32 @@ func (t *Transition) funcName(
 		switch {
 		case state == am.StateStart:
 			if tx != nil && tx.Is1(statesIndex, state) {
-				states += state + ".class: [_1s" + class + "]\n"
+				ret += state + ".class: [_1s" + class + "]\n"
 			} else {
-				states += state + ".class: [_0s" + class + "]\n"
+				ret += state + ".class: [_0s" + class + "]\n"
 			}
 		case state == am.StateReady:
 			if tx != nil && tx.Is1(statesIndex, state) {
-				states += state + ".class: [_1r" + class + "]\n"
+				ret += state + ".class: [_1r" + class + "]\n"
 			} else {
-				states += state + ".class: [_0r" + class + "]\n"
+				ret += state + ".class: [_0r" + class + "]\n"
 			}
 		case tx != nil && tx.Is1(statesIndex, state):
 			if IsStateInherited(state, statesIndex) {
-				states += state + ".class: [_1i" + class + "]\n"
+				ret += state + ".class: [_1i" + class + "]\n"
 			} else {
-				states += state + ".class: [_1" + class + "]\n"
+				ret += state + ".class: [_1" + class + "]\n"
 			}
 		default:
 			if IsStateInherited(state, statesIndex) {
-				states += state + ".class: [_0i" + class + "]\n"
+				ret += state + ".class: [_0i" + class + "]\n"
 			} else {
-				states += state + ".class: [_0" + class + "]\n"
+				ret += state + ".class: [_0" + class + "]\n"
 			}
 		}
 	}
-	return states
+
+	return ret
 }
 
 func (t *Transition) d2Gen(

--- a/tools/visualizer/visualizer.go
+++ b/tools/visualizer/visualizer.go
@@ -60,6 +60,7 @@ func PresetMap(r *Renderer) {
 
 	r.RenderNestSubmachines = true
 	r.RenderStates = false
+	// TODO enable?
 	r.RenderPipes = false
 	r.RenderStart = false
 	r.RenderReady = false
@@ -232,6 +233,10 @@ type Renderer struct {
 	RenderMachs []string
 	// Render only these states
 	RenderAllowlist am.S
+	// Render states as zoomed in (incl their rels)
+	RenderZoom am.S
+	// Render machine IDs as box titles.
+	RenderMachTitles bool
 	// Render only machines matching the regular expressions as starting points.
 	RenderMachsRe []*regexp.Regexp
 	// Skip rendering of these machines.
@@ -343,6 +348,7 @@ func NewRenderer(
 func (r *Renderer) RenderDefaults() {
 	// ON
 
+	r.RenderMachTitles = true
 	r.RenderReady = true
 	r.RenderStart = true
 	r.RenderException = true
@@ -397,6 +403,11 @@ func (r *Renderer) GenDiagrams(ctx context.Context) error {
 			return fmt.Errorf("failed to generate mermaid: %w", err)
 		}
 	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	if r.OutputD2 {
 		if err := r.outputD2(ctx); err != nil {
 			return fmt.Errorf("failed to generate D2: %w", err)
@@ -670,6 +681,8 @@ func (r *Renderer) shouldRenderMach(machId string) bool {
 		return true
 	}
 
+	// TODO check if any state from this mach is being rendered
+
 	return false
 }
 
@@ -936,14 +949,6 @@ func UpdateCache(
 			}
 		}
 
-		// TODO get from classes
-		cssTxt := "text-anchor: middle; font-size: 30px;"
-		cssInner := ""
-		if isSelected {
-			cssTxt += "fill: black;"
-			cssInner += "fill: " + colorSelected + ";"
-		}
-
 		// update
 
 		// query TODO query class
@@ -954,6 +959,18 @@ func UpdateCache(
 			})
 		inner := txt.Prev()
 		root := txt.Parent()
+
+		// TODO get from classes
+		cssTxt := "text-anchor: middle; font-size: 30px;"
+		cssInner := ""
+		if isSelected {
+			cssTxt += "fill: black;"
+			cssInner += "fill: " + colorSelected + ";"
+		}
+		if root.Is(".state-zoom") {
+			cssTxt = "text-anchor: middle; font-size: 50px;"
+			cssInner = "stroke-width:10;"
+		}
 
 		// colors
 		txt.SetAttr("fill", fillTxt).
@@ -1071,6 +1088,10 @@ func UpdateCache(
 		SetAttr("style", "stroke-width: 2")
 	dom.Find("g.add > path").SetAttr("stroke", colorRelAdd).
 		SetAttr("style", "stroke-width: 2")
+	// reset relation zoom
+	dom.Find("g.rel-zoom > path").SetAttr("stroke", colorRelRemove).
+		SetAttr("style", "stroke-width: 10")
+
 	// selected state
 	if filters.Selected != nil {
 		for _, state := range filters.Selected {


### PR DESCRIPTION
- feat(am-dbg): add state "zoom" diagrams
- feat(am-dbg): filter steps diagrams with a selected group

The web viewer handles all 4 types of diagrams, and the Chrome extension isn't necessary anymore.
 
State-zoom diagram: a new type of diagrams for large schemas which show the selected state and neighbors of it's neighbors (max graph transversal - 2 relation edges). The state and its relations are enlarged (thus the name).

Steps diagram: the states visible on the transition sequence diagrams will now honor the **diag-group** button and only render the selected group.