### PR TITLE
feat(am-dbg): add loading spinner

### DIFF
--- a/tools/debugger/dbg_handlers.go
+++ b/tools/debugger/dbg_handlers.go
@@ -2639,3 +2639,38 @@ func (d *Debugger) SshServerState(e *am.Event) {
 func (d *Debugger) SshServerEnd(e *am.Event) {
 	d.sshSrv.Close()
 }
+
+var _ = ss.Loading
+
+func (d *Debugger) LoadingState(e *am.Event) {
+	ctx := d.Mach.NewStateCtx(ss.Loading)
+	mach := d.Mach
+
+	mach.Fork(ctx, e, func() {
+		i := 0
+		for ctx.Err() == nil {
+			i++
+			mach.Eval(ss.Loading+am.SuffixState, func() {
+				d.loadingPos = i
+				d.hUpdateStatusBar()
+			}, ctx)
+			d.draw(d.statusBarLeft)
+			i = i % 9
+			time.Sleep(100 * time.Millisecond)
+
+			// check if valid TODO push when leaving states
+			if !d.Mach.Any1(states.DebuggerGroups.Loading...) {
+				d.Mach.EvRemove1(e, ss.Loading, nil)
+			}
+		}
+	})
+}
+
+func (d *Debugger) LoadingExit(e *am.Event) bool {
+	return !d.Mach.Any1(states.DebuggerGroups.Loading...)
+}
+
+func (d *Debugger) LoadingEnd(e *am.Event) {
+	d.hUpdateStatusBar()
+	d.draw(d.statusBarLeft)
+}

--- a/tools/debugger/debugger.go
+++ b/tools/debugger/debugger.go
@@ -2385,6 +2385,8 @@ func (d *Debugger) hUpdateMatrixRain() {
 	}
 }
 
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
 func (d *Debugger) hUpdateStatusBar() {
 	d.statusBarLeft.SetText("")
 	d.statusBarRight.SetText("")
@@ -2395,10 +2397,14 @@ func (d *Debugger) hUpdateStatusBar() {
 	}
 	tx := d.hCurrentTx()
 
+	loading := " "
+	if d.Mach.Is1(ss.Loading) {
+		loading = spinnerFrames[d.loadingPos]
+	}
+
 	// left
 
-	// current) global mach time
-
+	// current global mach time
 	var graphMTime uint64
 	var currHTime time.Time
 	// current tx of the selected client
@@ -2416,7 +2422,7 @@ func (d *Debugger) hUpdateStatusBar() {
 			graphMTime += parsed.TimeSum
 		}
 	}
-	left := []string{d.P.Sprintf("Graph:t%v", graphMTime)}
+	left := []string{P.Sprintf("%sGraph:t%v", loading, graphMTime)}
 
 	// selected state
 	idx := slices.Index(c.MsgStruct.StatesIndex, c.SelectedState)

--- a/tools/debugger/states/ss_dbg.go
+++ b/tools/debugger/states/ss_dbg.go
@@ -117,6 +117,7 @@ type DebuggerStatesDef struct {
 	FilterRpcMachs        string
 	FilterOutGroup        string
 	Redraw                string
+	Loading               string
 
 	// actions
 	Start             string
@@ -299,6 +300,7 @@ var DebuggerSchema = ssam.BasicSchema.Merge(
 		ssD.FilterRpcMachs:       {},
 		ssD.FilterOutGroup:       {},
 		ssD.Redraw:               {},
+		ssD.Loading:              {},
 
 		// ///// Actions
 
@@ -487,6 +489,9 @@ type DebuggerGroupsDef struct {
 
 	Mcp         S
 	McpReadonly S
+
+	// states triggering the Loading state
+	Loading S
 }
 
 // EXPORTS AND GROUPS


### PR DESCRIPTION
Because diagrams take a very long time to initially generate, the spinner will expose it to the user.